### PR TITLE
append git prefix to repository url

### DIFF
--- a/packages/androidXR/package.json
+++ b/packages/androidXR/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/webspatial/webspatial-sdk.git",
+    "url": "git+https://github.com/webspatial/webspatial-sdk.git",
     "directory": "packages/androidXR"
   },
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/webspatial/webspatial-sdk.git",
+    "url": "git+https://github.com/webspatial/webspatial-sdk.git",
     "directory": "packages/cli"
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/webspatial/webspatial-sdk.git",
+    "url": "git+https://github.com/webspatial/webspatial-sdk.git",
     "directory": "packages/core"
   },
   "author": "",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/webspatial/webspatial-sdk.git",
+    "url": "git+https://github.com/webspatial/webspatial-sdk.git",
     "directory": "packages/react"
   },
   "author": "",

--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/webspatial/webspatial-sdk.git",
+    "url": "git+https://github.com/webspatial/webspatial-sdk.git",
     "directory": "packages/visionOS"
   },
   "files": [


### PR DESCRIPTION
The repository.directory field in a package's package.json is particularly useful in monorepo projects. It clearly specifies the location of each subpackage within the repository, facilitating easier navigation and usage by tools and users alike. When using tools like pkg-pr-new, correctly configuring this field ensures accurate and effective preview deployments.