### PR TITLE
feat: Model add play(), pause(), and paused for animation playback

### DIFF
--- a/.changeset/better-bats-live.md
+++ b/.changeset/better-bats-live.md
@@ -1,0 +1,8 @@
+---
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
+---
+
+Model add play(), pause(), and paused for playback controls

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -70,6 +70,23 @@ function App() {
           className="w-full h-[200px] object-contain"
         />
       </Model>
+      <section className="playbackControls">
+        <button
+          className="btn btn-success m-1"
+          onClick={() => modelRef.current?.play()}
+        >
+          |▶
+        </button>
+        <button
+          className="btn btn-info  m-1"
+          onClick={() => modelRef.current?.pause()}
+        >
+          ⏸
+        </button>
+        <span className="m-1">
+          Paused: {modelRef.current?.paused ?? 'false'}
+        </span>
+      </section>
       <Logger logs={logs} clearLog={clearLog} />
     </div>
   )
@@ -272,7 +289,10 @@ function NumberInput({ label, value, setValue, step }: InputProps) {
   return (
     <span className="m-1 inline-block">
       <label>{label}:</label>
-      <button className="btn btn-sm" onClick={() => setValue(value - step)}>
+      <button
+        className="btn btn-neutral btn-sm"
+        onClick={() => setValue(value - step)}
+      >
         -
       </button>
       <input
@@ -282,7 +302,10 @@ function NumberInput({ label, value, setValue, step }: InputProps) {
         value={value}
         onChange={e => setValue(parseFloat(e.currentTarget.value))}
       />
-      <button className="btn btn-sm" onClick={() => setValue(value + step)}>
+      <button
+        className="btn btn-neutral btn-sm"
+        onClick={() => setValue(value + step)}
+      >
         +
       </button>{' '}
     </span>
@@ -297,11 +320,11 @@ type ToggleProps = {
 function Toggle({ label, setValue, step }: ToggleProps) {
   return (
     <span className="m-1 inline-block">
-      <button className="btn btn-sm" onClick={e => setValue(-step)}>
+      <button className="btn btn-neutral btn-sm" onClick={e => setValue(-step)}>
         -
       </button>
       <label>{label}</label>
-      <button className="btn btn-sm" onClick={e => setValue(step)}>
+      <button className="btn btn-neutral btn-sm" onClick={e => setValue(step)}>
         +
       </button>{' '}
     </span>

--- a/docs/Model.md
+++ b/docs/Model.md
@@ -10,7 +10,7 @@ The `<Model>`component handles loading 3D assets, managing playback of embedded 
 
 ```jsx
 function Example() {
-  const style = { height: '200px', '--xr-depth': '100px' }
+  const style = { display: 'block', height: '200px', '--xr-depth': '100px' }
   return (
     <Model enable-xr autoPlay loop style={style}>
       <source src="/model/fox.usdz" type="model/vnd.usdz+zip" />
@@ -343,14 +343,7 @@ The implementation will touch four key areas of the WebSpatial SDK.
 
 #### 4.2. Core SDK (`@webspatial/core-sdk`)
 
-- **New JSB Commands**: We will define a new set of commands in `JSBCommand.ts` for animation control, all targeting a `SpatializedStatic3DElement`.
-
-  - `PlayAnimationCommand(id: string)`
-  - `PauseAnimationCommand(id: string)`
-  - `SetAnimationTimeCommand(id: string, time: number)`
-  - `SetPlaybackRateCommand(id: string, rate: number)`
-
-- **New Properties**: The `UpdateSpatializedStatic3DElementProperties` command will be extended to carry `autoplay` and `loop` booleans.
+- **New Properties**: The `UpdateSpatializedStatic3DElementProperties` command will be extended to carry `autoplay`, `loop`, `animationPaused`, `playbackRate` and `currentTime`.
 
 - **New WebMsg Events**: To sync state from native back to the web, we'll define new events in `WebMsgCommand.ts`:
 

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -8,6 +8,8 @@ import {
   ModelLoadSuccess,
   ModelLoadFailure,
   SpatialWebMsgType,
+  AnimationStateChangeDetail,
+  AnimationStateChangeMsg,
 } from './WebMsgCommand'
 
 /**
@@ -113,13 +115,57 @@ export class SpatializedStatic3DElement extends SpatializedElement {
   }
 
   /**
+   * Whether the animation is currently paused.
+   */
+  private _paused: boolean = true
+
+  /**
+   * Returns whether the animation is currently paused.
+   */
+  get paused(): boolean {
+    return this._paused
+  }
+
+  /**
+   * Callback for animation state changes.
+   */
+  private _onAnimationStateChangeCallback?: (
+    detail: AnimationStateChangeDetail,
+  ) => void
+
+  /**
+   * Sets the callback for animation state changes.
+   */
+  set onAnimationStateChangeCallback(
+    callback: undefined | ((detail: AnimationStateChangeDetail) => void),
+  ) {
+    this._onAnimationStateChangeCallback = callback
+  }
+
+  /**
+   * Starts or resumes animation playback.
+   * @returns Promise resolving when the command is sent
+   */
+  async play(): Promise<void> {
+    this._paused = false
+    await this.updateProperties({ animationPaused: false })
+  }
+
+  /**
+   * Pauses animation playback.
+   * @returns Promise resolving when the command is sent
+   */
+  async pause(): Promise<void> {
+    this._paused = true
+    await this.updateProperties({ animationPaused: true })
+  }
+
+  /**
    * Processes events received from the WebSpatial environment.
    * Handles model loading events in addition to base spatial events.
    * @param data The event data received from the WebSpatial system
    */
-  override onReceiveEvent(
-    data: ModelLoadSuccess | ModelLoadFailure | ReceiveEventData,
-  ) {
+  override onReceiveEvent(data: Static3DReceiveEventData) {
     if (data.type === SpatialWebMsgType.modelloaded) {
       // On old runtimes (<⍺2.1) detail is not returned so fallback to modelURL
       this._currentSrc = data.detail?.src ?? this.modelURL ?? ''
@@ -130,6 +176,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       // Handle model loading failure
       this._onLoadFailureCallback?.()
       this._readyResolve?.(false)
+    } else if (data.type === SpatialWebMsgType.animationstatechange) {
+      this._paused = data.detail.paused
+      this._onAnimationStateChangeCallback?.(data.detail)
     } else {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data)
@@ -191,3 +240,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     this.updateProperties({ modelTransform })
   }
 }
+
+type Static3DReceiveEventData =
+  | ModelLoadSuccess
+  | ModelLoadFailure
+  | ReceiveEventData
+  | AnimationStateChangeMsg

--- a/packages/core/src/WebMsgCommand.ts
+++ b/packages/core/src/WebMsgCommand.ts
@@ -19,6 +19,8 @@ export enum SpatialWebMsgType {
   spatialmagnify = 'spatialmagnify',
   spatialmagnifyend = 'spatialmagnifyend',
 
+  animationstatechange = 'animationstatechange',
+
   objectdestroy = 'objectdestroy',
 }
 
@@ -74,4 +76,14 @@ export interface ModelLoadSuccess {
 
 export interface ModelLoadFailure {
   type: SpatialWebMsgType.modelloadfailed
+}
+
+export interface AnimationStateChangeDetail {
+  paused: boolean
+  duration: number
+}
+
+export interface AnimationStateChangeMsg {
+  type: SpatialWebMsgType.animationstatechange
+  detail: AnimationStateChangeDetail
 }

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -107,6 +107,7 @@ export interface SpatializedStatic3DElementProperties
   modelTransform?: number[]
   autoplay?: boolean
   loop?: boolean
+  animationPaused?: boolean
 }
 
 export interface SpatialSceneCreationOptions {

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -179,6 +179,24 @@ function SpatializedStatic3DElementContainerBase(
             | undefined
           spatializedElement?.updateModelTransform(modelTransform)
         },
+        async play(): Promise<void> {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          await spatializedElement?.play()
+        },
+        async pause(): Promise<void> {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          await spatializedElement?.pause()
+        },
+        get paused(): boolean {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          return spatializedElement?.paused ?? true
+        },
       }
     },
     [],

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -122,6 +122,9 @@ export type SpatializedStatic3DElementRef = SpatializedDivElementRef & {
   currentSrc: string
   ready: Promise<ModelLoadEvent>
   entityTransform: DOMMatrixReadOnly
+  play(): Promise<void>
+  pause(): Promise<void>
+  readonly paused: boolean
 }
 
 type CurrentTarget<T extends SpatializedElementRef> = {

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -265,6 +265,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
     let modelTransform: [Double]?
     let autoplay: Bool?
     let loop: Bool?
+    let animationPaused: Bool?
 }
 
 struct UpdateSpatializedDynamic3DElementProperties: SpatializedElementProperties {

--- a/packages/visionOS/web-spatial/WebMsgCommand.swift
+++ b/packages/visionOS/web-spatial/WebMsgCommand.swift
@@ -25,6 +25,8 @@ enum SpatialWebMsgType: String, Encodable {
     case spatialmagnify
     case spatialmagnifyend
 
+    case animationstatechange
+
     case objectdestroy
 }
 
@@ -112,6 +114,16 @@ struct ModelLoadSuccess: Encodable {
 
 struct ModelLoadFailure: Encodable {
     let type: SpatialWebMsgType = .modelloadfailed
+}
+
+struct AnimationStateChangeDetail: Encodable {
+    let paused: Bool
+    let duration: Double
+}
+
+struct AnimationStateChangeEvent: Encodable {
+    let type: SpatialWebMsgType = .animationstatechange
+    let detail: AnimationStateChangeDetail
 }
 
 struct SpatialObjectDestroiedEvent: Encodable {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -619,6 +619,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             spatializedElement.loop = loop
         }
 
+        if let animationPaused = command.animationPaused {
+            spatializedElement.animationPaused = animationPaused
+        }
+
         resolve(.success(baseReplyData))
     }
 

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -13,6 +13,7 @@ class SpatializedStatic3DElement: SpatializedElement {
     var modelTransform: AffineTransform3D = .identity
     var autoplay: Bool = false
     var loop: Bool = false
+    var animationPaused: Bool = true
     var allSources: [ModelSource] {
         return if let modelURL {
             [ModelSource(src: modelURL, type: nil)] + sources

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -67,17 +67,42 @@ struct SpatializedStatic3DView: View {
             .offset(x: x, y: y)
             .offset(z: z)
             .onChange(of: asset?.animationPlaybackController?.isComplete) { _, isComplete in
-                guard isComplete == true,
-                      spatializedStatic3DElement.loop,
-                      let asset,
-                      let animation = asset.availableAnimations.first else { return }
-                asset.selectedAnimation = animation
-                asset.animationPlaybackController?.resume()
+                guard isComplete == true else { return }
+                if spatializedStatic3DElement.loop,
+                   let asset,
+                   let animation = asset.availableAnimations.first
+                {
+                    asset.selectedAnimation = animation
+                    asset.animationPlaybackController?.resume()
+                } else {
+                    // Non-looping animation completed naturally; sync paused state to JS
+                    spatializedStatic3DElement.animationPaused = true
+                }
             }
+            .onChange(of: spatializedStatic3DElement.animationPaused) { onPlayback(isPaused: $1) }
             .task(id: spatializedStatic3DElement.allSources) { await loadSources() }
         } else {
             EmptyView()
         }
+    }
+
+    /// Plays or pauses the model animation and sends an animation state to the web code
+    private func onPlayback(isPaused: Bool) {
+        guard let asset else {
+            // If the entity has not loaded yet then autoplay after load
+            spatializedStatic3DElement.autoplay = true
+            return
+        }
+        asset.selectedAnimation = asset.availableAnimations.first
+        let controller = asset.animationPlaybackController
+        isPaused ? controller?.pause() : controller?.resume()
+        let duration = controller?.duration ?? 0
+        spatialScene.sendWebMsg(
+            spatializedElement.id,
+            AnimationStateChangeEvent(
+                detail: AnimationStateChangeDetail(paused: isPaused, duration: duration)
+            )
+        )
     }
 
     /// Downloads a remote model file and loads it as a Model3DAsset.
@@ -100,8 +125,8 @@ struct SpatializedStatic3DView: View {
         let result = await loadSources(spatializedStatic3DElement.allSources)
         asset = result?.asset
         source = result?.url.absoluteString
-        if spatializedStatic3DElement.autoplay, let firstAnimation = asset?.availableAnimations.first {
-            asset?.selectedAnimation = firstAnimation
+        if spatializedStatic3DElement.autoplay {
+            spatializedStatic3DElement.animationPaused = false
         }
         isLoading = false
     }


### PR DESCRIPTION
Expose programmatic animation playback control on Model refs:
- play(): resumes animation
- pause(): halts animation
- paused (read-only): reflects current playback state https://claude.ai/code/session_01HjZi7VkEHFrCgovgmHFD79 https://claude.ai/code/session_01SAT84oieuqGrpAVJiP5z9E

Fixes #1037

https://github.com/user-attachments/assets/9a176260-05e3-4cf8-886c-e790261fd208