### PR TITLE
Modify the export path of the test package

### DIFF
--- a/.changeset/slimy-dingos-cheat.md
+++ b/.changeset/slimy-dingos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/builder': patch
+---
+
+Modify the export path of the test package

--- a/packages/cli/src/lib/resource/index.ts
+++ b/packages/cli/src/lib/resource/index.ts
@@ -85,7 +85,7 @@ export class ResourceManager {
     let tempProjectDir = join(tempPlatformDir, './project')
     let temBuildDir = join(tempPlatformDir, './build')
     let temExportDir = join(tempPlatformDir, './export')
-    let temTestDir = join(tempPlatformDir, './test')
+    let temTestDir = `./webspatial-builder-temp/platform-${usePlatform}/test`
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir)
     }
@@ -100,6 +100,12 @@ export class ResourceManager {
     }
     if (!fs.existsSync(temExportDir)) {
       fs.mkdirSync(temExportDir)
+    }
+    if (!fs.existsSync('./webspatial-builder-temp')) {
+      fs.mkdirSync('./webspatial-builder-temp')
+    }
+    if (!fs.existsSync(`./webspatial-builder-temp/platform-${usePlatform}`)) {
+      fs.mkdirSync(`./webspatial-builder-temp/platform-${usePlatform}`)
     }
     if (!fs.existsSync(temTestDir)) {
       fs.mkdirSync(temTestDir)

--- a/packages/cli/src/lib/resource/index.ts
+++ b/packages/cli/src/lib/resource/index.ts
@@ -85,7 +85,7 @@ export class ResourceManager {
     let tempProjectDir = join(tempPlatformDir, './project')
     let temBuildDir = join(tempPlatformDir, './build')
     let temExportDir = join(tempPlatformDir, './export')
-    let temTestDir = `./webspatial-builder-temp/platform-${usePlatform}/test`
+    let temTestDir = `./node_modules/.webspatial-builder-temp/platform-${usePlatform}/test`
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir)
     }
@@ -101,11 +101,17 @@ export class ResourceManager {
     if (!fs.existsSync(temExportDir)) {
       fs.mkdirSync(temExportDir)
     }
-    if (!fs.existsSync('./webspatial-builder-temp')) {
-      fs.mkdirSync('./webspatial-builder-temp')
+    if (!fs.existsSync('./node_modules/.webspatial-builder-temp')) {
+      fs.mkdirSync('./node_modules/.webspatial-builder-temp')
     }
-    if (!fs.existsSync(`./webspatial-builder-temp/platform-${usePlatform}`)) {
-      fs.mkdirSync(`./webspatial-builder-temp/platform-${usePlatform}`)
+    if (
+      !fs.existsSync(
+        `./node_modules/.webspatial-builder-temp/platform-${usePlatform}`,
+      )
+    ) {
+      fs.mkdirSync(
+        `./node_modules/.webspatial-builder-temp/platform-${usePlatform}`,
+      )
     }
     if (!fs.existsSync(temTestDir)) {
       fs.mkdirSync(temTestDir)


### PR DESCRIPTION
Modify the export path of the test package to prevent the issue of being unable to install to the simulator due to excessively long paths