### PR TITLE
Remove Git LFS configuration from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-docs/assets/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
Removed the Git LFS (Large File Storage) configuration. Git LFS is not used in this repo and we don't plan to add support for large files. This change was generated by Claude AI.

https://claude.ai/code/session_01A1EE8Ba8kEbHbseiKwgtev