### PR TITLE
support logging object

### DIFF
--- a/runtime/src/core/SpatialSession.ts
+++ b/runtime/src/core/SpatialSession.ts
@@ -279,7 +279,13 @@ export class SpatialSession {
    * @param msg mesage to log
    */
   async log(...msg: any[]) {
-    await WebSpatial.sendCommand(new RemoteCommand('log', { logString: msg }))
+    await WebSpatial.sendCommand(
+      new RemoteCommand('log', {
+        logString: msg.map(x => {
+          return JSON.stringify(x)
+        }),
+      }),
+    )
   }
 
   /**


### PR DESCRIPTION
If i do session.log({test: 3}) i get an error instead of an actual log. Fix that.