### PR TITLE
Use local version of prettier when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   },
   "lint-staged": {
     "*.{js,json}": [
-      "prettier --write"
+      "npx prettier --write"
     ],
     "*.ts?(x)": [
-      "prettier --write"
+      "npx prettier --write"
     ],
     "*.swift": [
       "swiftformat"


### PR DESCRIPTION
All formatting commands use `npx prettier` except for the lint-staged command which runs as a pre commit hook. This requires prettier to be installed both locally and globally potentially causing a formatting mismatch due to version conflicts at commit time.