### PR TITLE
ci: use latest Node.js version in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-test-pages.yml
+++ b/.github/workflows/auto-test-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'latest'
           cache: 'pnpm'
 
       - name: Install autotest and build required packages

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'latest'
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'latest'
           cache: 'pnpm'
       
       - name: Install dependencies and build

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'latest'
           cache: 'pnpm'
       
       - name: Install dependencies and build


### PR DESCRIPTION
Update node-version from 20 to 'latest' in ci.yml, auto-test-pages.yml, changesets.yml, and preview-release.yml so CI always tests against the most recent Node.js release.

Closes #941

https://claude.ai/code/session_01JzzeaMoAzqf4B3TCazjwRj