### PR TITLE
sidebar late render triggers DOM update to spatial container

### DIFF
--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -91,7 +91,7 @@ function App() {
         style={{ backgroundColor: 'var(--spa-bg-color, #ffffff)' }}
       >
         <Sidebar />
-        <main className={mainClass}>
+        <main className={mainClass} enable-xr-monitor>
           <Suspense
             fallback={
               <div className="flex items-center justify-center h-full">

--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -89,9 +89,10 @@ function App() {
       <div
         className={outerClass}
         style={{ backgroundColor: 'var(--spa-bg-color, #ffffff)' }}
+        enable-xr-monitor
       >
         <Sidebar />
-        <main className={mainClass} enable-xr-monitor>
+        <main className={mainClass}>
           <Suspense
             fallback={
               <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
- I added enable-xr-monitor to the app’s outer container div. 
- This scopes a single MutationObserver to the whole app subtree that includes both Sidebar and Main, so when the sidebar mounts and shifts layout, the monitor fires and the SDK recomputes the model’s placement.

https://webspatial.dev/docs/development-guide/using-the-webspatial-api/elevate-2d-elements#dynamic-change

Without this, sometimes, model loads out of place
<img width="1190" height="920" alt="Screenshot 2026-02-24 at 12 46 34 PM" src="https://github.com/user-attachments/assets/4e1e0b98-fe47-4d29-aba8-3d5e3f042f84" />

