### PR TITLE
docs: add CR notes for PR #1129 on UnlitMaterial texture handling

### DIFF
--- a/reviews/pr-1129-cr.md
+++ b/reviews/pr-1129-cr.md
@@ -1,0 +1,27 @@
+# CR for PR #1129 (End-to-end texture support for UnlitMaterial)
+
+## Findings
+
+### 1) Unhandled rejection path in `UnlitMaterial` initialization
+
+In `packages/react/src/reality/components/UnlitMaterial.tsx`, texture resolution (`await texturePending`) happens before entering the `try/catch` that handles material creation.
+
+If the texture promise rejects, the async `init()` exits via an unhandled rejection and neither `onError` nor a graceful fallback path runs. This can leave the material absent with no actionable signal for consumers.
+
+### 2) Logical texture id may still be sent to native on update path
+
+In the dynamic update effect for `UnlitMaterial`, when `textureId` is provided but not yet present in `resourceRegistry`, code falls back to:
+
+```ts
+updates.textureId = options.textureId
+```
+
+This reintroduces the original mismatch this PR aims to fix (logical ID vs native UUID), and may fail permanently if no subsequent reactive trigger occurs after the texture becomes available.
+
+## Suggested fixes
+
+- Wrap *all* async work in `init()` with `try/catch`, including texture promise resolution.
+- In update flow, do not send unresolved logical IDs to native. Either:
+  - defer update until texture resolves in registry, or
+  - explicitly clear / no-op and retry when the texture resource promise settles.
+


### PR DESCRIPTION
### Motivation
- Capture and record focused code-review findings for PR #1129 about end-to-end texture support for `UnlitMaterial`, calling out potential runtime gaps (unhandled texture promise rejections and sending logical `textureId` to native before registry resolution).

### Description
- Add `reviews/pr-1129-cr.md` containing the findings and concrete suggested fixes; this change is documentation-only and does not modify runtime code.

### Testing
- Ran pre-commit checks (via `lint-staged`) which executed `node ./tools/scripts/check-filesize.js` and `node ./tools/scripts/check-valid-characters.js`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda3dd5c68832cbefb9be771cd0806)