### PR TITLE
feat: Model autoplay attribute for animations

### DIFF
--- a/.changeset/major-pigs-juggle.md
+++ b/.changeset/major-pigs-juggle.md
@@ -1,0 +1,10 @@
+---
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
+---
+
+Add autoplay attribute to <Model>
+
+When a 3D model contains an embedded animation, developers can opt into automatic playback via a simple boolean attribute. When autoplay is set, the model's first available animation begins playing as soon as the model has successfully loaded.

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -26,8 +26,11 @@ function App() {
       <EntityTransform model={modelRef} />
       <Model
         className="block"
-        src="/modelasset/cone.usdz"
+        src="https://developer.apple.com/augmented-reality/quick-look/models/biplane/toy_biplane_realistic.usdz"
+        // src="https://webkit.org/demos/model-demos/models/stopwatch.usdz"
+        // src="/modelasset/cone.usdz"
         enable-xr
+        autoplay
         style={{
           height: '200px',
           '--xr-depth': '100px',

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -63,6 +63,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
         this.ready = this.createReadyPromise()
       }
     }
+    if (properties.autoplay !== undefined) {
+      this._autoplay = properties.autoplay
+    }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
       properties,
@@ -87,6 +90,18 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data as any)
     }
+  }
+
+  /**
+   * Whether the model should automatically play its first animation on load.
+   */
+  private _autoplay: boolean = false
+
+  /**
+   * Returns whether autoplay is enabled for this element.
+   */
+  get autoplay(): boolean {
+    return this._autoplay
   }
 
   /**

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -94,6 +94,7 @@ export interface SpatializedStatic3DElementProperties
   extends SpatializedElementProperties {
   modelURL: string
   modelTransform?: number[]
+  autoplay?: boolean
 }
 
 export interface SpatialSceneCreationOptions {

--- a/packages/react/src/Model.tsx
+++ b/packages/react/src/Model.tsx
@@ -33,6 +33,7 @@ function ModelBase(props: ModelProps, ref: ForwardedRef<ModelRef>) {
       onSpatialRotateEnd,
       onSpatialMagnify,
       onSpatialMagnifyEnd,
+      autoplay: _autoplay,
       ...modelProps
     } = restProps
     // map to VisionOS26 model tag outside attachments

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -64,7 +64,7 @@ function createLoadSuccessEvent(
 }
 
 function SpatializedContent(props: SpatializedStatic3DContentProps) {
-  const { src, spatializedElement, onLoad, onError } = props
+  const { src, spatializedElement, onLoad, onError, autoplay } = props
   const spatializedStatic3DElement =
     spatializedElement as SpatializedStatic3DElement
 
@@ -76,9 +76,12 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
 
   useEffect(() => {
     if (src) {
-      spatializedStatic3DElement.updateProperties({ modelURL: currentSrc })
+      spatializedStatic3DElement.updateProperties({
+        modelURL: currentSrc,
+        autoplay,
+      })
     }
-  }, [currentSrc])
+  }, [currentSrc, autoplay])
 
   useEffect(() => {
     if (onLoad) {

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -86,6 +86,7 @@ export type SpatializedStatic3DContainerProps =
   SpatialEventProps<SpatializedStatic3DElementRef> &
     Omit<React.ComponentPropsWithoutRef<'div'>, 'onLoad' | 'onError'> & {
       src?: string
+      autoplay?: boolean
       onLoad?: (event: ModelLoadEvent) => void
       onError?: (event: ModelLoadEvent) => void
     }
@@ -93,6 +94,7 @@ export type SpatializedStatic3DContainerProps =
 export type SpatializedStatic3DContentProps = {
   spatializedElement: SpatializedStatic3DElement
   src?: string
+  autoplay?: boolean
   onLoad?: (event: ModelLoadEvent) => void
   onError?: (event: ModelLoadEvent) => void
 }

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -229,6 +229,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
 
     let modelURL: String?
     let modelTransform: [Double]?
+    let autoplay: Bool?
 }
 
 struct UpdateSpatializedDynamic3DElementProperties: SpatializedElementProperties {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -565,6 +565,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             spatializedElement.modelTransform = affineTransform3D
         }
 
+        if let autoplay = command.autoplay {
+            spatializedElement.autoplay = autoplay
+        }
+
         resolve(.success(baseReplyData))
     }
 

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -5,6 +5,7 @@ import SwiftUI
 class SpatializedStatic3DElement: SpatializedElement {
     var modelURL: String = ""
     var modelTransform: AffineTransform3D = .identity
+    var autoplay: Bool = false
 
     enum CodingKeys: String, CodingKey {
         case modelURL, type

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -5,6 +5,9 @@ struct SpatializedStatic3DView: View {
     @Environment(SpatializedElement.self) var spatializedElement: SpatializedElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
 
+    @State private var asset: Model3DAsset?
+    @State private var loadFailed = false
+
     private var spatializedStatic3DElement: SpatializedStatic3DElement {
         return spatializedElement as! SpatializedStatic3DElement
     }
@@ -15,6 +18,21 @@ struct SpatializedStatic3DView: View {
 
     func onLoadFailure() {
         spatialScene.sendWebMsg(spatializedElement.id, ModelLoadFailure())
+    }
+
+    /// Downloads a remote model file and loads it as a Model3DAsset.
+    /// Model3DAsset(url:) requires a local file URL, so remote
+    /// resources must be downloaded first.
+    private func loadAsset(from url: URL) async throws -> Model3DAsset {
+        if url.isFileURL {
+            return try await Model3DAsset(url: url)
+        }
+        let (tempURL, _) = try await URLSession.shared.download(from: url)
+        // TODO: Use FileManager.temporaryDirectory and FileManager.removeItem for auto cleanup
+        let localURL = tempURL.deletingPathExtension()
+            .appendingPathExtension(url.pathExtension)
+        try FileManager.default.moveItem(at: tempURL, to: localURL)
+        return try await Model3DAsset(url: localURL)
     }
 
     var body: some View {
@@ -28,29 +46,44 @@ struct SpatializedStatic3DView: View {
         let z = translation.z
 
         let enableGesture = spatializedElement.enableGesture
-        if let url = URL(string: spatializedStatic3DElement.modelURL) {
-            Model3D(url: url) { newPhase in
-                switch newPhase {
-                case .empty:
-                    ProgressView()
-                case let .success(resolvedModel3D):
-                    resolvedModel3D
-                        .resizable(true)
-                        .aspectRatio(
-                            nil,
-                            contentMode: .fit
-                        )
-                        .if(!depth.isZero) { view in view.scaledToFit3D() }
-                        .onAppear {
-                            self.onLoadSuccess()
-                        }
-                        .if(enableGesture) { view in view.hoverEffect() }
-                case .failure:
+        if URL(string: spatializedStatic3DElement.modelURL) != nil {
+            Group {
+                if let asset {
+                    Model3D(asset: asset) { resolvedModel3D in
+                        resolvedModel3D
+                            .resizable(true)
+                            .aspectRatio(
+                                nil,
+                                contentMode: .fit
+                            )
+                            .if(!depth.isZero) { view in view.scaledToFit3D() }
+                            .onAppear {
+                                self.onLoadSuccess()
+                            }
+                            .if(enableGesture) { view in view.hoverEffect() }
+                    }
+                } else if loadFailed {
                     Text("").onAppear {
                         self.onLoadFailure()
                     }
-                @unknown default:
-                    EmptyView()
+                } else {
+                    ProgressView()
+                }
+            }
+            .task(id: spatializedStatic3DElement.modelURL) {
+                guard let url = URL(string: spatializedStatic3DElement.modelURL) else { return }
+                do {
+                    let loaded = try await loadAsset(from: url)
+                    if spatializedStatic3DElement.autoplay {
+                        if let firstAnimation = loaded.availableAnimations.first {
+                            loaded.selectedAnimation = firstAnimation
+                        }
+                    }
+                    self.asset = loaded
+                    self.loadFailed = false
+                } catch {
+                    self.asset = nil
+                    self.loadFailed = true
                 }
             }
             .scaleEffect(


### PR DESCRIPTION
Fixes #1007. Add `autoplay` boolean prop to the <Model> component that triggers automatic playback of the first embedded animation in a 3D model upon load. Rewrites SpatializedStatic3DView.swift to use Model3DAsset instead of Model3D(url:) to access AnimationPlaybackController for animation playback support.

Xcode Claude AI
https://claude.ai/code/session_01TfKAU2rRf6uugk2PwBQoAq