### PR TITLE
Changeset base branch should be main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "stable",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
   "privatePackages": { "version": true, "tag": false }


### PR DESCRIPTION
In daily development the base branch against which changes are compared should be the main branch. The stable branch is only used for releases to production.