### PR TITLE
Fix wrong property being set on Spatialized2DElement for scrollEdgeInsetsMarginRight

### DIFF
--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -505,7 +505,7 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
         }
 
         if let scrollEdgeInsetsMarginRight = command.scrollEdgeInsetsMarginRight {
-            spatialized2DElement.cornerRadius = cornerRadius
+            spatialized2DElement.scrollEdgeInsetsMarginRight = scrollEdgeInsetsMarginRight
         }
 
         resolve(.success(baseReplyData))


### PR DESCRIPTION
Fix wrong property being set on Spatialized2DElement for scrollEdgeInsetsMarginRight. `command.scrollEdgeInsetsMarginRight` should update `scrollEdgeInsetsMarginRight` property on Spatialized2DElement not cornerRadius.