### PR TITLE
Add better text contrast on SpatialCorner test

### DIFF
--- a/apps/test-server/src/spatialCorner/index.tsx
+++ b/apps/test-server/src/spatialCorner/index.tsx
@@ -50,7 +50,7 @@ function App() {
         </a>
       </div>
 
-      <div className="text-orange-200 mx-2.5 my-2.5">
+      <div className="text-gray-950 mx-2.5 my-2.5">
         <button className="bg-indigo-500" onClick={toggleBackgroundMaterial}>
           toggle background material:
         </button>
@@ -131,7 +131,7 @@ function App() {
         </div>
       </div>
 
-      <div className="flex flex-row space-x-2 w-screen text-orange-500   text-center">
+      <div className="flex flex-row space-x-2 w-screen text-gray-900   text-center">
         <div
           enable-xr
           style={{


### PR DESCRIPTION
When using transparent or glass material background a darker text color is required for better contrast.

<img width="609" height="428" alt="Screenshot 2025-11-05 at 12 35 41" src="https://github.com/user-attachments/assets/87b75ce1-15f5-4302-9f8b-64a4963d36b0" />
