### PR TITLE
Use relative path as source in model-test

### DIFF
--- a/apps/test-server/src/model-test/index.tsx
+++ b/apps/test-server/src/model-test/index.tsx
@@ -54,7 +54,7 @@ function ModelTest() {
     contentVisibility: 'visible',
   }
 
-  const src = 'http://localhost:5173/public/modelasset/cone.usdz'
+  const src = '/public/modelasset/cone.usdz'
 
   const refModel = useRef<ModelRef>(null)
 


### PR DESCRIPTION
Using absolute source breaks when testing across devices.