### PR TITLE
Fix get native version

### DIFF
--- a/.changeset/stupid-queens-carry.md
+++ b/.changeset/stupid-queens-carry.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Fixed the issue where the default version number of the native was “PACKAGE_VERSION” and the client got the version incorrectly

--- a/packages/core/src/core/Spatial.ts
+++ b/packages/core/src/core/Spatial.ts
@@ -35,7 +35,9 @@ export class Spatial {
     if (window.__WebSpatialData && window.__WebSpatialData.getNativeVersion) {
       return window.__WebSpatialData.getNativeVersion()
     }
-    return window.WebSpatailNativeVersion
+    return window.WebSpatailNativeVersion === 'PACKAGE_VERSION'
+      ? this.getClientVersion()
+      : window.WebSpatailNativeVersion
   }
 
   /**


### PR DESCRIPTION
Fixed the issue where the default version number of the native was “PACKAGE_VERSION” and the client got the version incorrectly