### PR TITLE
fix(react): avoid crash when accessing static 3D model APIs early

### DIFF
--- a/.changeset/friendly-grapes-joke.md
+++ b/.changeset/friendly-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"@webspatial/react-sdk": patch
+---
+
+Fix a crash when accessing `ready`/`entityTransform` on static 3D models before the underlying spatialized element is attached.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -66,6 +66,7 @@
     }
   },
   "devDependencies": {
+    "@webspatial/core-sdk": "workspace:*",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.5.5",

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1725,9 +1725,90 @@ describe('SpatializedStatic3DElementContainer', () => {
     const m = extra.entityTransform
     ;(m as any).m11 = 2
     extra.entityTransform = m
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
     expect(updateModelTransform).toHaveBeenCalledTimes(1)
     expect(updateModelTransform).toHaveBeenCalledWith(expect.any(DOMMatrix))
     expect((domProxy as any).entityTransform).toBeUndefined()
+    ;(globalThis as any).requestAnimationFrame = originalRAF
+  })
+
+  it('does not crash when ready/entityTransform accessed before __spatializedElement is attached', async () => {
+    vi.resetModules()
+
+    const updateModelTransform = vi.fn()
+    const spatializedStatic3DElement: any = {
+      updateProperties: vi.fn(),
+      updateModelTransform,
+      ready: Promise.resolve(true),
+    }
+    const createSpatializedStatic3DElement = vi
+      .fn()
+      .mockResolvedValue(spatializedStatic3DElement)
+
+    vi.doMock('./utils', () => {
+      return {
+        getSession: () => ({ createSpatializedStatic3DElement }),
+        enableDebugTool: vi.fn(),
+      }
+    })
+
+    const originalRAF = (globalThis as any).requestAnimationFrame
+    ;(globalThis as any).requestAnimationFrame = (cb: any) => {
+      cb()
+      return 0
+    }
+
+    let extra: any
+    let rawDom: any
+    vi.doMock('./spatialized-container/SpatializedContainer', () => {
+      const React = require('react')
+      function MockSpatializedContainer(props: any) {
+        rawDom = {}
+        const domProxy = { __raw: rawDom }
+        // Build extra ref props before __spatializedElement is attached.
+        extra = props.extraRefProps(domProxy)
+
+        React.useEffect(() => {
+          Promise.resolve(props.createSpatializedElement()).then((el: any) => {
+            Object.assign(rawDom, { __spatializedElement: el })
+          })
+        }, [])
+
+        return React.createElement('div')
+      }
+      return { SpatializedContainer: MockSpatializedContainer }
+    })
+
+    const { SpatializedStatic3DElementContainer } = await import(
+      './spatialized-container/SpatializedStatic3DElementContainer'
+    )
+
+    render(
+      React.createElement(SpatializedStatic3DElementContainer as any, {
+        src: '/m.glb',
+      }),
+    )
+
+    // Access / set before __spatializedElement is attached (should not throw).
+    const m = extra.entityTransform
+    extra.entityTransform = m
+    const readyPromise = extra.ready
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await expect(readyPromise).resolves.toMatchObject({ type: 'modelloaded' })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(updateModelTransform).toHaveBeenCalledTimes(1)
     ;(globalThis as any).requestAnimationFrame = originalRAF
   })
 

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -122,30 +122,113 @@ function SpatializedStatic3DElementContainerBase(
     (domProxy: SpatializedStatic3DElementRef) => {
       let modelTransform = new DOMMatrixReadOnly()
 
+      const rawDom = ((domProxy as any).__raw as any) || (domProxy as any)
+      const WAIT_PROMISE_KEY = '__webspatial_wait_spatialized_static3d_element'
+      const WAIT_RESOLVE_KEY =
+        '__webspatial_wait_spatialized_static3d_element_resolve'
+      const WAIT_CURRENT_KEY =
+        '__webspatial_spatialized_static3d_element_current'
+
+      const getSpatializedElementSync =
+        (): SpatializedStatic3DElement | null => {
+          return (
+            ((rawDom as any)
+              .__spatializedElement as SpatializedStatic3DElement) ||
+            ((domProxy as any)
+              .__spatializedElement as SpatializedStatic3DElement) ||
+            null
+          )
+        }
+
+      const ensureSpatializedElement =
+        (): Promise<SpatializedStatic3DElement> => {
+          const existing = getSpatializedElementSync()
+          if (existing) {
+            return Promise.resolve(existing)
+          }
+
+          if ((rawDom as any)[WAIT_PROMISE_KEY]) {
+            return (rawDom as any)[WAIT_PROMISE_KEY]
+          }
+
+          let resolveFn: ((el: SpatializedStatic3DElement) => void) | undefined
+          const promise = new Promise<SpatializedStatic3DElement>(resolve => {
+            resolveFn = resolve
+          })
+          ;(rawDom as any)[WAIT_PROMISE_KEY] = promise
+          ;(rawDom as any)[WAIT_RESOLVE_KEY] = resolveFn
+
+          const resolveIfReady = (el: any) => {
+            if (!el) {
+              return
+            }
+            ;(rawDom as any)[WAIT_CURRENT_KEY] = el
+            const r = (rawDom as any)[WAIT_RESOLVE_KEY] as
+              | ((e: SpatializedStatic3DElement) => void)
+              | undefined
+            if (r) {
+              ;(rawDom as any)[WAIT_RESOLVE_KEY] = undefined
+              r(el)
+            }
+          }
+
+          try {
+            const desc = Object.getOwnPropertyDescriptor(
+              rawDom,
+              '__spatializedElement',
+            )
+            if (!desc || desc.configurable) {
+              // Use an accessor so that Object.assign(dom, { __spatializedElement }) triggers the setter.
+              Object.defineProperty(rawDom, '__spatializedElement', {
+                configurable: true,
+                enumerable: true,
+                get() {
+                  return (rawDom as any)[WAIT_CURRENT_KEY]
+                },
+                set(v) {
+                  resolveIfReady(v)
+                },
+              })
+            }
+          } catch {
+            // Fallback to rAF polling (should be rare).
+            const poll = () => {
+              const el = getSpatializedElementSync()
+              if (el) {
+                resolveIfReady(el)
+                return
+              }
+              requestAnimationFrame(poll)
+            }
+            requestAnimationFrame(poll)
+          }
+
+          return promise
+        }
+
       return {
         get currentSrc() {
           return getAbsoluteURL(props.src)
         },
         get ready() {
-          const spatializedElement = (domProxy as any)
-            .__spatializedElement as SpatializedStatic3DElement
-
-          const promise = spatializedElement.ready.then((success: boolean) => {
-            if (success) {
-              return createLoadSuccessEvent(() => domProxy)
-            }
-            throw createLoadFailureEvent(() => domProxy)
-          })
-          return promise
+          return ensureSpatializedElement()
+            .then(el => el.ready)
+            .then((success: boolean) => {
+              if (success) {
+                return createLoadSuccessEvent(() => domProxy)
+              }
+              throw createLoadFailureEvent(() => domProxy)
+            })
         },
         get entityTransform() {
           return modelTransform
         },
         set entityTransform(value: DOMMatrixReadOnly) {
           modelTransform = value
-          const spatializedElement = (domProxy as any)
-            .__spatializedElement as SpatializedStatic3DElement
-          spatializedElement.updateModelTransform(modelTransform)
+          // Defer update until the spatialized element is attached.
+          void ensureSpatializedElement().then(el => {
+            el.updateModelTransform(modelTransform)
+          })
         },
       }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,10 +324,6 @@ importers:
         version: 5.7.3
 
   packages/react:
-    dependencies:
-      '@webspatial/core-sdk':
-        specifier: workspace:*
-        version: link:../core
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.8
@@ -353,6 +349,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^2.0.4
         version: 2.1.9(vitest@2.1.9(@types/node@22.15.2)(jsdom@24.1.3)(lightningcss@1.29.3)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0))
+      '@webspatial/core-sdk':
+        specifier: workspace:*
+        version: link:../core
       esbuild:
         specifier: '>=0.25.0'
         version: 0.25.3


### PR DESCRIPTION
Fixes #1001.

When using the static 3D model container, calling extra DOM APIs like `ref.current.ready` or reading/setting `ref.current.entityTransform` before the underlying native element is attached could crash. This PR makes those accessors wait until `__spatializedElement` is available, then proceeds safely.

Changes:
- Add a small wait mechanism for `__spatializedElement` (accessor hook + rAF fallback).
- Defer `ready` and `entityTransform` behavior until the element is attached.
- Add a regression test covering early access.
- Add a changeset for `@webspatial/react-sdk` (patch).