### PR TITLE
fix: should set resizability before setSize when reopen last scene

### DIFF
--- a/packages/visionOS/web-spatial/libs/SpatialWindowContainer.swift
+++ b/packages/visionOS/web-spatial/libs/SpatialWindowContainer.swift
@@ -76,6 +76,7 @@ class SpatialWindowContainer: SpatialObject {
     var toggleImmersiveSpace = PassthroughSubject<Bool, Never>()
 
     var setSize = PassthroughSubject<CGSize, Never>()
+    var setResizeRange = PassthroughSubject<ResizeRange, Never>()
 
     var updateFrame = false
     var openWindowData = PassthroughSubject<WindowContainerData, Never>()

--- a/packages/visionOS/web-spatial/views/PlainWindowContainerView.swift
+++ b/packages/visionOS/web-spatial/views/PlainWindowContainerView.swift
@@ -94,6 +94,9 @@ struct PlainWindowContainerView: View {
             .onReceive(windowContainerContent.setSize) { newSize in
                 setSize(size: newSize)
             }
+            .onReceive(windowContainerContent.setResizeRange) { resizeRange in
+                self.setResizeRange(resizeRange: resizeRange)
+            }
             .onAppear {
                 let wd = WindowContainerMgr.Instance.getValue()
                 if let range = wd.resizeRange {

--- a/packages/visionOS/web-spatial/web_spatialApp.swift
+++ b/packages/visionOS/web-spatial/web_spatialApp.swift
@@ -108,6 +108,9 @@ struct web_spatialApp: App {
                         }
                         // reset to mainScene size
                         wgm.setToMainSceneCfg()
+                        if let resizeRange = wgm.getValue().resizeRange {
+                            wc.setResizeRange.send(resizeRange)
+                        }
                         wc.setSize.send(getDefaultSize())
                     }
                 }


### PR DESCRIPTION
Current logic of reopen is to reuse last scene and set its size, which not set resizability properly and it should set before setSize.

In this PR I add a event to set resizeRange and prioritize it before setSize.