### PR TITLE
async attachment window setup

### DIFF
--- a/packages/react/src/reality/components/AttachmentEntity.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Attachment } from '@webspatial/core-sdk'
 import { useRealityContext, useParentContext } from '../context'
 import {
-  setOpenWindowStyle,
-  syncParentHeadToChild,
-} from '../../utils/windowStyleSync'
+  yieldToMainThread,
+  setupChildWindow,
+} from '../../utils/childWindowSetup'
+import { useHeadSync } from '../../utils/useHeadSync'
 
 let instanceCounter = 0
 
@@ -27,6 +28,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
   const instanceIdRef = useRef(`att_${++instanceCounter}`)
   const attachmentNameRef = useRef(attachmentName)
   const [childWindow, setChildWindow] = useState<WindowProxy | null>(null)
+  // Keep the attachment child window's head in sync with the parent (debounced).
+  useHeadSync(childWindow)
 
   // Create the attachment when the parent entity is ready
   useEffect(() => {
@@ -39,6 +42,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
 
     const init = async () => {
       try {
+        // Yield so multiple attachments don't call window.open() in one flush.
+        await yieldToMainThread()
         const att = await ctx.session.createAttachmentEntity({
           parentEntityId: parentId,
           position: position ?? [0, 0, 0],
@@ -48,34 +53,9 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
           att.destroy()
           return
         }
-        // Initial style sync for attachment window
         const windowProxy = att.getWindowProxy()
-        setOpenWindowStyle(windowProxy)
-        // setOpenWindowStyle() above applies SpatialDiv defaults (inline-block, fit-content)
-        // which shrink the body to its content. Attachments need the opposite — the body
-        // must fill the RealityKit attachment frame — so override to block/100%.
-        windowProxy.document.body.style.display = 'block'
-        windowProxy.document.body.style.minWidth = '100%'
-        windowProxy.document.body.style.maxWidth = '100%'
-        windowProxy.document.body.style.minHeight = '100%'
-        await syncParentHeadToChild(windowProxy)
-
-        // Ensure viewport meta
-        const viewport = windowProxy.document.querySelector(
-          'meta[name="viewport"]',
-        )
-        if (!viewport) {
-          const meta = windowProxy.document.createElement('meta')
-          meta.name = 'viewport'
-          meta.content =
-            'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
-          windowProxy.document.head.appendChild(meta)
-        }
-
-        // Ensure base href for relative URLs
-        const base = windowProxy.document.createElement('base')
-        base.href = document.baseURI
-        windowProxy.document.head.appendChild(base)
+        // Shared child-window setup; ensures body fill + head/viewport/base tags.
+        await setupChildWindow(windowProxy, 'attachment')
 
         attachmentRef.current = att
         setChildWindow(windowProxy)
@@ -124,28 +104,7 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
     }
   }, [ctx, attachmentName])
 
-  // Ongoing style sync when parent document head changes
-  useEffect(() => {
-    if (!childWindow) return
-    let timer: number | undefined
-    // Debounce rapid successive head mutations to avoid redundant style syncs
-    const scheduleSync = () => {
-      if (timer) window.clearTimeout(timer)
-      timer = window.setTimeout(() => {
-        syncParentHeadToChild(childWindow)
-      }, 100)
-    }
-
-    // initial sync (in case head changes happened between create and observer attach)
-    scheduleSync()
-
-    const observer = new MutationObserver(scheduleSync)
-    observer.observe(document.head, { childList: true, subtree: true })
-    return () => {
-      if (timer) window.clearTimeout(timer)
-      observer.disconnect()
-    }
-  }, [childWindow])
+  // Debounce rapid successive head mutations to avoid redundant style syncs
 
   // Update position/size when they change
   useEffect(() => {

--- a/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
@@ -22,10 +22,8 @@ import {
 import { Spatialized2DElement } from '@webspatial/core-sdk'
 import { createPortal } from 'react-dom'
 import { getInheritedStyleProps, parseCornerRadius } from './utils'
-import {
-  setOpenWindowStyle,
-  syncParentHeadToChild,
-} from '../utils/windowStyleSync'
+import { setupChildWindow } from '../utils/childWindowSetup'
+import { useHeadSync } from '../utils/useHeadSync'
 function getJSXPortalInstance<P extends ElementType>(
   inProps: Omit<
     SpatializedContentProps<SpatializedElementRef, P>,
@@ -75,18 +73,6 @@ function useSyncDocumentTitle(
   }, [name])
 }
 
-function useSyncHeaderStyle(windowProxy: WindowProxy) {
-  useEffect(() => {
-    const headObserver = new MutationObserver(_ => {
-      syncParentHeadToChild(windowProxy)
-    })
-    headObserver.observe(document.head, { childList: true, subtree: true })
-    return () => {
-      headObserver.disconnect()
-    }
-  }, [])
-}
-
 function SpatializedContent<P extends ElementType>(
   props: SpatializedContentProps<SpatializedElementRef, P>,
 ) {
@@ -94,7 +80,8 @@ function SpatializedContent<P extends ElementType>(
   const spatialized2DElement = spatializedElement as Spatialized2DElement
   const windowProxy = spatialized2DElement.windowProxy
 
-  useSyncHeaderStyle(windowProxy)
+  // Mirror parent head changes into the SpatialDiv child window (debounced).
+  useHeadSync(windowProxy)
 
   const name: string = (restProps as any)['data-name'] || ''
   useSyncDocumentTitle(windowProxy, spatialized2DElement, name)
@@ -134,21 +121,8 @@ function getExtraSpatializedElementProperties(
 async function createSpatializedElement() {
   const spatializedElement = await getSession()!.createSpatialized2DElement()
   const windowProxy = spatializedElement.windowProxy
-  setOpenWindowStyle(windowProxy)
-  await syncParentHeadToChild(windowProxy)
-
-  const viewport = windowProxy.document.querySelector('meta[name="viewport"]')
-  if (viewport) {
-    viewport?.setAttribute(
-      'content',
-      ' initial-scale=1.0, maximum-scale=1.0, user-scalable=no',
-    )
-  } else {
-    const meta = windowProxy.document.createElement('meta')
-    meta.name = 'viewport'
-    meta.content = 'initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
-    windowProxy.document.head.appendChild(meta)
-  }
+  // Shared child-window setup (styles + head + viewport).
+  await setupChildWindow(windowProxy, 'div')
 
   return spatializedElement
 }

--- a/packages/react/src/utils/childWindowSetup.ts
+++ b/packages/react/src/utils/childWindowSetup.ts
@@ -1,0 +1,55 @@
+// Shared helpers for opening and initializing child windows (SpatialDiv, attachments).
+// Keep logic centralized to avoid duplicating style, meta, and head-sync setup.
+import { setOpenWindowStyle, syncParentHeadToChild } from './windowStyleSync'
+
+// Yield to the browser event loop so expensive operations like window.open()
+// don't stack up during a React effect flush.
+export function yieldToMainThread(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+// Apply base styles, sync parent head, and ensure viewport/base tags for the child window.
+export async function setupChildWindow(
+  windowProxy: WindowProxy,
+  mode: 'div' | 'attachment',
+): Promise<void> {
+  // Base HTML/body styles (transparent, margins, etc.)
+  setOpenWindowStyle(windowProxy)
+
+  if (mode === 'attachment') {
+    // Attachments should fill their RealityKit frame
+    const body = windowProxy.document.body
+    body.style.display = 'block'
+    body.style.minWidth = '100%'
+    body.style.maxWidth = '100%'
+    body.style.minHeight = '100%'
+  }
+
+  // Copy parent head links/meta/classes into the child window
+  await syncParentHeadToChild(windowProxy)
+
+  // Ensure viewport meta is present and correct
+  const head = windowProxy.document.head
+  const existing = windowProxy.document.querySelector('meta[name="viewport"]')
+  if (existing) {
+    existing.setAttribute(
+      'content',
+      'initial-scale=1.0, maximum-scale=1.0, user-scalable=no',
+    )
+  } else {
+    const meta = windowProxy.document.createElement('meta')
+    meta.name = 'viewport'
+    meta.content =
+      mode === 'attachment'
+        ? 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+        : 'initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+    head.appendChild(meta)
+  }
+
+  if (mode === 'attachment') {
+    // Ensure relative URLs resolve relative to the parent document
+    const base = windowProxy.document.createElement('base')
+    base.href = document.baseURI
+    head.appendChild(base)
+  }
+}

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { getSession } from './getSession'
 export { enableDebugTool } from './debugTool'
+export { setupChildWindow, yieldToMainThread } from './childWindowSetup'
+export { useHeadSync } from './useHeadSync'

--- a/packages/react/src/utils/useHeadSync.ts
+++ b/packages/react/src/utils/useHeadSync.ts
@@ -1,0 +1,26 @@
+// Debounced head sync hook: mirrors parent document.head into a child window.
+// Use for SpatialDivs and attachments to keep styles/meta in sync.
+import { useEffect } from 'react'
+import { syncParentHeadToChild } from './windowStyleSync'
+
+// Observes parent head mutations and schedules a debounced sync.
+export function useHeadSync(childWindow: WindowProxy | null) {
+  useEffect(() => {
+    if (!childWindow) return
+    let timer: number | undefined
+    const scheduleSync = () => {
+      if (timer) window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        syncParentHeadToChild(childWindow)
+      }, 100)
+    }
+    // Initial sync in case mutations happened before observer attached
+    scheduleSync()
+    const observer = new MutationObserver(scheduleSync)
+    observer.observe(document.head, { childList: true, subtree: true })
+    return () => {
+      if (timer) window.clearTimeout(timer)
+      observer.disconnect()
+    }
+  }, [childWindow])
+}


### PR DESCRIPTION
- Fixes UI blocking when multiple AttachmentEntity components mount by yielding to the main thread before window.open(), preventing many WKWebViews from being created in one synchronous task.

- Centralizes child-window setup logic into shared utilities (setupChildWindow, yieldToMainThread, useHeadSync) to remove duplicated logic between AttachmentEntity and Spatialized2DElementContainer.

- Introduces debounced head synchronization via MutationObserver to keep child windows’ <head> in sync with the parent.
