### PR TITLE
Fix Spatial UA detection and align no-runtime fallback behavior

### DIFF
--- a/.changeset/bright-poems-tease.md
+++ b/.changeset/bright-poems-tease.md
@@ -1,7 +1,8 @@
 ---
-'@webspatial/platform-visionos': patch
-'@webspatial/react-sdk': patch
-'@webspatial/core-sdk': patch
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
 ---
 
 Model add <source> element support for multi-format fallback

--- a/.changeset/bright-poems-tease.md
+++ b/.changeset/bright-poems-tease.md
@@ -4,4 +4,4 @@
 '@webspatial/core-sdk': patch
 ---
 
-Add `<source>` fix Spatial UA detection, and align no-runtime fallback behavior.
+Model add <source> element support for multi-format fallback

--- a/.changeset/bright-poems-tease.md
+++ b/.changeset/bright-poems-tease.md
@@ -5,4 +5,4 @@
 '@webspatial/core-sdk': minor
 ---
 
-Model add <source> element support for multi-format fallback
+Add `<source>` support for model multi-format fallback, fix Spatial UA detection, and align no-runtime fallback behavior.

--- a/.changeset/bright-poems-tease.md
+++ b/.changeset/bright-poems-tease.md
@@ -1,8 +1,7 @@
 ---
-'@webspatial/platform-visionos': minor
-'web-content': minor
-'@webspatial/react-sdk': minor
-'@webspatial/core-sdk': minor
+'@webspatial/platform-visionos': patch
+'@webspatial/react-sdk': patch
+'@webspatial/core-sdk': patch
 ---
 
-Add `<source>` support for model multi-format fallback, fix Spatial UA detection, and align no-runtime fallback behavior.
+Add `<source>` fix Spatial UA detection, and align no-runtime fallback behavior.

--- a/.changeset/nervous-peaches-know.md
+++ b/.changeset/nervous-peaches-know.md
@@ -1,0 +1,6 @@
+---
+"@webspatial/core-sdk": patch
+"@webspatial/react-sdk": patch
+---
+
+Fix Spatial UA detection and align no-runtime fallback behavior

--- a/packages/core/src/Spatial.ts
+++ b/packages/core/src/Spatial.ts
@@ -29,7 +29,7 @@ export class Spatial {
    * @returns True if running in a spatial web environment, false otherwise
    */
   runInSpatialWeb() {
-    if (navigator.userAgent.indexOf('WebSpatial/') > 0) {
+    if (navigator.userAgent.indexOf('WebSpatial/') >= 0) {
       return true
     }
     return false

--- a/packages/react/src/noRuntime.test.ts
+++ b/packages/react/src/noRuntime.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { PhysicalMetrics } from './noRuntime'
+
+describe('noRuntime PhysicalMetrics', () => {
+  it('subscribe returns an unsubscribe function in no-runtime builds', () => {
+    const unsubscribe = PhysicalMetrics.subscribe(() => {})
+    expect(typeof unsubscribe).toBe('function')
+    expect(() => unsubscribe()).not.toThrow()
+  })
+})

--- a/packages/react/src/noRuntime.ts
+++ b/packages/react/src/noRuntime.ts
@@ -6,7 +6,7 @@ export const SpatialHelper = {}
 export class Spatial {
   /**
    * Requests a session object from the browser
-   * @returns The session or null if not availible in the current browser
+   * @returns The session or null if not available in the current browser
    * [TODO] discuss implications of this not being async
    */
   requestSession() {
@@ -28,14 +28,14 @@ export class Spatial {
   }
   /**
    * Gets the native version, format is "x.x.x"
-   * @returns native version string
+   * @returns native version string, or null when runtime is unavailable
    */
   getNativeVersion() {
     return null
   }
   /**
    * Gets the client version, format is "x.x.x"
-   * @returns client version string
+   * @returns client version string, or null when runtime is unavailable
    */
   getClientVersion() {
     return null
@@ -61,5 +61,5 @@ export const PhysicalMetrics = {
     meterToPtUnscaled: 1360,
     meterToPtScaled: 1360,
   }),
-  subscribe: (cb: any) => {},
+  subscribe: (cb: any) => () => {},
 }


### PR DESCRIPTION
### Motivation
- `Spatial.runInSpatialWeb()` failed to detect `WebSpatial/` when it appears at the start of the `userAgent` string, causing incorrect runtime detection. 
- The no-runtime fallback in `packages/react/src/noRuntime.ts` had a typo and a small API mismatch in `PhysicalMetrics.subscribe` compared to the runtime API contract. 
- Add a small unit test to lock the no-runtime behavior and prevent regressions.

### Description
- Updated UA detection in `Spatial.runInSpatialWeb()` to use `indexOf('WebSpatial/') >= 0` so `WebSpatial/` at index 0 is detected correctly (file: `packages/core/src/Spatial.ts`).
- Fixed a spelling error and clarified return-value documentation in `packages/react/src/noRuntime.ts` for `requestSession`, `getNativeVersion`, and `getClientVersion` to state they return `null` when runtime is unavailable.
- Aligned no-runtime API behavior by changing `PhysicalMetrics.subscribe` to return a callable no-op unsubscribe function instead of `undefined` (file: `packages/react/src/noRuntime.ts`).
- Added unit test `packages/react/src/noRuntime.test.ts` to assert `PhysicalMetrics.subscribe` returns an unsubscribe function and that calling it does not throw.

### Testing
- Ran `pnpm --filter @webspatial/core-sdk test` and all core package tests passed.
- Ran `pnpm --filter @webspatial/react-sdk test` and the full react test suite failed in this environment due to existing package entry resolution issues for `@webspatial/core-sdk` (this is unrelated to the changes in this PR); individual test added for no-runtime passes.
- Ran the new react unit test directly with `pnpm --dir packages/react exec vitest run src/noRuntime.test.ts` and it passed (the added test completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d753ed026c832c97231a42760ed4de)