### PR TITLE
fix dom sync on webview container resize

### DIFF
--- a/react/src/spatial-react-components/SpatialReactComponent/StandardInstance.tsx
+++ b/react/src/spatial-react-components/SpatialReactComponent/StandardInstance.tsx
@@ -24,7 +24,9 @@ function useDetectDomRectChange() {
   })
 
   // listen to webview container size change and notifyDomChange
-  // this cannot be detected by ResizeObserver
+  // document.body.clientWidth may change as page loads.
+  // when creating a new scene, clientWidth changes from 0 to some positive value.
+  // this cannot be detected by ResizeObserver which only observe the dom element itself
   useEffect(() => {
     if (!ref.current || !spatialReactContextObject) {
       console.warn(


### PR DESCRIPTION
when open a new scene, document.body.clientWidth is zero and then it became some number greater than zero.

However this cannot be dectected by ResizeObserver, which leads to incorrect spatialDiv Translate.

## before
<img width="424" alt="image" src="https://github.com/user-attachments/assets/4111d97f-19ff-445e-b10d-ef90297b63c7" />


## after

<img width="584" alt="image" src="https://github.com/user-attachments/assets/10d4115f-888b-4f69-beb0-33fdb4f586b5" />
