### PR TITLE
Add visual Logger component

### DIFF
--- a/apps/test-server/src/static-3d-model/Logger.tsx
+++ b/apps/test-server/src/static-3d-model/Logger.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useLogger(initialLog = '') {
+  const [logs, setLogs] = useState(initialLog)
+  const logLine = (...args: any[]) => {
+    const msg = args
+      .map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a)))
+      .join(' ')
+    setLogs(prev => (prev ? prev + '\n' : '') + msg)
+  }
+  const clearLog = () => setLogs('')
+
+  return [logs, logLine, clearLog] as const
+}
+
+export type LoggerProps = { logs: String; clearLog: () => void }
+export function Logger({ logs, clearLog }: LoggerProps) {
+  return (
+    <section>
+      <h2>Console</h2>
+      <button onClick={clearLog}>Clear Log</button>
+      <pre>{logs}</pre>
+    </section>
+  )
+}

--- a/apps/test-server/src/static-3d-model/index.tsx
+++ b/apps/test-server/src/static-3d-model/index.tsx
@@ -1,14 +1,20 @@
 import ReactDOM from 'react-dom/client'
 
-import { enableDebugTool, Model, ModelRef } from '@webspatial/react-sdk'
+import {
+  enableDebugTool,
+  toSceneSpatial,
+  Model,
+  ModelRef,
+} from '@webspatial/react-sdk'
 import { useRef, useState } from 'react'
+import { useLogger, Logger } from './Logger'
 
 enableDebugTool()
 
 function App() {
   const modelRef = useRef<ModelRef>(null)
-  const [loadStatus, setLoadStatus] = useState('')
   const [loadCount, setLoadCount] = useState(0)
+  const [logs, logLine, clearLog] = useLogger()
 
   const [translateX, setTranslateX] = useState(0)
   const [translateY, setTranslateY] = useState(0)
@@ -126,18 +132,23 @@ function App() {
         }}
         src={'/public/modelasset/cone.usdz'}
         ref={modelRef}
-        onError={event => {
-          setLoadStatus(`Model load error`)
+        onError={e => {
+          logLine(`Model load error`)
         }}
-        onLoad={event => {
-          setLoadStatus('Model load success')
+        onLoad={e => {
+          logLine(`Model load success ${modelRef?.current?.currentSrc}`)
           setLoadCount(loadCount + 1)
         }}
+        onSpatialTap={e => {
+          logLine(
+            'model onSpatialTap',
+            e.currentTarget.getBoundingClientCube(),
+            e.detail.location3D,
+          )
+        }}
       />
-      <p>
-        {loadStatus} {loadCount}
-      </p>
-      <p>modelRef {modelRef?.current?.currentSrc}</p>
+      <p>{loadCount}</p>
+      <Logger logs={logs} clearLog={clearLog} />
     </div>
   )
 }


### PR DESCRIPTION
For on device testing it's often beneficial to have a console log directly on the page reducing the need to attach an external browser.

<img width="3840" height="2160" alt="Simulator Screenshot - Apple Vision Pro 26 2 - 2026-01-20 at 12 16 52" src="https://github.com/user-attachments/assets/e2d80f72-3f2b-4d6f-b72f-0f4ee0bb6dcd" />
