### PR TITLE
fix(react): prevent Model ref from being used before element is created

### DIFF
--- a/.changeset/friendly-grapes-joke.md
+++ b/.changeset/friendly-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"@webspatial/react-sdk": patch
+---
+
+Fix a crash when accessing `ready`/`entityTransform` on static 3D models before the underlying spatialized element is attached.

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -5,6 +5,9 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useState,
+  useImperativeHandle,
+  useRef,
 } from 'react'
 import { SpatializedContainer } from './SpatializedContainer'
 import { getSession } from '../utils'
@@ -110,14 +113,22 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
   return <></>
 }
 
-async function createSpatializedElement() {
-  return getSession()!.createSpatializedStatic3DElement()
-}
-
 function SpatializedStatic3DElementContainerBase(
   props: SpatializedStatic3DContainerProps,
   ref: ForwardedRef<SpatializedStatic3DElementRef>,
 ) {
+  const containerRef = useRef<SpatializedStatic3DElementRef>(null)
+  const [elementCreated, setElementCreated] = useState(false)
+  useImperativeHandle<
+    SpatializedStatic3DElementRef | null,
+    SpatializedStatic3DElementRef | null
+  >(ref, () => (elementCreated ? containerRef.current : null), [elementCreated])
+
+  const createSpatializedElement = useCallback(async () => {
+    const element = await getSession()!.createSpatializedStatic3DElement()
+    setElementCreated(true)
+    return element
+  }, [setElementCreated])
   const extraRefProps = useCallback(
     (domProxy: SpatializedStatic3DElementRef) => {
       let modelTransform = new DOMMatrixReadOnly()
@@ -154,7 +165,7 @@ function SpatializedStatic3DElementContainerBase(
 
   return (
     <SpatializedContainer<SpatializedStatic3DElementRef>
-      ref={ref}
+      ref={containerRef}
       component="div"
       createSpatializedElement={createSpatializedElement}
       spatializedContent={SpatializedContent}


### PR DESCRIPTION
Fix #1001. Wait until createSpatializedElement has completed before setting ref on Model component.

<img width="3840" height="2160" alt="Simulator Screenshot - Apple Vision Pro 26 2 - 2026-03-05 at 19 59 45" src="https://github.com/user-attachments/assets/0991f077-8237-434b-ac13-d8f818aefed8" />
