### PR TITLE
Require URL for SpatializedStatic3DElement

### DIFF
--- a/.changeset/fruity-symbols-worry.md
+++ b/.changeset/fruity-symbols-worry.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': minor
+---
+
+Require URL for SpatializedStatic3DElement

--- a/apps/test-server/src/pages/jsapi-test/jsapi.ts
+++ b/apps/test-server/src/pages/jsapi-test/jsapi.ts
@@ -169,7 +169,7 @@ export async function testAddMultipleSpatializedStatic3DElement(
     const spatialScene = session.getSpatialScene()
 
     const spatializedStatic3DElementA: SpatializedStatic3DElement =
-      await session.createSpatializedStatic3DElement()
+      await session.createSpatializedStatic3DElement('/modelasset/cone.usdz')
     await spatializedStatic3DElementA.updateProperties({
       name: 'ModelA',
       width: 200,
@@ -188,7 +188,7 @@ export async function testAddMultipleSpatializedStatic3DElement(
 
     // create
     const spatializedStatic3DElementB: SpatializedStatic3DElement =
-      await session.createSpatializedStatic3DElement()
+      await session.createSpatializedStatic3DElement('/modelasset/cone.usdz')
     await spatializedStatic3DElementB.updateProperties({
       name: 'ModelB',
       width: 200,

--- a/packages/core/src/SpatialSession.ts
+++ b/packages/core/src/SpatialSession.ts
@@ -72,7 +72,7 @@ export class SpatialSession {
    * @returns Promise resolving to a new SpatializedStatic3DElement instance
    */
   createSpatializedStatic3DElement(
-    modelURL: string = '',
+    modelURL: string,
   ): Promise<SpatializedStatic3DElement> {
     return createSpatializedStatic3DElement(modelURL)
   }
@@ -196,7 +196,9 @@ export class SpatialSession {
    * @param options Configuration options including parent entity ID, position, and size
    * @returns Promise resolving to a new Attachment instance
    */
-  createAttachmentEntity(options: AttachmentEntityOptions): Promise<Attachment> {
+  createAttachmentEntity(
+    options: AttachmentEntityOptions,
+  ): Promise<Attachment> {
     return createAttachmentEntity(options)
   }
 }

--- a/packages/core/src/SpatializedElementCreator.ts
+++ b/packages/core/src/SpatializedElementCreator.ts
@@ -30,7 +30,7 @@ export async function createSpatializedStatic3DElement(
     throw new Error('createSpatializedStatic3DElement failed')
   } else {
     const { id } = result.data
-    return new SpatializedStatic3DElement(id)
+    return new SpatializedStatic3DElement(id, modelURL)
   }
 }
 

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -10,6 +10,17 @@ import { SpatialWebMsgType } from './WebMsgCommand'
  */
 export class SpatializedStatic3DElement extends SpatializedElement {
   /**
+   * Creates a new spatialized static 3D element with the specified ID and URL.
+   * Registers the element to receive spatial events.
+   * @param id Unique identifier for this element
+   * @param modelURL URL of the 3D model
+   */
+  constructor(id: string, modelURL: string) {
+    super(id)
+    this.modelURL = modelURL
+  }
+
+  /**
    * Promise resolver for the ready state.
    * Used to resolve the ready promise when the model is loaded.
    */
@@ -19,7 +30,7 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * Caches the last model URL to detect changes.
    * Used to reset the ready promise when the model URL changes.
    */
-  private modelURL: string = ''
+  private modelURL: string
 
   /**
    * Creates a new promise for tracking the ready state of the model.


### PR DESCRIPTION
When creating a 3D model immediately set the model URL instead of setting a blank string and then uploading with the `src` attribute. This optimizes 3D model loading. It also fixes the issue where `ref.current.ready` returns the promise for loading the model defined in src instead of the promise for loading a blank URL.

<img width="2160" height="2158" alt="Screenshot_1773354507" src="https://github.com/user-attachments/assets/87b8b6cf-4c39-4a52-8a04-a90d1c8e8ae1" />