### PR TITLE
fix material not render correct when back

### DIFF
--- a/builder/visionOSApp/web-spatial/libs/SpatialWindowComponent.swift
+++ b/builder/visionOSApp/web-spatial/libs/SpatialWindowComponent.swift
@@ -358,9 +358,10 @@ class SpatialWindowComponent: SpatialComponent {
         isLoading = true
         loadingStyles = LoadingStyles()
 
-        // with materialWithBorderCorner
-        // SwiftUI not updating UIViewRepresentable when its deps update
-        // we trigger it by manually
+        // FIXME:
+        // This is a workaround to force run UIViewRepresentable.update()
+        // SwiftUI not trigger it when go back from example page.
+        // Warning of `AttributeGraph: cycle detected through attribute` fired when goes to example page
         webViewNative?.initialLoad()
     }
 


### PR DESCRIPTION
## steps

click example

click back

see ghost render effect. No spatial material effect.

## before
<img width="529" alt="image" src="https://github.com/user-attachments/assets/9ec9e7bb-f19c-4e99-afd3-cbfaea1a7074" />

## after
<img width="491" alt="image" src="https://github.com/user-attachments/assets/3c9c1c8a-af0e-40fa-adc5-3d27cea9fae6" />
