### PR TITLE
feat(core): Model autoplay attribute for animations

### DIFF
--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -52,6 +52,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
         this.ready = this.createReadyPromise()
       }
     }
+    if (properties.autoplay !== undefined) {
+      this._autoplay = properties.autoplay
+    }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
       properties,
@@ -76,6 +79,18 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data as any)
     }
+  }
+
+  /**
+   * Whether the model should automatically play its first animation on load.
+   */
+  private _autoplay: boolean = false
+
+  /**
+   * Returns whether autoplay is enabled for this element.
+   */
+  get autoplay(): boolean {
+    return this._autoplay
   }
 
   /**

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -94,6 +94,7 @@ export interface SpatializedStatic3DElementProperties
   extends SpatializedElementProperties {
   modelURL: string
   modelTransform?: number[]
+  autoplay?: boolean
 }
 
 export interface SpatialSceneCreationOptions {


### PR DESCRIPTION
Add `autoplay` boolean prop to the <Model> component that triggers automatic playback of the first embedded animation in a 3D model upon load.

Issue #1007
https://claude.ai/code/session_01TfKAU2rRf6uugk2PwBQoAq