### PR TITLE
[avp] reduce flicker on reopen 

### DIFF
--- a/.changeset/bright-bugs-give.md
+++ b/.changeset/bright-bugs-give.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+reduce flicker on reopen

--- a/packages/visionOS/web-spatial/web_spatialApp.swift
+++ b/packages/visionOS/web-spatial/web_spatialApp.swift
@@ -100,8 +100,10 @@ struct web_spatialApp: App {
 
                         if let wv = rootEntity?.getComponent(SpatialWindowComponent.self) {
                             // remove the webview's name to behave like new opened root scene
-                            wv.removeWebviewName {
-                                wv.navigateToURL(url: fileUrl)
+                            if wv.getURL() != fileUrl {
+                                wv.removeWebviewName {
+                                    wv.navigateToURL(url: fileUrl)
+                                }
                             }
                         }
                         // reset to mainScene size


### PR DESCRIPTION
currently when reopen it always navigate, which cause flicker.

to reduce this issue, only do navigate when scene's url not equal to start_url