### PR TITLE
[Part 1] fix core-sdk import autocomplete to just be packagename instead of packagename/dist

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -4,11 +4,10 @@
   "description": "this is the core js API for webspatial",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
       "import": "./dist/index.js"
     }
   },


### PR DESCRIPTION
https://github.com/webspatial/webspatial-sdk/issues/613