### PR TITLE
feat: Model loop attribute for continuous animations

### DIFF
--- a/.changeset/wicked-mangos-listen.md
+++ b/.changeset/wicked-mangos-listen.md
@@ -1,0 +1,10 @@
+---
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
+---
+
+Add loop attribute to <Model>
+
+When loop is set, the animation automatically seeks back to the start upon reaching the end.

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -31,6 +31,7 @@ function App() {
         // src="/modelasset/cone.usdz"
         enable-xr
         autoplay
+        loop
         style={{
           height: '200px',
           '--xr-depth': '100px',

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -66,6 +66,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     if (properties.autoplay !== undefined) {
       this._autoplay = properties.autoplay
     }
+    if (properties.loop !== undefined) {
+      this._loop = properties.loop
+    }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
       properties,
@@ -102,6 +105,18 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    */
   get autoplay(): boolean {
     return this._autoplay
+  }
+
+  /**
+   * Whether the model animation should loop continuously.
+   */
+  private _loop: boolean = false
+
+  /**
+   * Returns whether loop is enabled for this element.
+   */
+  get loop(): boolean {
+    return this._loop
   }
 
   /**

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -95,6 +95,7 @@ export interface SpatializedStatic3DElementProperties
   modelURL: string
   modelTransform?: number[]
   autoplay?: boolean
+  loop?: boolean
 }
 
 export interface SpatialSceneCreationOptions {

--- a/packages/react/src/Model.tsx
+++ b/packages/react/src/Model.tsx
@@ -34,6 +34,7 @@ function ModelBase(props: ModelProps, ref: ForwardedRef<ModelRef>) {
       onSpatialMagnify,
       onSpatialMagnifyEnd,
       autoplay: _autoplay,
+      loop: _loop,
       ...modelProps
     } = restProps
     // map to VisionOS26 model tag outside attachments

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -64,7 +64,7 @@ function createLoadSuccessEvent(
 }
 
 function SpatializedContent(props: SpatializedStatic3DContentProps) {
-  const { src, spatializedElement, onLoad, onError, autoplay } = props
+  const { src, spatializedElement, onLoad, onError, autoplay, loop } = props
   const spatializedStatic3DElement =
     spatializedElement as SpatializedStatic3DElement
 
@@ -79,9 +79,10 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       spatializedStatic3DElement.updateProperties({
         modelURL: currentSrc,
         autoplay,
+        loop,
       })
     }
-  }, [currentSrc, autoplay])
+  }, [currentSrc, autoplay, loop])
 
   useEffect(() => {
     if (onLoad) {

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -87,6 +87,7 @@ export type SpatializedStatic3DContainerProps =
     Omit<React.ComponentPropsWithoutRef<'div'>, 'onLoad' | 'onError'> & {
       src?: string
       autoplay?: boolean
+      loop?: boolean
       onLoad?: (event: ModelLoadEvent) => void
       onError?: (event: ModelLoadEvent) => void
     }
@@ -95,6 +96,7 @@ export type SpatializedStatic3DContentProps = {
   spatializedElement: SpatializedStatic3DElement
   src?: string
   autoplay?: boolean
+  loop?: boolean
   onLoad?: (event: ModelLoadEvent) => void
   onError?: (event: ModelLoadEvent) => void
 }

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -230,6 +230,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
     let modelURL: String?
     let modelTransform: [Double]?
     let autoplay: Bool?
+    let loop: Bool?
 }
 
 struct UpdateSpatializedDynamic3DElementProperties: SpatializedElementProperties {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -569,6 +569,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             spatializedElement.autoplay = autoplay
         }
 
+        if let loop = command.loop {
+            spatializedElement.loop = loop
+        }
+
         resolve(.success(baseReplyData))
     }
 

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -6,6 +6,7 @@ class SpatializedStatic3DElement: SpatializedElement {
     var modelURL: String = ""
     var modelTransform: AffineTransform3D = .identity
     var autoplay: Bool = false
+    var loop: Bool = false
 
     enum CodingKeys: String, CodingKey {
         case modelURL, type

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -70,6 +70,14 @@ struct SpatializedStatic3DView: View {
                     ProgressView()
                 }
             }
+            .onChange(of: asset?.animationPlaybackController?.isComplete) { _, isComplete in
+                guard isComplete == true,
+                      spatializedStatic3DElement.loop,
+                      let asset,
+                      let animation = asset.availableAnimations.first else { return }
+                asset.selectedAnimation = animation
+                asset.animationPlaybackController?.resume()
+            }
             .task(id: spatializedStatic3DElement.modelURL) {
                 guard let url = URL(string: spatializedStatic3DElement.modelURL) else { return }
                 do {


### PR DESCRIPTION
Fixes #1035. Add a `loop` boolean prop to the <Model> component that restarts the animation when it completes, enabling continuous looping. In Swift observe AnimationPlaybackController.isComplete and reset selectedAnimation and resume the animation each time it finishes while loop is enabled.

https://claude.ai/code/session_01Dt9R9myc6BE5SaPoU7EFmz