### PR TITLE
force CSSParseDom Style can't animate to avoid bad behavior when set …

### DIFF
--- a/react/src/spatial-react-components/CSSSpatialDiv/CSSSpatialComponent.tsx
+++ b/react/src/spatial-react-components/CSSSpatialDiv/CSSSpatialComponent.tsx
@@ -52,6 +52,7 @@ function renderRootCSSSpatialComponent(
     ...style,
     width: 0,
     height: 0,
+    transition: 'none',
   }
 
   const spatialDivStyle: CSSProperties = {
@@ -147,6 +148,7 @@ function renderInPortalInstance(
     ...style,
     width: 0,
     height: 0,
+    transition: 'none',
   }
 
   const spatialDivStyle: CSSProperties = {


### PR DESCRIPTION
…css animation style on SpatialDiv

fix #84 