### PR TITLE
fix spatialDiv create issue

### DIFF
--- a/.changeset/funny-turtles-cut.md
+++ b/.changeset/funny-turtles-cut.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+fix spatialDiv create issue. API change for token access.

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -184,7 +184,8 @@ class SceneManager {
         url.includes('createSpatialized2DElement') ||
         url.includes('createAttachment')
       ) {
-        const token = window.webSpatial?.genToken?.()
+        const token = //@ts-ignore
+          (window.webSpatial || window.__webspatialShell__)?.genToken?.()
         if (token) {
           const command = url.includes('createAttachment')
             ? 'createAttachment'


### PR DESCRIPTION

## summary
fix create spatialdiv issue due to token API change

## before
<img width="658" height="396" alt="image" src="https://github.com/user-attachments/assets/cfb5acac-e4e2-4b60-8461-9330b80c0166" />


## after
<img width="680" height="377" alt="image" src="https://github.com/user-attachments/assets/b33908d4-5ad2-4f2f-acab-21bae1edc439" />
