### PR TITLE
ci: require changeset when PR touches packages/

### DIFF
--- a/.github/workflows/validate-changeset.yml
+++ b/.github/workflows/validate-changeset.yml
@@ -1,0 +1,49 @@
+name: Validate changeset
+
+# When a PR changes published packages under packages/, require a .changeset/*.md
+# (add with `pnpm changeset`). Label `skip-changeset` bypasses for docs-only or maintainer exceptions.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: validate-changeset-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  require-changeset:
+    if: github.repository == 'webspatial/webspatial-sdk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect skip-changeset label
+        uses: actions/github-script@v7
+        id: label
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const skip = labels.some(l => l.name === 'skip-changeset');
+            core.setOutput('skip', skip ? '1' : '0');
+
+      - name: Validate packages/ changes include a changeset
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKIP_CHANGESET: ${{ steps.label.outputs.skip }}
+        run: bash tools/scripts/validate-pr-changeset.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,24 @@ npm run dev
 - [@webspatial/core-sdk](packages/core/README.md) - The React SDK is implemented on top of the Core SDK, which is a framework-agnostic pure-JS API that enables the WebSpatial App Shell to natively spatialize 2D HTML content and render 3D content.
 - [@webspatial/builder](packages/cli/README.md) - The build tool transforms websites into Packaged WebSpatial Apps for debugging and distributing on spatial computing platforms.
 
+## Changesets (releases)
+
+Published packages in this monorepo are versioned with [Changesets](https://github.com/changesets/changesets). Configuration lives in [`.changeset/config.json`](.changeset/config.json).
+
+### When you need a changeset
+
+If your pull request **changes anything under `packages/`** (source, `package.json`, platform shells, etc.), add a changeset so the release notes and semver bumps stay accurate:
+
+1. From the repo root, run **`pnpm changeset`** (or `npx changeset add`).
+2. Select the affected `@webspatial/*` packages and **patch**, **minor**, or **major** as appropriate. The `fixed` group in config bumps several packages together when any of them changes.
+3. Commit the generated **`.changeset/<random-name>.md`** with your code.
+
+You do **not** need a changeset for edits that only touch `apps/`, `tests/`, `.github/` (unless they change published packages), docs outside packages, or other paths that do not modify `packages/`.
+
+### Bypass (maintainers)
+
+For rare cases where `packages/` changed but **no** release note or version bump should be recorded, a maintainer can add the GitHub label **`skip-changeset`** to the PR so CI allows merging without a new `.changeset/*.md` file. Create that label once under **Issues → Labels** if it does not exist yet.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/tools/scripts/validate-pr-changeset.sh
+++ b/tools/scripts/validate-pr-changeset.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Used by CI: when a PR touches packages/, require an accompanying .changeset/*.md
+# (not README.md). Set SKIP_CHANGESET=1 when the PR has label skip-changeset.
+set -euo pipefail
+
+if [[ "${SKIP_CHANGESET:-0}" == "1" ]]; then
+  echo "Skipping changeset check (skip-changeset)."
+  exit 0
+fi
+
+BASE_SHA="${BASE_SHA:?BASE_SHA required}"
+HEAD_SHA="${HEAD_SHA:?HEAD_SHA required}"
+
+CHANGED=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" 2>/dev/null || true)
+
+if ! grep -q '^packages/' <<<"$CHANGED" 2>/dev/null; then
+  echo "No packages/ changes; changeset not required."
+  exit 0
+fi
+
+# Any .changeset/*.md except README.md counts as a release note entry
+if echo "$CHANGED" | grep -E '^\.changeset/.+\.md$' | grep -v '^\.changeset/README\.md$' | grep -q .; then
+  echo "Changeset requirement satisfied."
+  exit 0
+fi
+
+echo "::error::Changes under packages/ require a changeset. Run \`pnpm changeset\` at the repo root, commit the new file under .changeset/, and push. Maintainers may add the \`skip-changeset\` label to bypass when no release note is needed."
+exit 1


### PR DESCRIPTION
## Summary
- New workflow `validate-changeset.yml` runs on pull requests targeting `main`.
- If the PR diff touches `packages/`, it must also include a new or updated `.changeset/*.md` (from `pnpm changeset`). `.changeset/README.md` does not count.
- Maintainers can apply the `skip-changeset` label to bypass when appropriate.
- **CONTRIBUTING.md**: documents when to add a changeset, the `pnpm changeset` flow, and the bypass label (create the label once in the repo if missing).

## Implementation
- `tools/scripts/validate-pr-changeset.sh` — portable bash (no `mapfile`), compares base..head SHAs from the PR event.
- Checkout uses `head.repo.full_name` + `head.sha` so fork PRs work.

Made with [Cursor](https://cursor.com)