### PR TITLE
use addOnEngineUpdateEventListener instead of requestAnimationFrame t…

### DIFF
--- a/runtime/src/core/SpatialHelper.ts
+++ b/runtime/src/core/SpatialHelper.ts
@@ -79,27 +79,6 @@ export class SpatialHelper {
     },
   }
 
-  _currentAnimationLoop = null as any
-  _loopActive = false
-  _startAnimationloop = () => {
-    var loop = async (time: DOMHighResTimeStamp) => {
-      await this.session.transaction(() => {
-        if (this._currentAnimationLoop) {
-          this._currentAnimationLoop(time)
-        }
-      })
-      this.session.requestAnimationFrame(loop)
-    }
-    this.session.requestAnimationFrame(loop)
-  }
-  setAnimationLoop = (fn: (time: DOMHighResTimeStamp) => void) => {
-    this._currentAnimationLoop = fn
-    if (!this._loopActive) {
-      this._loopActive = true
-      this._startAnimationloop()
-    }
-  }
-
   setBackgroundStyle = async (
     style: StyleParam,
     backgroundColor = '#00000000',

--- a/runtime/src/core/SpatialSession.ts
+++ b/runtime/src/core/SpatialSession.ts
@@ -22,24 +22,21 @@ type animCallback = (time: DOMHighResTimeStamp) => void
  */
 export class SpatialSession {
   /** @hidden */
-  _animationFrameCallbacks = Array<animCallback>()
+  _engineUpdateListeners = Array<animCallback>()
   /** @hidden */
   _frameLoopStarted = false
 
   /**
-   * Request a callback to be called before the next render update
-   * [TODO] might want to rework this to be triggered by native code or better handle frame timing
-   * @param callback callback to be called before next render update
+   * Add event listener callback to be called each frame
+   * @param callback callback to be called each update
    */
-  requestAnimationFrame(callback: animCallback) {
-    this._animationFrameCallbacks.push(callback)
+  addOnEngineUpdateEventListener(callback: animCallback) {
+    this._engineUpdateListeners.push(callback)
 
     if (!this._frameLoopStarted) {
       this._frameLoopStarted = true
       WebSpatial.onFrame((time: number, delta: number) => {
-        var cbs = this._animationFrameCallbacks
-        this._animationFrameCallbacks = []
-        for (var cb of cbs) {
+        for (var cb of this._engineUpdateListeners) {
           cb(time)
         }
       })

--- a/testServer/index.tsx
+++ b/testServer/index.tsx
@@ -235,9 +235,8 @@ function App() {
               entity.updateTransform()
             }
           })
-          session!.requestAnimationFrame(loop)
         }
-        session.requestAnimationFrame(loop)
+        session!.addOnEngineUpdateEventListener(loop)
       })()
     } else {
     }

--- a/testServer/src/CITest/test.tsx
+++ b/testServer/src/CITest/test.tsx
@@ -63,11 +63,10 @@ async function createWebViewJSAPI() {
       if (e.isDestroyed()) {
         return
       }
-      session!.requestAnimationFrame(loop)
       e.transform.position.x = 500 + Math.sin(time / 1000) * 200
       e.updateTransform()
     }
-    session!.requestAnimationFrame(loop)
+    session!.addOnEngineUpdateEventListener(loop)
 
     //destory
     await new Promise(resolve => setTimeout(resolve, 1000))

--- a/testServer/src/docsWebsite/examples/gameLoop.tsx
+++ b/testServer/src/docsWebsite/examples/gameLoop.tsx
@@ -4,7 +4,7 @@ import { showSample } from './sampleLoader'
 
 function MySample(props: { session?: SpatialSession }) {
   useEffect(() => {
-    ; (async () => {
+    ;(async () => {
       if (props.session) {
         let session = props.session
 
@@ -31,7 +31,6 @@ function MySample(props: { session?: SpatialSession }) {
         var dt = 0
         var curTime = Date.now()
         let loop = async () => {
-          session.requestAnimationFrame(loop)
           dt = Date.now() - curTime
           curTime = Date.now()
           // Perform onFrame logic
@@ -41,11 +40,11 @@ function MySample(props: { session?: SpatialSession }) {
             entity.updateTransform()
           })
         }
-        loop()
+        session.addOnEngineUpdateEventListener(loop)
         // CODESAMPLE_END
       }
     })()
   }, [])
-  return <div style={{ height: "400px" }}></div>
+  return <div style={{ height: '400px' }}></div>
 }
 showSample(MySample)

--- a/testServer/src/docsWebsite/examples/openWindowGroup.tsx
+++ b/testServer/src/docsWebsite/examples/openWindowGroup.tsx
@@ -59,7 +59,6 @@ function MySample(props: { session?: SpatialSession }) {
             var dt = 0
             var curTime = Date.now()
             let loop = async () => {
-              session.requestAnimationFrame(loop)
               dt = Date.now() - curTime
               curTime = Date.now()
               // Perform onFrame logic
@@ -69,7 +68,7 @@ function MySample(props: { session?: SpatialSession }) {
                 e2.updateTransform()
               })
             }
-            loop()
+            session.addOnEngineUpdateEventListener(loop)
           }
         }}
       >
@@ -106,7 +105,6 @@ function MySample(props: { session?: SpatialSession }) {
             var dt = 0
             var curTime = Date.now()
             let loop = async () => {
-              session.requestAnimationFrame(loop)
               dt = Date.now() - curTime
               curTime = Date.now()
               // Perform onFrame logic
@@ -118,7 +116,7 @@ function MySample(props: { session?: SpatialSession }) {
                 e2.updateTransform()
               })
             }
-            loop()
+            session.addOnEngineUpdateEventListener(loop)
           }
         }}
       >

--- a/testServer/src/jsApiTestPages/tests.ts
+++ b/testServer/src/jsApiTestPages/tests.ts
@@ -157,11 +157,10 @@ var main = async () => {
         if (w.entity.isDestroyed()) {
           return
         }
-        session.requestAnimationFrame(loop)
         w.entity.transform.position.x = 500 + Math.sin(time / 1000) * 200
         w.entity.updateTransform()
       }
-      session.requestAnimationFrame(loop)
+      session.addOnEngineUpdateEventListener(loop)
 
       setTimeout(async () => {
         await w.entity.destroy()
@@ -356,7 +355,6 @@ var main = async () => {
       var dt = 0
       var curTime = Date.now()
       let loop = async (time: DOMHighResTimeStamp) => {
-        session.requestAnimationFrame(loop)
         dt = Date.now() - curTime
         curTime = Date.now()
         var floor = -0.1
@@ -380,7 +378,7 @@ var main = async () => {
           }
         })
       }
-      session.requestAnimationFrame(loop)
+      session.addOnEngineUpdateEventListener(loop)
 
       session.log('entity created')
       return
@@ -441,9 +439,8 @@ var main = async () => {
 
       // Populate results and request animation frame
       b.innerHTML = results
-      session.requestAnimationFrame(loop)
     }
-    session.requestAnimationFrame(loop)
+    session.addOnEngineUpdateEventListener(loop)
 
     session.log('Got response')
   } else if (page == 'winodwInnerHTML') {


### PR DESCRIPTION
…o give webspatial more control over update loop

Currently apps can potentially miss frames if their update logic takes too long and they don't call requestAnimationFrame fast enuf, by changing the api, we can better handle situations like this in the future like driving the loop based on native code