### PR TITLE
Remove tests from Git pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generateStaticSite": "./tools/scripts/generateWebsite.sh"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm lint-staged && pnpm test"
+    "pre-commit": "pnpm lint-staged"
   },
   "lint-staged": {
     "*.{js,json}": [


### PR DESCRIPTION
Don't run tests in Git pre commit hooks. Instead tests will be run as part of the pull request. As tests get larger they will block developers from committing code locally.

Run `npx simple-git-hooks` to refresh local commit hooks