### PR TITLE
fix(attachments): prevent head sync bloat and improve attachment reli…

### DIFF
--- a/packages/react/src/reality/components/AttachmentEntity.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Attachment } from '@webspatial/core-sdk'
 import { useRealityContext, useParentContext } from '../context'
 import {
@@ -24,6 +24,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
   const attachmentRef = useRef<Attachment | null>(null)
   const parentIdRef = useRef<string | null>(null)
   const instanceIdRef = useRef(`att_${++instanceCounter}`)
+  const attachmentNameRef = useRef(attachmentName)
+  const [childWindow, setChildWindow] = useState<WindowProxy | null>(null)
 
   // Create the attachment when the parent entity is ready
   useEffect(() => {
@@ -72,8 +74,9 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
         windowProxy.document.head.appendChild(base)
 
         attachmentRef.current = att
+        setChildWindow(windowProxy)
         ctx.attachmentRegistry.addContainer(
-          attachmentName,
+          attachmentNameRef.current,
           instanceIdRef.current,
           att.getContainer(),
         )
@@ -89,26 +92,55 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
       const att = attachmentRef.current
       if (att) {
         ctx.attachmentRegistry.removeContainer(
-          attachmentName,
+          attachmentNameRef.current,
           instanceIdRef.current,
         )
         att.destroy()
         attachmentRef.current = null
+        setChildWindow(null)
       }
     }
   }, [ctx, parent])
 
+  // If attachment name changes at runtime, migrate the container mapping
+  useEffect(() => {
+    if (!ctx) return
+    const att = attachmentRef.current
+    const prevName = attachmentNameRef.current
+    if (att && prevName !== attachmentName) {
+      ctx.attachmentRegistry.removeContainer(prevName, instanceIdRef.current)
+      ctx.attachmentRegistry.addContainer(
+        attachmentName,
+        instanceIdRef.current,
+        att.getContainer(),
+      )
+      attachmentNameRef.current = attachmentName
+    } else {
+      attachmentNameRef.current = attachmentName
+    }
+  }, [ctx, attachmentName])
+
   // Ongoing style sync when parent document head changes
   useEffect(() => {
-    const att = attachmentRef.current
-    if (!att) return
-    const windowProxy = att.getWindowProxy()
-    const observer = new MutationObserver(() => {
-      syncParentHeadToChild(windowProxy)
-    })
+    if (!childWindow) return
+    let timer: number | undefined
+    const scheduleSync = () => {
+      if (timer) window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        syncParentHeadToChild(childWindow)
+      }, 100)
+    }
+
+    // initial sync (in case head changes happened between create and observer attach)
+    scheduleSync()
+
+    const observer = new MutationObserver(scheduleSync)
     observer.observe(document.head, { childList: true, subtree: true })
-    return () => observer.disconnect()
-  }, [attachmentRef.current])
+    return () => {
+      if (timer) window.clearTimeout(timer)
+      observer.disconnect()
+    }
+  }, [childWindow])
 
   // Update position/size when they change
   useEffect(() => {

--- a/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
@@ -167,14 +167,26 @@ function Spatialized2DElementContainerBase<P extends ElementType>(
     console.warn(
       '[WebSpatial] SpatialDiv cannot be used inside AttachmentAsset. Rendering as plain HTML.',
     )
+    // When rendering as plain HTML, strip spatial-only props to avoid React warnings
+    // and keep the rest of the DOM props intact.
+    const {
+      component: El,
+      children,
+      'enable-xr': _enableXR,
+      onSpatialTap: _onSpatialTap,
+      onSpatialDragStart: _onSpatialDragStart,
+      onSpatialDrag: _onSpatialDrag,
+      onSpatialDragEnd: _onSpatialDragEnd,
+      onSpatialRotate: _onSpatialRotate,
+      onSpatialRotateEnd: _onSpatialRotateEnd,
+      onSpatialMagnify: _onSpatialMagnify,
+      onSpatialMagnifyEnd: _onSpatialMagnifyEnd,
+      ...rest
+    } = props as any
     return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        className={props.className}
-        style={props.style}
-      >
-        {props.children}
-      </div>
+      <El ref={ref as any} {...rest}>
+        {children}
+      </El>
     )
   }
   return (

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -22,6 +22,16 @@ export function asyncLoadStyleToChildWindow(
   })
 }
 
+const WEBSPATIAL_SYNC_ATTR = 'data-webspatial-sync'
+
+function clearPreviousSyncedHead(childWindow: WindowProxy) {
+  // Remove nodes previously synced from the parent document.
+  // Without this, repeated syncs will append duplicates indefinitely.
+  const head = childWindow.document.head
+  const prev = head.querySelectorAll(`[${WEBSPATIAL_SYNC_ATTR}="1"]`)
+  prev.forEach(n => n.parentNode?.removeChild(n))
+}
+
 export function setOpenWindowStyle(openedWindow: WindowProxy) {
   openedWindow.document.documentElement.style.cssText +=
     document.documentElement.style.cssText
@@ -38,9 +48,14 @@ export function setOpenWindowStyle(openedWindow: WindowProxy) {
 }
 
 export async function syncParentHeadToChild(childWindow: WindowProxy) {
+  clearPreviousSyncedHead(childWindow)
   const styleLoadedPromises: Array<Promise<any>> = []
   for (let i = 0; i < document.head.children.length; i++) {
     const n = document.head.children[i].cloneNode(true) as any
+    // mark as synced so we can clean it up next time
+    if (n?.setAttribute) {
+      n.setAttribute(WEBSPATIAL_SYNC_ATTR, '1')
+    }
     if (
       n.nodeName === 'LINK' &&
       (n as HTMLLinkElement).rel === 'stylesheet' &&

--- a/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
@@ -117,6 +117,7 @@ struct SpatializedDynamic3DView: View {
                 }
             }
         }, update: { _, attachments in
+            let rootEntity = spatializedDynamic3DElement.getRoot()
             // Update attachment positions and parenting
             for (_, info) in spatialScene.attachmentManager.attachments {
                 if let attachmentEntity = attachments.entity(for: info.id) {
@@ -125,6 +126,11 @@ struct SpatializedDynamic3DView: View {
                     if let parentEntity = findSpatialEntity(info.parentEntityId) {
                         if attachmentEntity.parent != parentEntity {
                             parentEntity.addChild(attachmentEntity)
+                        }
+                    } else {
+                        // Parent entity might have been destroyed; fall back to root.
+                        if attachmentEntity.parent != rootEntity {
+                            rootEntity.addChild(attachmentEntity)
                         }
                     }
                 }


### PR DESCRIPTION
…ability

- Deduplicate synced <head> content by tagging and clearing previously-synced nodes
- Fix AttachmentEntity style sync effect deps and debounce head sync
- Preserve DOM props when degrading SpatialDiv inside attachments
- Re-parent attachments to root when the parent entity is missing (visionOS)