### PR TITLE
fix: mute resource abort error log

### DIFF
--- a/packages/react/src/reality/components/GeometryEntity.tsx
+++ b/packages/react/src/reality/components/GeometryEntity.tsx
@@ -84,7 +84,11 @@ export const GeometryEntity = forwardRef<EntityRefShape, GeometryEntityProps>(
           await ent.addComponent(modelComponent)
           return ent
         } catch (error) {
-          console.error(error)
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            // AbortError is expected, just ignore it
+          } else {
+            console.error(error)
+          }
           await manager.dispose()
           return null as any
         }


### PR DESCRIPTION
In React strictMode, loading resource always will be interrupted to raise this error. It should be muted and nothing goes wrong