### PR TITLE
fix window.open URL cast issue

### DIFF
--- a/.changeset/lucky-peaches-tease.md
+++ b/.changeset/lucky-peaches-tease.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+fix window.open URL cast issue

--- a/apps/test-server/src/scene/index.tsx
+++ b/apps/test-server/src/scene/index.tsx
@@ -77,14 +77,14 @@ function App() {
             'sa',
             () => ({
               defaultSize: {
-                width: "10cm",
+                width: '10cm',
                 height: 1,
                 depth: 1,
               },
               // resizability: {
               //   minWidth: 0.5,
               //   maxWidth: 1.5,
-              //   minHeight: 0.5,  
+              //   minHeight: 0.5,
               //   maxHeight: 1.5,
               // },
               // worldScaling: 'automatic',
@@ -301,6 +301,52 @@ function App() {
         open volume baseplateVisibility visible
       </button>
 
+      <h1 className="text-2xl text-black">relative url</h1>
+      <button
+        className={btnCls}
+        onClick={async () => {
+          startlog('open')
+          initScene('sa', () => ({
+            defaultSize: {
+              width: 900,
+              height: 900,
+            },
+            resizability: {
+              minWidth: 700,
+              minHeight: 700,
+              // maxWidth: 900,
+              // maxHeight: 900,
+            },
+          }))
+          winARef.current = window.open('./xrapp.html', 'sa')
+          // winARef.current = window.open('', 'sa')
+        }}
+      >
+        window.open relative url
+      </button>
+
+      <button
+        className={btnCls}
+        onClick={async () => {
+          startlog('open')
+          initScene('sa', () => ({
+            defaultSize: {
+              width: 900,
+              height: 900,
+            },
+            resizability: {
+              minWidth: 700,
+              minHeight: 700,
+              // maxWidth: 900,
+              // maxHeight: 900,
+            },
+          }))
+          winARef.current = window.open('/src/scene/xrapp.html', 'sa')
+          // winARef.current = window.open('', 'sa')
+        }}
+      >
+        window.open relative url 2
+      </button>
       <h1 className="text-2xl text-black">resize</h1>
       <button
         className={btnCls}

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -50,17 +50,37 @@ class SceneManager {
     return this.configMap[name]
   }
 
+  // Ensure URL is absolute; only convert when a relative path is provided
+  // - Keep external and special schemes untouched (http, https, data, blob, about, file, mailto, etc.)
+  // - Handle protocol-relative URLs (//example.com/path)
+  // - Resolve relative paths against document.baseURI (respects <base href>)
+  private ensureAbsoluteUrl(raw?: string): string | undefined {
+    if (!raw) return raw
+    // Already has a scheme (includes internal webspatial:// which is handled earlier)
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw)) {
+      return raw
+    }
+    // Protocol-relative URL
+    if (raw.startsWith('//')) {
+      return `${window.location.protocol}${raw}`
+    }
+    // Resolve against base URI
+    try {
+      return new URL(raw, document.baseURI).toString()
+    } catch {
+      // Fallback: leave unchanged
+      return raw
+    }
+  }
+
   private open = (url?: string, target?: string, features?: string) => {
     // bypass internal
     if (url?.startsWith(INTERNAL_SCHEMA_PREFIX)) {
       return this.originalOpen(url, target, features)
     }
 
-    //  absolute url
-    const prefix = `${window.location.protocol}//${window.location.host}`
-    if (!url?.startsWith(prefix)) {
-      url = prefix + url
-    }
+    // Normalize only relative URLs to absolute for platform handling
+    url = this.ensureAbsoluteUrl(url)
 
     // if target is special
     if (target === '_self' || target === '_parent' || target === '_top') {


### PR DESCRIPTION
what is the issue about:

If your are on `http://a.com`, then you click on a link to `http://b.com`, then it will add the prefix, and finally url become `http://a.comhttp://b.com`.

It should be `http://b.com`.