### PR TITLE
Support using the default manifest under the run command

### DIFF
--- a/.changeset/large-guests-sip.md
+++ b/.changeset/large-guests-sip.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/builder': patch
+---
+
+Under the run command, when the manifest file is missing, the default manifest can be used instead.

--- a/cli/src/lib/Cli.ts
+++ b/cli/src/lib/Cli.ts
@@ -7,7 +7,7 @@ import { start, store, run } from './cmds/build'
 import { version } from './cmds/version'
 import { fetch, downloadFile, decompressResponseBuffer } from './utils/fetch'
 export class Cli {
-  static log: ConsoleLog = new ConsoleLog('cli')
+  static log: ConsoleLog = new ConsoleLog('webspatial-builder')
   async run(args: string[]): Promise<boolean> {
     if (major(process.versions.node) < 14) {
       throw new Error(

--- a/cli/src/lib/cmds/build.ts
+++ b/cli/src/lib/cmds/build.ts
@@ -35,7 +35,10 @@ export async function start(
     await ResourceManager.moveProjectFrom(args['project'] ?? 'dist')
     console.log('move web project: ok')
   }
-  const icon = await ResourceManager.generateIcon(manifestInfo)
+  let icon
+  if (manifestInfo.json.icons?.length && isDev) {
+    icon = await ResourceManager.generateIcon(manifestInfo)
+  }
   console.log('generate icon: ok')
   /**
    * Xcode steps

--- a/cli/src/lib/pwa/config.ts
+++ b/cli/src/lib/pwa/config.ts
@@ -47,7 +47,7 @@ export function configStartUrl(
     const startFullPath = startUrl.pathname + startUrl.search + startUrl.hash
     start_url = new URL(startFullPath, baseUrl.origin + baseUrl.pathname).href
   }
-  manifestJson.start_url = start_url
+  return start_url
 }
 
 export function configScope(manifestJson: Record<string, any>) {
@@ -93,6 +93,7 @@ export function configDisplay(manifestJson: Record<string, any>) {
       display = 'standalone'
     }
   }
+  manifestJson.display = display
 }
 
 export function configMainScene(manifestJson: Record<string, any>) {

--- a/cli/src/lib/pwa/index.ts
+++ b/cli/src/lib/pwa/index.ts
@@ -15,6 +15,7 @@ import {
   checkStartUrl,
 } from './validate'
 import * as fs from 'fs'
+import { Cli } from '../Cli'
 
 export interface InitArgs {
   'manifest-url'?: string // remote manifest url
@@ -79,8 +80,11 @@ export class PWAGenerator {
       if (!fs.existsSync(url)) {
         if (isDev) {
           useDefault = true
+          Cli.log.warn(
+            'manifest.json or manifest.webmanifest not found, use default in run mode',
+          )
         } else {
-          throw new Error('manifest not found')
+          throw new Error('manifest.json or manifest.webmanifest not found')
         }
       }
       manifest = useDefault
@@ -90,7 +94,9 @@ export class PWAGenerator {
     }
     // check manifest.json
     checkManifestJson(manifest, isDev)
-    var isNetWeb = checkStartUrl(manifest, url, args['base'], fromNet, isDev)
+    let start_url = configStartUrl(manifest, args['base'] ?? '')
+    var isNetWeb = checkStartUrl(start_url, url, fromNet, isDev)
+    manifest.start_url = start_url
     if (!isDev) checkId(manifest, args['bundle-id'] ?? '')
     await checkIcons(manifest, url, isDev)
     return {
@@ -106,7 +112,6 @@ export class PWAGenerator {
     args: InitArgs,
     isDev: boolean,
   ) {
-    configStartUrl(manifestInfo.json, args['base'] ?? '')
     if (!isDev) configId(manifestInfo.json, args['bundle-id'] ?? '')
     configScope(manifestInfo.json)
     configDisplay(manifestInfo.json)

--- a/cli/src/lib/xcode/xcodeproject.ts
+++ b/cli/src/lib/xcode/xcodeproject.ts
@@ -85,7 +85,7 @@ export default class XcodeProject {
       this.updateTeamId(project, option['teamId'])
     }
     this.updateExportOptions()
-    await this.bindIcon(option.icon)
+    if (option.icon) await this.bindIcon(option.icon)
     this.bindManifestInfo(project, option.manifestInfo.json)
     if (option['version']) {
       this.updateVersion(project, option['version'])


### PR DESCRIPTION
Under the run command
- When the manifest file is missing, the default manifest can be used instead.
- Allow no icon