### PR TITLE
Change Model entityTransform type to DOMMatrixReadOnly

### DIFF
--- a/.changeset/thin-waves-build.md
+++ b/.changeset/thin-waves-build.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/react-sdk': minor
+'web-content': patch
+'@webspatial/core-sdk': patch
+---
+
+Change <Model> entityTransform type from DOMMatrix to DOMMatrixReadOnly

--- a/apps/test-server/src/pages/model-test/index.tsx
+++ b/apps/test-server/src/pages/model-test/index.tsx
@@ -59,14 +59,19 @@ function ModelTest() {
       y: e.detail.translation3D.y - dragTranslationRef.current.y,
       z: e.detail.translation3D.z - dragTranslationRef.current.z,
     }
-    refModel.current?.entityTransform.translateSelf(delta.x, delta.y, delta.z)
+    if (refModel.current) {
+      refModel.current.entityTransform = DOMMatrix.fromMatrix(
+        refModel.current.entityTransform,
+      ).translate(delta.x, delta.y, delta.z)
+    }
+
     dragTranslationRef.current = e.detail.translation3D
   }
 
   const onSpatialDragEnd = (e: ModelSpatialDragEndEvent) => {
-    refModel.current?.entityTransform.setMatrixValue(
-      'translateX(0px) translateY(0px) translateZ(0px)',
-    )
+    if (refModel.current) {
+      refModel.current.entityTransform = new DOMMatrix()
+    }
   }
 
   const onSpatialRotate = (e: ModelSpatialRotateEvent) => {
@@ -81,7 +86,11 @@ function ModelTest() {
     const y = (euler.y * 180) / Math.PI
     const z = (euler.z * 180) / Math.PI
     rotateRef.current = { x, y, z }
-    refModel.current?.entityTransform.rotateSelf(x, y, z)
+    if (refModel.current) {
+      refModel.current.entityTransform = DOMMatrix.fromMatrix(
+        refModel.current.entityTransform,
+      ).rotate(x, y, z)
+    }
   }
 
   const onSpatialMagnify = (e: ModelSpatialMagnifyEvent) => {

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -13,7 +13,11 @@ enableDebugTool()
 
 function App() {
   const modelRef = useRef<ModelRef>(null)
-  const entityTransform = modelRef.current?.entityTransform
+  const entityTransform = (cb: (e: DOMMatrix) => DOMMatrixReadOnly) => {
+    let current = modelRef.current
+    if (current === null) return
+    current.entityTransform = cb(DOMMatrix.fromMatrix(current.entityTransform))
+  }
   const [loadCount, setLoadCount] = useState(0)
   const [logs, logLine, clearLog] = useLogger()
 
@@ -114,52 +118,52 @@ function App() {
           <Toggle
             label="translateX"
             step={10}
-            setValue={val => entityTransform?.translateSelf(val, 0, 0)}
+            setValue={val => entityTransform(e => e.translate(val, 0, 0))}
           />
           <Toggle
             label="translateY"
             step={10}
-            setValue={val => entityTransform?.translateSelf(0, val, 0)}
+            setValue={val => entityTransform(e => e.translate(0, val, 0))}
           />
           <Toggle
             label="translateZ"
             step={10}
-            setValue={val => entityTransform?.translateSelf(0, 0, val)}
+            setValue={val => entityTransform(e => e.translate(0, 0, val))}
           />
           <Toggle
             label="rotateX"
             step={5}
-            setValue={val => entityTransform?.rotateSelf(val, 0, 0)}
+            setValue={val => entityTransform(e => e.rotate(val, 0, 0))}
           />
           <Toggle
             label="rotateY"
             step={5}
-            setValue={val => entityTransform?.rotateSelf(0, val, 0)}
+            setValue={val => entityTransform(e => e.rotate(0, val, 0))}
           />
           <Toggle
             label="rotateZ"
             step={5}
-            setValue={val => entityTransform?.rotateSelf(0, 0, val)}
+            setValue={val => entityTransform(e => e.rotate(0, 0, val))}
           />
           <Toggle
             label="scaleX"
             step={0.1}
-            setValue={val => entityTransform?.scaleSelf(1 + val, 1, 1)}
+            setValue={val => entityTransform(e => e.scale(1 + val, 1, 1))}
           />
           <Toggle
             label="scaleY"
             step={0.1}
-            setValue={val => entityTransform?.scaleSelf(1, 1 + val, 1)}
+            setValue={val => entityTransform(e => e.scale(1, 1 + val, 1))}
           />
           <Toggle
             label="scaleZ"
             step={0.1}
-            setValue={val => entityTransform?.scaleSelf(1, 1, 1 + val)}
+            setValue={val => entityTransform(e => e.scale(1, 1, 1 + val))}
           />
           <button
             onClick={e => {
               const resetCSS = `translate3d(0, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0)`
-              entityTransform?.setMatrixValue(resetCSS)
+              entityTransform(e => e.setMatrixValue(resetCSS))
             }}
           >
             ❌
@@ -197,17 +201,12 @@ function App() {
             y: e.detail.translation3D.y - dragTranslation.y,
             z: e.detail.translation3D.z - dragTranslation.z,
           }
-          modelRef.current?.entityTransform.translateSelf(
-            delta.x,
-            delta.y,
-            delta.z,
-          )
-
+          entityTransform(e => e.translateSelf(delta.x, delta.y, delta.z))
           setDragTranslation(e.detail.translation3D)
         }}
         onSpatialDragEnd={e => {
-          modelRef.current?.entityTransform.setMatrixValue(
-            'translateX(0px) translateY(0px) translateZ(0px)',
+          entityTransform(e =>
+            e.setMatrixValue('translateX(0px) translateY(0px) translateZ(0px)'),
           )
           setDragTranslation({ x: 0, y: 0, z: 0 })
         }}

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -104,7 +104,7 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     this._onLoadFailureCallback = callback
   }
 
-  updateModelTransform(transform: DOMMatrix) {
+  updateModelTransform(transform: DOMMatrixReadOnly) {
     const modelTransform = Array.from(transform.toFloat64Array())
     this.updateProperties({ modelTransform })
   }

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -71,7 +71,21 @@ if (!(globalThis as any).DOMMatrix) {
         (p.z ?? 0) + this.tz,
       )
     }
+
+    static fromMatrix(other: any) {
+      const m = new DOMMatrixPolyfill()
+      if (other) {
+        m.tx = other.tx || 0
+        m.ty = other.ty || 0
+        m.tz = other.tz || 0
+      }
+      return m
+    }
   }
+}
+
+if (!(globalThis as any).DOMMatrixReadOnly) {
+  ; (globalThis as any).DOMMatrixReadOnly = (globalThis as any).DOMMatrix
 }
 
 describe('spatialized-container/utils', () => {
@@ -1536,11 +1550,12 @@ describe('SpatializedStatic3DElementContainer', () => {
     expect(onError.mock.calls[0]?.[0].type).toBe('modelloadfailed')
     expect(onLoad.mock.calls[0]?.[0].target).toEqual({ tid: 1 })
 
-    expect(extra.currentSrc()).toBe(window.location.origin + '/m.glb')
-    await expect(extra.ready()).resolves.toMatchObject({ type: 'modelloaded' })
+    expect(extra.currentSrc).toBe(window.location.origin + '/m.glb')
+    await expect(extra.ready).resolves.toMatchObject({ type: 'modelloaded' })
 
-    const m = extra.entityTransform()
+    const m = extra.entityTransform
     ;(m as any).m11 = 2
+    extra.entityTransform = m
     expect(updateModelTransform).toHaveBeenCalledTimes(1)
     expect(updateModelTransform).toHaveBeenCalledWith(expect.any(DOMMatrix))
     expect((domProxy as any).entityTransform).toBeUndefined()
@@ -1603,7 +1618,7 @@ describe('SpatializedStatic3DElementContainer', () => {
       await Promise.resolve()
     })
 
-    await expect(extra.ready()).rejects.toMatchObject({
+    await expect(extra.ready).rejects.toMatchObject({
       type: 'modelloadfailed',
     })
   })

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -119,39 +119,13 @@ function SpatializedStatic3DElementContainerBase(
 ) {
   const extraRefProps = useCallback(
     (domProxy: SpatializedStatic3DElementRef) => {
-      const modelTransform = new DOMMatrix()
-      let needupdate = false
-      const triggerUpdate = () => {
-        const spatializedElement = (domProxy as any)
-          .__spatializedElement as SpatializedStatic3DElement
-        spatializedElement.updateModelTransform(modelTransform)
-        needupdate = false
-      }
-      const domMatrixProxy = new Proxy(modelTransform, {
-        get(target, prop, receiver) {
-          const value = Reflect.get(target, prop, receiver)
-          if (typeof value === 'function') {
-            return function (...args: any[]) {
-              requestAnimationFrame(triggerUpdate)
-              return value.apply(target, args)
-            }
-          } else {
-            return value
-          }
-        },
-        set(target, prop, value) {
-          const success = Reflect.set(target, prop, value)
-          if (!needupdate) {
-            needupdate = true
-            requestAnimationFrame(triggerUpdate)
-          }
-          return success
-        },
-      })
+      let modelTransform = new DOMMatrixReadOnly()
 
       return {
-        currentSrc: () => getAbsoluteURL(props.src),
-        ready: () => {
+        get currentSrc() {
+          return getAbsoluteURL(props.src)
+        },
+        get ready() {
           const spatializedElement = (domProxy as any)
             .__spatializedElement as SpatializedStatic3DElement
 
@@ -163,7 +137,15 @@ function SpatializedStatic3DElementContainerBase(
           })
           return promise
         },
-        entityTransform: () => domMatrixProxy,
+        get entityTransform() {
+          return modelTransform
+        },
+        set entityTransform(value: DOMMatrixReadOnly) {
+          modelTransform = value
+          const spatializedElement = (domProxy as any)
+            .__spatializedElement as SpatializedStatic3DElement
+          spatializedElement.updateModelTransform(modelTransform)
+        },
       }
     },
     [],

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -129,7 +129,9 @@ describe('SpatialContainerRefProxy', () => {
   it('supports extra ref props', () => {
     const ref = { current: null as any }
     const proxy = new SpatialContainerRefProxy<any>(ref, () => ({
-      foo: () => 'bar',
+      get foo() {
+        return 'bar'
+      },
     }))
 
     const dom = document.createElement('div')

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -65,7 +65,7 @@ export type SpatializedContainerProps<T extends SpatializedElementRef> = Omit<
   StandardSpatializedContainerProps & PortalSpatializedContainerProps<T>,
   typeof SpatialID | 'onLoad' | 'onError'
 > & {
-  extraRefProps?: (domProxy: T) => Record<string, () => any>
+  extraRefProps?: (domProxy: T) => Record<string, unknown>
 }
 
 export type SpatializedContentProps<
@@ -115,7 +115,7 @@ export type SpatializedDivElementRef = SpatializedElementRef<HTMLDivElement>
 export type SpatializedStatic3DElementRef = SpatializedDivElementRef & {
   currentSrc: string
   ready: Promise<ModelLoadEvent>
-  entityTransform: DOMMatrix
+  entityTransform: DOMMatrixReadOnly
 }
 
 type CurrentTarget<T extends SpatializedElementRef> = {


### PR DESCRIPTION
Fixes #956. [According to the model proposal](https://immersive-web.github.io/model-element/#the-htmlmodelelement-interface) entityTransform should be [DOMMatrixReadOnly](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly) not [DOMMatrix](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix)


https://github.com/user-attachments/assets/d2c5c3c9-0113-4687-9d4b-e871161888e3

