### PR TITLE
Support token provider on `__webspatialShell__`, update typings, add changeset

### DIFF
--- a/.changeset/funny-turtles-cut.md
+++ b/.changeset/funny-turtles-cut.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+fix spatialDiv create issue. API change for token access.

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -184,7 +184,9 @@ class SceneManager {
         url.includes('createSpatialized2DElement') ||
         url.includes('createAttachment')
       ) {
-        const token = window.webSpatial?.genToken?.()
+        const token = (
+          window.webSpatial ?? window.__webspatialShell__
+        )?.genToken?.()
         if (token) {
           const command = url.includes('createAttachment')
             ? 'createAttachment'

--- a/packages/core/src/types/global.d.ts
+++ b/packages/core/src/types/global.d.ts
@@ -26,6 +26,9 @@ declare global {
     webSpatial?: {
       genToken?: () => string
     }
+    __webspatialShell__?: {
+      genToken?: () => string
+    }
 
     // Will be removed in favor of __WebSpatialData
     WebSpatailNativeVersion: string


### PR DESCRIPTION
### Motivation
- Fix failures when creating spatialized elements due to token-access API differences in some embedded shells by supporting an alternate global provider.

### Description
- Add a fallback token lookup in `SceneManager.open` to use `window.__webspatialShell__?.genToken` in addition to `window.webSpatial?.genToken` so internal create commands work in more environments.
- Update global TypeScript declarations in `packages/core/src/types/global.d.ts` to include `__webspatialShell__?: { genToken?: () => string }` for correct typing and IDE support.
- Add a changeset file `.changeset/funny-turtles-cut.md` documenting the patch-level change and the API token access fix.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) against the changed packages which succeeded. 
- Ran the repository's automated unit test suite (`yarn test`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda0f104e4832cab380beab0679207)