### PR TITLE
fix unhandled error throw when destroy modelAssets

### DIFF
--- a/packages/react/src/reality/components/ModelAsset.tsx
+++ b/packages/react/src/reality/components/ModelAsset.tsx
@@ -25,11 +25,11 @@ export const ModelAsset: React.FC<Props> = ({ children, ...options }) => {
     if (!ctx) return
     const { session, reality, resourceRegistry } = ctx
     const init = async () => {
-      const resolvedUrl = resolveAssetUrl(options.src)
-      const modelAssetPromise = session.createModelAsset({ url: resolvedUrl })
-      resourceRegistry.add(options.id, modelAssetPromise)
-
       try {
+        const resolvedUrl = resolveAssetUrl(options.src)
+        const modelAssetPromise = session.createModelAsset({ url: resolvedUrl })
+        resourceRegistry.add(options.id, modelAssetPromise)
+
         const mat = await modelAssetPromise
         if (controller.signal.aborted) {
           mat.destroy()

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -18,7 +18,9 @@ export class ResourceRegistry {
     const p = this.resources.get(id)
     if (p) {
       // Schedule destruction when the resource becomes available
-      p.then(spatialObj => spatialObj.destroy())
+      p.then(spatialObj => spatialObj.destroy()).catch(() => {
+        // swallow rejection to avoid unhandled promise errors during teardown
+      })
     }
     this.resources.delete(id)
   }
@@ -31,6 +33,12 @@ export class ResourceRegistry {
     this.resources.clear()
 
     // Best-effort destroy for all resolved and future-resolving resources
-    pending.forEach(promise => promise.then(spatialObj => spatialObj.destroy()))
+    pending.forEach(promise =>
+      promise
+        .then(spatialObj => spatialObj.destroy())
+        .catch(() => {
+          // swallow rejection to avoid unhandled promise errors during teardown
+        }),
+    )
   }
 }


### PR DESCRIPTION
# the problem to fix

if the model url is not correct, createModelAsset cmd will rejected. 

When page unload, in destroy hook of useEffect, we cleaning up the pending promise which will raise the unhandled.

<img width="190" height="201" alt="image" src="https://github.com/user-attachments/assets/7bb031bc-8bd1-4bd3-8493-239cfa896cb7" />
