### PR TITLE
resolve relative URLs to absolute in ModelAsset

### DIFF
--- a/packages/react/src/reality/components/ModelAsset.tsx
+++ b/packages/react/src/reality/components/ModelAsset.tsx
@@ -8,6 +8,15 @@ type Props = {
   onLoad?: () => void
   onError?: (error: any) => void
 }
+
+// Resolve relative URLs to absolute for the native bridge
+const resolveAssetUrl = (url: string): string => {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    return url
+  }
+  return new URL(url, window.location.href).href
+}
+
 export const ModelAsset: React.FC<Props> = ({ children, ...options }) => {
   const ctx = useRealityContext()
   const materialRef = useRef<SpatialModelAsset>()
@@ -16,7 +25,8 @@ export const ModelAsset: React.FC<Props> = ({ children, ...options }) => {
     if (!ctx) return
     const { session, reality, resourceRegistry } = ctx
     const init = async () => {
-      const modelAssetPromise = session.createModelAsset({ url: options.src })
+      const resolvedUrl = resolveAssetUrl(options.src)
+      const modelAssetPromise = session.createModelAsset({ url: resolvedUrl })
       resourceRegistry.add(options.id, modelAssetPromise)
 
       try {


### PR DESCRIPTION
when loading a ModelAsset like: 
```src={`${__XR_ENV_BASE__}/[xyz].usdz`}```


ModelAsset passes URLs directly to Swift, which lacks webpage origin context and can't resolve relative paths. Uses new URL(src, window.location.href) to convert relative paths to absolute URLs before crossing the JS-to-Swift bridge.

Using new URL(url, window.location.href).href handles all cases:
- absolute URLs pass through unchanged
- relative paths like /webspatial/avp/[x].usdz get the origin prepended, and even ./ or ../ paths resolve correctly.



Previous Behavior: 
```[Error] ModelEntity error: – Error: createModelAsset failed:Failed to download model: Error Domain=NSURLErrorDomain Code=-1002 "unsupported URL" UserInfo={NSLocalizedDescription=unsupported URL, NSErrorFailingURLStringKey=/webspatial/avp/Teddy.usdz, NSErrorFailingURLKey=/webspatial/avp/Teddy.usdz, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDownloadTask <7BE8CE77-BF85-4B6A-B491-44A714877012>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDownloadTask <7BE8CE77-BF85-4B6A-B491-44A714877012>.<1>, NSUnderlyingError=0x600000eac840 {Error Domain=kCFErrorDomainCFNetwork Code=-1002 "(null)"}} — realityCreator.ts:89
Error: createModelAsset failed:Failed to download model: Error Domain=NSURLErrorDomain Code=-1002 "unsupported URL" UserInfo={NSLocalizedDescription=unsupported URL, NSErrorFailingURLStringKey=/webspatial/avp/Teddy.usdz, NSErrorFailingURLKey=/webspatial/avp/Teddy.usdz, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDownloadTask <7BE8CE77-BF85-4B6A-B491-44A714877012>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDownloadTask <7BE8CE77-BF85-4B6A-B491-44A714877012>.<1>, NSUnderlyingError=0x600000eac840 {Error Domain=kCFErrorDomainCFNetwork Code=-1002 "(null)"}} — realityCreator.ts:89
	(anonymous function) (chunk-AAT34WJS.js:2439)```