### PR TITLE
Avoid using wrong IDs in command manager

### DIFF
--- a/builder/visionOSApp/web-spatial/libs/SpatialWindowComponent.swift
+++ b/builder/visionOSApp/web-spatial/libs/SpatialWindowComponent.swift
@@ -20,14 +20,6 @@ func getDocumentsDirectory() -> URL {
     return documentsDirectory
 }
 
-struct CommandInfo {
-    var windowGroupID = "notFound"
-    var entityID = "notFound"
-    var resourceID = "notFound"
-    var requestID = -1
-    var cmd: JSBCommand
-}
-
 struct LoadingStyles {
     var cornerRadius: CornerRadius = .init()
     var windowGroupSize = DefaultPlainWindowGroupSize

--- a/builder/visionOSApp/web-spatial/libs/Utils/CommandManager.swift
+++ b/builder/visionOSApp/web-spatial/libs/Utils/CommandManager.swift
@@ -8,6 +8,14 @@ import Foundation
 import RealityKit
 import SwiftUI
 
+struct CommandInfo {
+    var windowGroupID = "notFound"
+    var entityID = "notFound"
+    var resourceID = "notFound"
+    var requestID = -1
+    var cmd: JSBCommand
+}
+
 class CommandManager {
     static let Instance = CommandManager()
 


### PR DESCRIPTION
Using raw IDs can cause issues as there are some special IDs like "current" that need to be remapped. Should use CmdInfo id's instead.

Also we have 2 classes for no reason, make this one and mark methods as private to avoid misuse

https://github.com/spatial-web/XRSDK/issues/173