### PR TITLE
Prevent WebSpatial initialization inside iframes to avoid resource leaks

### DIFF
--- a/apps/test-server/src/pages/cleanup/index.tsx
+++ b/apps/test-server/src/pages/cleanup/index.tsx
@@ -63,10 +63,16 @@ export function CleanupModel() {
 }
 
 export function CleanupIframe() {
-  const iframeSrc = `https://webspatial-hackathon.vercel.app/`
+  // Use a same-origin local route so the updated SDK's iframe guard is exercised.
+  // The SDK detects iframe context and falls back to degraded (non-spatial) mode.
+  const iframeSrc = `${window.location.origin}/#/static-3d-model`
   return (
     <div className="p-6">
       <h2 className="text-xl mb-4">Static Model within Iframe</h2>
+      <p style={{ color: '#888', fontSize: '14px', marginBottom: '12px' }}>
+        WebSpatial should be disabled inside this iframe (degraded mode). No 3D
+        models should render spatially.
+      </p>
       <iframe
         title="cleanup-iframe"
         src={iframeSrc}

--- a/packages/core/src/Spatial.ts
+++ b/packages/core/src/Spatial.ts
@@ -1,5 +1,6 @@
 import { SpatialSession } from './SpatialSession'
 import { SpatialWebEvent } from './SpatialWebEvent'
+import { isInIframe, warnIfIframe } from './iframe-guard'
 
 /**
  * Base object designed to be placed on navigator.spatial to mirror navigator.xr for webxr.
@@ -27,6 +28,11 @@ export class Spatial {
    * @returns True if running in a spatial web environment, false otherwise
    */
   runInSpatialWeb() {
+    // Issue #970: block initialization inside iframes to prevent resource leaks
+    if (isInIframe()) {
+      warnIfIframe()
+      return false
+    }
     if (navigator.userAgent.indexOf('WebSpatial/') > 0) {
       return true
     }

--- a/packages/core/src/iframe-guard.ts
+++ b/packages/core/src/iframe-guard.ts
@@ -1,0 +1,29 @@
+// Issue #970: WebSpatial does not support running inside iframes.
+// Iframe removal does not trigger reliable cleanup in the child document,
+// leading to leaked XR sessions, GPU contexts, and spatial entities.
+
+let _isInIframe: boolean | null = null
+
+export function isInIframe(): boolean {
+  if (_isInIframe !== null) return _isInIframe
+  try {
+    _isInIframe = typeof window !== 'undefined' && window.self !== window.top
+  } catch {
+    // Cross-origin iframe — accessing window.top throws SecurityError
+    _isInIframe = true
+  }
+  return _isInIframe
+}
+
+const IFRAME_WARNING = `[WebSpatial] Running WebSpatial inside an iframe is currently unsupported.
+This can lead to resource leaks because iframe removal does not trigger reliable cleanup.
+WebSpatial initialization has been disabled.`
+
+let _warned = false
+
+export function warnIfIframe(): void {
+  if (isInIframe() && !_warned) {
+    _warned = true
+    console.warn(IFRAME_WARNING)
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,10 +14,17 @@ export * from './types/global.d'
 import { injectSceneHook } from './scene-polyfill'
 import { isSSREnv } from './ssr-polyfill'
 import { spatialWindowPolyfill } from './spatial-window-polyfill'
+import { isInIframe } from './iframe-guard'
 
 export { isSSREnv }
+export { isInIframe } from './iframe-guard'
 
-if (!isSSREnv() && navigator.userAgent.indexOf('WebSpatial/') > 0) {
+// Issue #970: skip polyfills inside iframes to prevent resource leaks
+if (
+  !isSSREnv() &&
+  !isInIframe() &&
+  navigator.userAgent.indexOf('WebSpatial/') > 0
+) {
   injectSceneHook()
   spatialWindowPolyfill()
 }

--- a/packages/core/src/platform-adapter/index.ts
+++ b/packages/core/src/platform-adapter/index.ts
@@ -1,3 +1,4 @@
+import { isInIframe, warnIfIframe } from '../iframe-guard'
 import { isSSREnv } from '../ssr-polyfill'
 import { PlatformAbility } from './interface'
 import { SSRPlatform } from './ssr/SSRPlatform'
@@ -28,6 +29,11 @@ function isVersionGreater(a: number[] | null, b: number[]): boolean {
 
 export function createPlatform(): PlatformAbility {
   if (isSSREnv()) {
+    return new SSRPlatform()
+  }
+  // Issue #970: return no-op platform inside iframes to block all native bridge commands
+  if (isInIframe()) {
+    warnIfIframe()
     return new SSRPlatform()
   }
   const userAgent = window.navigator.userAgent


### PR DESCRIPTION
## Summary
Block WebSpatial initialization when running inside an iframe.

**Changes**
- Added iframe-guard.ts utility for detecting iframe environments
- Prevented polyfill initialization when running inside an iframe
- Added an iframe guard to Spatial.runInSpatialWeb()

**Implementation Notes**
- Iframe detection is cached to avoid repeated checks
- Cross-origin iframes are handled via try/catch when accessing window.top
- Warning is logged once to avoid console spam
- The guard runs early to prevent spatial session creation and resource allocation (issues mentioned in Github Issue #970 )