### PR TITLE
fix esbuild plugin export

### DIFF
--- a/react/npm/plugin/esbuild.js
+++ b/react/npm/plugin/esbuild.js
@@ -1,5 +1,4 @@
-const { definePlugin } = require('esbuild-plugin-define')
-
+import { definePlugin } from 'esbuild-plugin-define'
 const injectEnvPlugin = () => {
   return definePlugin({
     process: {
@@ -9,4 +8,4 @@ const injectEnvPlugin = () => {
     },
   })
 }
-module.exports = injectEnvPlugin
+export default injectEnvPlugin


### PR DESCRIPTION
due to the previous change marked react-sdk module, so the content under it was recognized as esm by default.

Will move all the plugins out of this pkg.