### PR TITLE
fix: mute bad model file log

### DIFF
--- a/packages/react/src/reality/components/ModelEntity.tsx
+++ b/packages/react/src/reality/components/ModelEntity.tsx
@@ -37,7 +37,8 @@ export const ModelEntity = forwardRef<EntityRefShape, Props>(
             { id, name },
           )
         } catch (error) {
-          console.error('ModelEntity error:', error)
+          // error already handled in ModelAsset, no need to log again
+          // console.error('ModelEntity error:', error)
           return null as any
         }
       },


### PR DESCRIPTION
bad model already handled in ModelAsset, no need to log again