### PR TITLE
Fix depth property not working on Model tag

### DIFF
--- a/.changeset/tangy-pears-add.md
+++ b/.changeset/tangy-pears-add.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': minor
+---
+
+Fix depth property not working on Model tag

--- a/apps/test-server/src/static-3d-model/index.tsx
+++ b/apps/test-server/src/static-3d-model/index.tsx
@@ -10,7 +10,7 @@ function App() {
       <h1>Static 3D model test</h1>
       <Model
         enable-xr
-        style={{ width: '800px', height: '200px' }}
+        style={{ width: '800px', height: '200px', '--xr-depth': '50px' }}
         src={'/public/modelasset/cone.usdz'}
       >
         <div> this is place holder when failure </div>

--- a/packages/visionOS/web-spatial/manifest.swift
+++ b/packages/visionOS/web-spatial/manifest.swift
@@ -5,7 +5,7 @@ var pwaManager = PWAManager()
 
 struct PWAManager: Codable {
     var isLocal: Bool = false
-    var start_url: String = "http://localhost:5173/src/reality/gestures"
+    var start_url: String = "http://localhost:5173/src/static-3d-model"
 
     var scope: String = ""
     var id: String = "com.webspatial.pico"

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -19,6 +19,7 @@ struct SpatializedStatic3DView: View {
 
     @ViewBuilder
     var body: some View {
+        let depth = spatializedElement.depth
         let transform = spatializedStatic3DElement.modelTransform
         let translation = transform.translation
         let scale = transform.scale
@@ -41,6 +42,7 @@ struct SpatializedStatic3DView: View {
                             nil,
                             contentMode: .fit
                         )
+                        .if(!depth.isZero){ view in view.scaledToFit3D()}
                         .onAppear {
                             self.onLoadSuccess()
                         }


### PR DESCRIPTION
# Summary
Fixes #924. The depth property was not considered when resizing the model to fit within the container. Only the width and height property were considered for resize to fit. If no depth is set or it's 0 then take the intrinsic depth of the 3D model.
```tsx
<Model
        enable-xr
        style={{ width: '800px', height: '200px' }}
        style={{ width: '800px', height: '200px', '--xr-depth': '50px' }}
        src={'/public/modelasset/cone.usdz'}
      >
```

## Before 
CSS depth property of 50px is ignored
<img height="250" alt="before" src="https://github.com/user-attachments/assets/fe45c300-9446-464d-b356-33e3b25be211" />

## After
<img height="250" alt="static-3d-model" src="https://github.com/user-attachments/assets/a82c37c1-ba83-404d-b0de-7418aee3a678" />


## Existing Tests
<img height="250" alt="model-test" src="https://github.com/user-attachments/assets/25713e44-8b03-4238-a175-ed272c1b0067" />

<img height="250" alt="spatial-gesture" src="https://github.com/user-attachments/assets/0b93ac6c-6f22-45a6-ae6b-bc358f336cd8" />

<img height="250" alt="spatial-converter" src="https://github.com/user-attachments/assets/5e736735-333f-4b6e-a07a-9e6934fa2d3c" />
