### PR TITLE
Manually fix package versions to avoid major version bump

### DIFF
--- a/apps/test-server/CHANGELOG.md
+++ b/apps/test-server/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Updated dependencies [d1242ea]
 - Updated dependencies [3412d6d]
 - Updated dependencies [ffcfcc8]
-  - @webspatial/react-sdk@2.0.0
-  - @webspatial/core-sdk@2.0.0
+  - @webspatial/react-sdk@1.1.0
+  - @webspatial/core-sdk@1.1.0
 
 ## 0.0.17
 

--- a/packages/androidXR/CHANGELOG.md
+++ b/packages/androidXR/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @webspatial/platform-androidxrapp
 
-## 2.0.0
+## 1.1.0
 
 ## 1.0.5
 

--- a/packages/androidXR/package.json
+++ b/packages/androidXR/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/platform-androidxrapp",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "private": true,
   "files": [
     "webspatiallib",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,11 @@
 # @webspatial/builder
 
-## 2.0.0
+## 1.1.0
 
 ### Patch Changes
 
 - Updated dependencies [5055826]
-  - @webspatial/platform-visionos@2.0.0
+  - @webspatial/platform-visionos@1.1.0
 
 ## 1.0.5
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/builder",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "Client CLI tool to Generate XRApp project for Apple Vision Pro",
   "type": "commonjs",
   "engines": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @webspatial/core-sdk
 
-## 2.0.0
+## 1.1.0
 
 ### Patch Changes
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/core-sdk",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "this is the core js API for webspatial",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,13 +1,13 @@
 # @webspatial/react-sdk
 
-## 2.0.0
+## 1.1.0
 
 ### Patch Changes
 
 - d1242ea: fixbug when spatialdiv.style.setProperty visibility/transform
 - ffcfcc8: fix window.open URL cast issue
 - Updated dependencies [3412d6d]
-  - @webspatial/core-sdk@2.0.0
+  - @webspatial/core-sdk@1.1.0
 
 ## 1.0.5
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/react-sdk",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "React components for WebSpatial",
   "main": "./dist/default/index.js",
   "type": "module",

--- a/packages/visionOS/CHANGELOG.md
+++ b/packages/visionOS/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @webspatial/platform-avp
 
-## 2.0.0
+## 1.1.0
 
 ### Minor Changes
 

--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/platform-visionos",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "Used to publish WebSpatial projects to Apple Vision Pro",
   "type": "commonjs",
   "engines": {

--- a/tests/ci-test/CHANGELOG.md
+++ b/tests/ci-test/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Updated dependencies [d1242ea]
 - Updated dependencies [3412d6d]
 - Updated dependencies [ffcfcc8]
-  - @webspatial/react-sdk@2.0.0
-  - @webspatial/core-sdk@2.0.0
-  - @webspatial/builder@2.0.0
+  - @webspatial/react-sdk@1.1.0
+  - @webspatial/core-sdk@1.1.0
+  - @webspatial/builder@1.1.0
 
 ## 0.0.16
 


### PR DESCRIPTION
Due to changeset [bug](https://github.com/changesets/changesets/issues/1011) it incorrectly bumps the major version instead of minor version. Partially revert fc64d6216b62e6bf8a5d4e081c99d0efcf481a3b to fix incorrect major version bump.