### PR TITLE
fix spatialzedElementView stuttering issue when dragging

### DIFF
--- a/.changeset/plenty-zoos-share.md
+++ b/.changeset/plenty-zoos-share.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+fix spatialzedElementView stuttering issue when dragging

--- a/apps/test-server/.eslintrc.cjs
+++ b/apps/test-server/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'esbuild.mjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {

--- a/apps/test-server/esbuild.mjs
+++ b/apps/test-server/esbuild.mjs
@@ -52,6 +52,7 @@ const buildOptions = {
   },
   // Avoid multiple react copies. https://github.com/evanw/esbuild/issues/3419
   alias: {
+    three: path.resolve('node_modules/three/src/Three.js'),
     react: path.resolve('node_modules/react'),
     'react-dom': path.resolve('node_modules/react-dom'),
     '@webspatial/react-sdk/jsx-runtime': path.resolve(

--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -20,6 +20,7 @@ import RealityTest from './src/pages/reality/index'
 import RealityDebug from './src/pages/reality/debug'
 import RealityDynamic3D from './src/pages/reality/dynamic3d'
 import RealityGestures from './src/pages/reality/gestures'
+import GestureDiv from './src/pages/reality/gestureDiv'
 import RealitySpatialDiv from './src/pages/reality/spatialDivDynamic'
 import BasicTransform from './src/pages/basic-transform/index'
 import ModelTest from './src/pages/model-test/index'
@@ -136,6 +137,7 @@ function App() {
                   element={<RealityDynamic3D />}
                 />
                 <Route path="/reality/gestures" element={<RealityGestures />} />
+                <Route path="/reality/gestureDiv" element={<GestureDiv />} />
                 <Route
                   path="/reality/spatial-div"
                   element={<RealitySpatialDiv />}

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export const routes = [
       { path: '/reality/debug', label: 'Reality Debug' },
       { path: '/reality/dynamic3d', label: 'Dynamic 3D' },
       { path: '/reality/gestures', label: 'Gestures' },
+      { path: '/reality/gestureDiv', label: 'Gesture Div' },
       { path: '/reality/spatial-div', label: 'Spatial Div Dynamic' },
       { path: '/reality/attachments', label: 'Attachments' },
       { path: '/reality/empty', label: 'Empty' },

--- a/apps/test-server/src/pages/reality/gestureDiv.tsx
+++ b/apps/test-server/src/pages/reality/gestureDiv.tsx
@@ -1,0 +1,76 @@
+import React, { useRef, useState } from 'react'
+import { enableDebugTool, type SpatialDragEvent } from '@webspatial/react-sdk'
+
+enableDebugTool()
+
+export default function GestureDiv() {
+  const [pos, setPos] = useState({ x: 0, y: 0, z: 0 })
+  const lastTranslation = useRef({ x: 0, y: 0, z: 0 })
+
+  const onSpatialDragStart = () => {
+    lastTranslation.current = { x: 0, y: 0, z: 0 }
+  }
+
+  const onSpatialDrag = (evt: SpatialDragEvent) => {
+    const deltaX = evt.detail.translation3D.x - lastTranslation.current.x
+    const deltaY = evt.detail.translation3D.y - lastTranslation.current.y
+    const deltaZ = evt.detail.translation3D.z - lastTranslation.current.z
+
+    lastTranslation.current = evt.detail.translation3D
+
+    setPos(prev => ({
+      x: prev.x + deltaX,
+      y: prev.y + deltaY,
+      z: prev.z + deltaZ,
+    }))
+  }
+
+  const onSpatialDragEnd = () => {
+    lastTranslation.current = { x: 0, y: 0, z: 0 }
+  }
+
+  return (
+    <div className="p-10 text-white min-h-full">
+      <h1 className="text-2xl mb-2">Gesture Div</h1>
+      <div className="text-sm text-gray-400 mb-6">
+        Drag the green spatial div to move it. Translation is applied via CSS
+        transform translate3d.
+      </div>
+
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          className="select-none px-4 py-2 text-sm font-semibold rounded-lg border border-gray-700 hover:text-white bg-gray-700 hover:bg-gray-600"
+          onClick={() => setPos({ x: 0, y: 0, z: 0 })}
+        >
+          Reset
+        </button>
+        <div className="text-xs text-gray-400 font-mono">
+          x: {pos.x.toFixed(2)} px, y: {pos.y.toFixed(2)} px, z:{' '}
+          {pos.z.toFixed(2)} px
+        </div>
+      </div>
+
+      <div className="relative border border-gray-800 rounded-xl overflow-hidden bg-[#111] h-[520px]">
+        <div
+          enable-xr
+          className="select-none flex items-center justify-center font-semibold rounded-xl cursor-grab active:cursor-grabbing"
+          style={{
+            width: 260,
+            height: 160,
+            background: '#22cc66',
+            color: '#071a0e',
+            '--xr-back': '80px',
+            transform: `translate3d(${pos.x}px, ${pos.y}px, ${pos.z}px)`,
+            touchAction: 'none',
+            userSelect: 'none',
+          }}
+          onSpatialDragStart={onSpatialDragStart}
+          onSpatialDrag={onSpatialDrag}
+          onSpatialDragEnd={onSpatialDragEnd}
+        >
+          Drag Me
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/test-server/src/pages/reality/gestureDiv.tsx
+++ b/apps/test-server/src/pages/reality/gestureDiv.tsx
@@ -5,28 +5,32 @@ enableDebugTool()
 
 export default function GestureDiv() {
   const [pos, setPos] = useState({ x: 0, y: 0, z: 0 })
-  const lastTranslation = useRef({ x: 0, y: 0, z: 0 })
+  const dragStartPos = useRef({ x: 0, y: 0, z: 0 })
 
   const onSpatialDragStart = () => {
-    lastTranslation.current = { x: 0, y: 0, z: 0 }
+    dragStartPos.current = pos
+    console.log(
+      '🚀 ~ onSpatialDragStart ~ dragStartPos.current:',
+      dragStartPos.current,
+    )
   }
 
   const onSpatialDrag = (evt: SpatialDragEvent) => {
-    const deltaX = evt.detail.translation3D.x - lastTranslation.current.x
-    const deltaY = evt.detail.translation3D.y - lastTranslation.current.y
-    const deltaZ = evt.detail.translation3D.z - lastTranslation.current.z
-
-    lastTranslation.current = evt.detail.translation3D
-
-    setPos(prev => ({
-      x: prev.x + deltaX,
-      y: prev.y + deltaY,
-      z: prev.z + deltaZ,
-    }))
+    const newPos = {
+      x: dragStartPos.current.x + evt.detail.translation3D.x,
+      y: dragStartPos.current.y + evt.detail.translation3D.y,
+      z: dragStartPos.current.z + evt.detail.translation3D.z,
+    }
+    console.log('🚀 ~ onSpatialDrag ~ newPos:', newPos)
+    setPos(newPos)
   }
 
   const onSpatialDragEnd = () => {
-    lastTranslation.current = { x: 0, y: 0, z: 0 }
+    dragStartPos.current = pos
+    console.log(
+      '🚀 ~ onSpatialDragEnd ~ dragStartPos.current:',
+      dragStartPos.current,
+    )
   }
 
   return (
@@ -59,7 +63,7 @@ export default function GestureDiv() {
             height: 160,
             background: '#22cc66',
             color: '#071a0e',
-            '--xr-back': '80px',
+            '--xr-back': '0px',
             transform: `translate3d(${pos.x}px, ${pos.y}px, ${pos.z}px)`,
             touchAction: 'none',
             userSelect: 'none',

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -85,6 +85,8 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
 
     // TOPIC end
 
+    var isSpatialElementGestureActive = false
+
     var spatialWebViewModel: SpatialWebViewModel
 
     private var meterToPtUnscaled: Double?

--- a/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
+++ b/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
@@ -72,6 +72,9 @@ struct Spatialized2DElementView: View {
         DragGesture()
             .onChanged { gesture in
 //                print("\(spatialized2DElement.name) dragWebGesture")
+                if spatialScene.isSpatialElementGestureActive {
+                    return
+                }
                 if spatialized2DElement.scrollPageEnabled {
                     if !gestureData.dragStarted {
                         gestureData.dragStarted = true
@@ -86,6 +89,9 @@ struct Spatialized2DElementView: View {
             }
             .onEnded { _ in
                 print("\(spatialized2DElement.name) dragWebGestureEnd")
+                if spatialScene.isSpatialElementGestureActive {
+                    return
+                }
                 if spatialized2DElement.scrollPageEnabled {
                     gestureData.dragStarted = false
                     gestureData.dragStart = 0

--- a/packages/visionOS/web-spatial/view/SpatializedElementView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedElementView.swift
@@ -203,6 +203,9 @@ struct SpatializedElementView<Content: View>: View {
             // Gesture before .position(): event.location3D is in the element's local space
             // (top-left origin), and does not include visual transforms.
             .simultaneousGesture(enableGesture ? gesture : nil)
+            .onDisappear {
+                spatialScene.isSpatialElementGestureActive = false
+            }
             .onGeometryChange3D(for: AffineTransform3D.self) { proxy in
                 proxy.transform(in: .named("SpatialScene"))!
             } action: { new in

--- a/packages/visionOS/web-spatial/view/SpatializedElementView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedElementView.swift
@@ -74,6 +74,10 @@ struct SpatializedElementView<Content: View>: View {
     }
 
     private func onDragging(_ event: DragGesture.Value) {
+        if !gestureState.isDrag {
+            spatialScene.isSpatialElementGestureActive = true
+        }
+
         if spatializedElement.enableDragStartGesture, !gestureState.isDrag {
             let startLocal = sceneToLocal(event.startLocation3D)
             let globalPoint3D = event.startLocation3D
@@ -97,6 +101,7 @@ struct SpatializedElementView<Content: View>: View {
 
     private func onDraggingEnded(_ event: DragGesture.Value) {
         gestureState.isDrag = false
+        spatialScene.isSpatialElementGestureActive = false
         if spatializedElement.enableDragEndGesture {
             let gestureEvent = WebSpatialDragEndGuestureEvent()
             spatialScene.sendWebMsg(spatializedElement.id, gestureEvent)

--- a/packages/visionOS/web-spatial/view/SpatializedElementView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedElementView.swift
@@ -22,7 +22,7 @@ struct SpatializedElementView<Content: View>: View {
 
     /// Begin Interaction
     var gesture: some Gesture {
-        DragGesture(minimumDistance: 10)
+        DragGesture(minimumDistance: 10, coordinateSpace: .named("SpatialScene"))
             .onChanged(onDragging)
             .onEnded(onDraggingEnded)
             .simultaneously(with:
@@ -75,13 +75,8 @@ struct SpatializedElementView<Content: View>: View {
 
     private func onDragging(_ event: DragGesture.Value) {
         if spatializedElement.enableDragStartGesture, !gestureState.isDrag {
-            let frameZ = localFrameOffsetZ()
-            let startLocal = Point3D(
-                x: event.startLocation3D.x,
-                y: event.startLocation3D.y,
-                z: event.startLocation3D.z - frameZ
-            )
-            let globalPoint3D = localToScene(event.startLocation3D)
+            let startLocal = sceneToLocal(event.startLocation3D)
+            let globalPoint3D = event.startLocation3D
             let gestureEvent = WebSpatialDragStartGuestureEvent(detail: .init(
                 startLocation3D: startLocal,
                 globalLocation3D: globalPoint3D
@@ -119,6 +114,11 @@ struct SpatializedElementView<Content: View>: View {
         let p = SIMD4<Double>(localPoint.x, localPoint.y, localPoint.z, 1.0)
         let scene = gestureState.proxyTransform.matrix * p
         return Point3D(x: scene.x, y: scene.y, z: scene.z)
+    }
+
+    private func sceneToLocal(_ scenePoint: Point3D) -> Point3D {
+        let local = spatializedElement.convertFromScene(SIMD3<Double>(scenePoint.x, scenePoint.y, scenePoint.z))
+        return Point3D(x: local.x, y: local.y, z: local.z)
     }
 
     private func onTapEnded(_ event: SpatialTapGesture.Value) {


### PR DESCRIPTION
## Summary
- Fixes unstable `translation3D` values during spatial drag (jitter / “fly away” behavior) by computing drag in a stable scene coordinate space on visionOS.
- Prevents vertical drag from simultaneously triggering 2D page scrolling (which caused visible up/down shaking).

## Background / Problem
In the test-server drag demo (`GestureDiv`), web code applies `evt.detail.translation3D` to CSS `transform: translate3d(...)`. On visionOS, the native drag gesture values were sensitive to changes in the element’s transform during the drag. This created a feedback loop:
- web updates CSS transform → native view transform changes
- next drag callback is computed in a shifting reference frame → `translation3D` oscillates and can grow rapidly

Additionally, vertical dragging could also trigger the parent webview’s scroll drag gesture, producing visible shaking.

## Changes

### Web (test-server)
- Update the `GestureDiv` demo to compute position as:
  - `pos = dragStartPos + translation3D`

### visionOS (web-spatial)
- Make spatial element drag gestures compute in the `SpatialScene` coordinate space to avoid transform-induced feedback:
  - `DragGesture(..., coordinateSpace: .named("SpatialScene"))`
- Preserve expected “local” semantics for `startLocation3D` by converting the scene-space start point back into the element’s local space before sending the drag-start event.
- Prevent the 2D frame’s “drag to scroll” gesture from running while a spatial element gesture is active:
  - Add a shared `isSpatialElementGestureActive` flag on `SpatialScene`
  - Set/unset it on spatial element drag begin/end
  - Early-return in the 2D frame drag-scrolling gesture when the flag is set

## Impact
- Dragging spatial elements produces stable, monotonic `translation3D` updates (no oscillation / runaway values).
- Vertical dragging no longer causes the page/webview to scroll at the same time, eliminating visible shaking.
- The test-server demo behavior is more predictable and resilient to event cadence.

## Testing Page

https://github.com/user-attachments/assets/3e331f6b-3bfb-4863-86f8-54f4344ec3f3


https://github.com/user-attachments/assets/9f5e477a-8f96-443b-81aa-000694ddf57e

