### PR TITLE
Model ref.current.ready should be stable

### DIFF
--- a/.changeset/many-geckos-eat.md
+++ b/.changeset/many-geckos-eat.md
@@ -1,0 +1,10 @@
+---
+'web-content': patch
+'@webspatial/react-sdk': patch
+---
+
+Fixed Model ref.current to be stable after initial render
+
+Changes to ref cannot be observed since React doesn't re-render
+on ref changes. So ref.current.ready Promise needs to be stable and
+immediately available. It should resolve after the 3D model has rendered

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -17,8 +17,8 @@ function App() {
   const [transform, setTransform] = useState('')
   const [dragTranslation, setDragTranslation] = useState({ x: 0, y: 0, z: 0 })
   useEffect(() => {
-    modelRef.current?.ready.then(() => logLine('ref.current.ready success'))
-  }, [modelRef.current, logLine])
+    modelRef.current!.ready.then(() => logLine('ref.current.ready success'))
+  }, [logLine])
 
   return (
     <div className="prose max-w-none">

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -5,8 +5,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useState,
-  useImperativeHandle,
   useRef,
 } from 'react'
 import { SpatializedContainer } from './SpatializedContainer'
@@ -117,18 +115,13 @@ function SpatializedStatic3DElementContainerBase(
   props: SpatializedStatic3DContainerProps,
   ref: ForwardedRef<SpatializedStatic3DElementRef>,
 ) {
-  const containerRef = useRef<SpatializedStatic3DElementRef>(null)
-  const [elementCreated, setElementCreated] = useState(false)
-  useImperativeHandle<
-    SpatializedStatic3DElementRef | null,
-    SpatializedStatic3DElementRef | null
-  >(ref, () => (elementCreated ? containerRef.current : null), [elementCreated])
+  const promiseRef = useRef<Promise<SpatializedStatic3DElement> | null>(null)
 
-  const createSpatializedElement = useCallback(async () => {
-    const element = await getSession()!.createSpatializedStatic3DElement()
-    setElementCreated(true)
-    return element
-  }, [setElementCreated])
+  const createSpatializedElement = useCallback(() => {
+    const url = getAbsoluteURL(props.src)
+    promiseRef.current = getSession()!.createSpatializedStatic3DElement(url)
+    return promiseRef.current
+  }, [])
   const extraRefProps = useCallback(
     (domProxy: SpatializedStatic3DElementRef) => {
       let modelTransform = new DOMMatrixReadOnly()
@@ -138,25 +131,22 @@ function SpatializedStatic3DElementContainerBase(
           return getAbsoluteURL(props.src)
         },
         get ready(): Promise<ModelLoadEvent> {
-          const spatializedElement = (domProxy as any)
-            .__spatializedElement as SpatializedStatic3DElement
-
-          const promise = spatializedElement.ready.then((success: boolean) => {
-            if (success) {
-              return createLoadSuccessEvent(() => domProxy)
-            }
-            throw createLoadFailureEvent(() => domProxy)
-          })
-          return promise
+          return promiseRef
+            .current!.then(spatializedElement => spatializedElement.ready)
+            .then(success => {
+              if (success) return createLoadSuccessEvent(() => domProxy)
+              throw createLoadFailureEvent(() => domProxy)
+            })
         },
         get entityTransform(): DOMMatrixReadOnly {
           return modelTransform
         },
         set entityTransform(value: DOMMatrixReadOnly) {
           modelTransform = value
-          const spatializedElement = (domProxy as any)
-            .__spatializedElement as SpatializedStatic3DElement
-          spatializedElement.updateModelTransform(modelTransform)
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          spatializedElement?.updateModelTransform(modelTransform)
         },
       }
     },
@@ -165,7 +155,7 @@ function SpatializedStatic3DElementContainerBase(
 
   return (
     <SpatializedContainer<SpatializedStatic3DElementRef>
-      ref={containerRef}
+      ref={ref}
       component="div"
       createSpatializedElement={createSpatializedElement}
       spatializedContent={SpatializedContent}


### PR DESCRIPTION
Follow up to #1001. Changes to `ref` cannot be observed since React doesn't re-render on ref changes. So `ref.current.ready` Promise needs to be stable and immediately available. It should resolve after the 3D model has rendered fully.

The previous code of using `useImperativeHandle` to return null until the asynchronous `createSpatializedElement` completes doesn't work since the consumer can not observe when the ref changes from a null to a real value.
```
useEffect(() => {
    modelRef.current?.ready.then(() => console.log('ref.current.ready success'))
  }, [modelRef.current])
```

<img width="2160" height="2158" alt="Screenshot_1773354507" src="https://github.com/user-attachments/assets/7c056211-d24b-457f-8e02-cdff09e61d31" />
