### PR TITLE
[IN PROGRESS, DO NOT MERGE] Move component creation to entity

### DIFF
--- a/runtime/src/core/SpatialEntity.ts
+++ b/runtime/src/core/SpatialEntity.ts
@@ -22,6 +22,25 @@ export class SpatialEntity extends SpatialObject {
   }
 
   /**
+   * Initializes a component on the entity
+   * @param type the type of component to add
+   * @param componentState the state to initialize the component with
+   */
+  async addComponent<T extends SpatialComponent>(
+    type: new (...args: any[]) => T,
+    componentState: Partial<T>,
+  ) {
+    // Setup component resource
+    var myComponent = new type() as any
+    await myComponent._createResource()
+    await myComponent.setState(componentState)
+
+    // Create add component to entity resource
+    await WebSpatial.setComponent(this._entity, myComponent._resource)
+    this.components.set(myComponent.constructor, myComponent)
+  }
+
+  /**
    * Syncs the transform with the renderer, must be called to observe updates
    */
   async updateTransform() {

--- a/runtime/src/core/component/SpatialComponent.ts
+++ b/runtime/src/core/component/SpatialComponent.ts
@@ -1,9 +1,11 @@
 import { WebSpatial, WebSpatialResource } from '../private/WebSpatial'
 import { SpatialEntity } from '../SpatialEntity'
 import { SpatialObject } from '../SpatialObject'
+import { SpatialWindowGroup } from '../SpatialWindowGroup'
 
 /** @hidden */
 export class SpatialComponent extends SpatialObject {
+  typeName = 'AbstractSpatialComponent'
   /**
    * Gets the entity this component is attached to
    * [TODO] should this be removed?
@@ -23,5 +25,25 @@ export class SpatialComponent extends SpatialObject {
       res.id = reqResp.data.parentID
       return new SpatialEntity(res)
     }
+  }
+
+  _preprocessState(options: any) {
+    return options
+  }
+
+  async setState(state: any) {
+    await WebSpatial.updateResource(
+      this._resource,
+      this._preprocessState(state),
+    )
+  }
+
+  async _createResource(wg?: SpatialWindowGroup) {
+    let res = await WebSpatial.createResource(
+      this.typeName,
+      wg ? wg._wg : WebSpatial.getCurrentWindowGroup(),
+      WebSpatial.getCurrentWebPanel(),
+    )
+    this._resource = res
   }
 }

--- a/runtime/src/core/component/SpatialWindowComponent.ts
+++ b/runtime/src/core/component/SpatialWindowComponent.ts
@@ -26,6 +26,19 @@ export type StyleParam = {
  * Used to position an web window in 3D space
  */
 export class SpatialWindowComponent extends SpatialComponent {
+  typeName = 'SpatialWebView'
+
+  _preprocessState(state: any) {
+    if (state.window) {
+      state.windowID = state.window._webSpatialID
+      delete state.window
+    }
+    return state
+  }
+
+  resolution?: { x: number; y: number }
+  window?: Window
+
   /**
    * Loads a url page in the window
    * @param url url to load

--- a/testServer/src/docsWebsite/examples/webElement.tsx
+++ b/testServer/src/docsWebsite/examples/webElement.tsx
@@ -1,11 +1,11 @@
-import { Spatial, SpatialSession } from '@xrsdk/runtime'
+import { Spatial, SpatialSession, SpatialWindowComponent } from '@xrsdk/runtime'
 import { useEffect, useState } from 'react'
 import { showSample } from './sampleLoader'
 
 function MySample(props: { session?: SpatialSession }) {
   var [supported, setSupported] = useState(false)
   useEffect(() => {
-    ; (async () => {
+    ;(async () => {
       if (props.session) {
         let session = props.session
         // CODESAMPLE_START
@@ -21,16 +21,16 @@ function MySample(props: { session?: SpatialSession }) {
 
         // Create a window context we can display html within
         let pageWindow = await session.createWindowContext()
-        pageWindow!.document.documentElement.style.backgroundColor = "#0033aa99"
+        pageWindow!.document.documentElement.style.backgroundColor = '#0033aa99'
         var newDiv = document.createElement('div')
         newDiv.innerHTML = "<div style='color:red;'>Hello world</div>"
         pageWindow!.document.body.appendChild(newDiv)
 
         // Add window content to entity
-        let wc = await session.createWindowComponent()
-        await wc.setResolution(100, 100)
-        await wc.setFromWindow(pageWindow!.window)
-        await entity.setComponent(wc)
+        await entity.addComponent(SpatialWindowComponent, {
+          resolution: { x: 100, y: 100 },
+          window: pageWindow!.window,
+        })
 
         // Add entity to the current page
         var rootWC = await session.getCurrentWindowComponent()
@@ -40,6 +40,6 @@ function MySample(props: { session?: SpatialSession }) {
       }
     })()
   }, [])
-  return <div className='h-32'></div>
+  return <div className="h-32"></div>
 }
 showSample(MySample)


### PR DESCRIPTION
- Trying to better match how our components are designed to better match standard ECS style architecture to make it more clear that components cannot be shared.
- Will do this in stages of adding new style of api to all components and then remove the old style so it will no longer be used