### PR TITLE
fix: `SpatialWebEvent` should supports multiple receivers per id

### DIFF
--- a/.changeset/fifty-geckos-hear.md
+++ b/.changeset/fifty-geckos-hear.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+`SpatialWebEvent` now supports multiple receivers per id

--- a/packages/core/src/SpatialWebEvent.ts
+++ b/packages/core/src/SpatialWebEvent.ts
@@ -4,20 +4,35 @@ interface SpatialWebEventData {
 }
 
 export class SpatialWebEvent {
-  static eventReceiver: Record<string, (data: any) => void> = {}
+  static eventReceiver: Record<string, Set<(data: any) => void>> = {}
   static init() {
     // inject __SpatialWebEvent
     window.__SpatialWebEvent = ({ id, data }: SpatialWebEventData) => {
       // console.log('__SpatialWebEvent', id, data)
-      SpatialWebEvent.eventReceiver[id]?.(data)
+      const receivers = SpatialWebEvent.eventReceiver[id]
+      if (!receivers) return
+      receivers.forEach(receiver => receiver(data))
     }
   }
 
   static addEventReceiver(id: string, callback: (data: any) => void) {
-    SpatialWebEvent.eventReceiver[id] = callback
+    // A single `id` can have multiple receivers.
+    SpatialWebEvent.eventReceiver[id] ??= new Set()
+    SpatialWebEvent.eventReceiver[id].add(callback)
   }
 
-  static removeEventReceiver(id: string) {
-    delete SpatialWebEvent.eventReceiver[id]
+  static removeEventReceiver(id: string, callback?: (data: any) => void) {
+    // If callback is omitted, remove all receivers for the id.
+    if (!callback) {
+      delete SpatialWebEvent.eventReceiver[id]
+      return
+    }
+
+    const receivers = SpatialWebEvent.eventReceiver[id]
+    if (!receivers) return
+    receivers.delete(callback)
+    if (receivers.size === 0) {
+      delete SpatialWebEvent.eventReceiver[id]
+    }
   }
 }

--- a/packages/core/src/SpatialWebEvent.ts
+++ b/packages/core/src/SpatialWebEvent.ts
@@ -4,35 +4,35 @@ interface SpatialWebEventData {
 }
 
 export class SpatialWebEvent {
-  static eventReceiver: Record<string, Set<(data: any) => void>> = {}
+  static eventReceiver: Map<string, Set<(data: any) => void>> = new Map()
   static init() {
     // inject __SpatialWebEvent
     window.__SpatialWebEvent = ({ id, data }: SpatialWebEventData) => {
       // console.log('__SpatialWebEvent', id, data)
-      const receivers = SpatialWebEvent.eventReceiver[id]
-      if (!receivers) return
-      receivers.forEach(receiver => receiver(data))
+      SpatialWebEvent.eventReceiver.get(id)?.forEach(fn => fn(data))
     }
   }
 
   static addEventReceiver(id: string, callback: (data: any) => void) {
     // A single `id` can have multiple receivers.
-    SpatialWebEvent.eventReceiver[id] ??= new Set()
-    SpatialWebEvent.eventReceiver[id].add(callback)
+    if (!SpatialWebEvent.eventReceiver.has(id)) {
+      SpatialWebEvent.eventReceiver.set(id, new Set())
+    }
+    SpatialWebEvent.eventReceiver.get(id)!.add(callback)
   }
 
   static removeEventReceiver(id: string, callback?: (data: any) => void) {
     // If callback is omitted, remove all receivers for the id.
     if (!callback) {
-      delete SpatialWebEvent.eventReceiver[id]
+      SpatialWebEvent.eventReceiver.delete(id)
       return
     }
 
-    const receivers = SpatialWebEvent.eventReceiver[id]
+    const receivers = SpatialWebEvent.eventReceiver.get(id)
     if (!receivers) return
     receivers.delete(callback)
     if (receivers.size === 0) {
-      delete SpatialWebEvent.eventReceiver[id]
+      SpatialWebEvent.eventReceiver.delete(id)
     }
   }
 }

--- a/packages/core/src/jsbcommand.coverage.test.ts
+++ b/packages/core/src/jsbcommand.coverage.test.ts
@@ -478,9 +478,9 @@ describe('SpatializedElement', () => {
     }
 
     const e = new TestElement('el4')
-    expect(SpatialWebEvent.eventReceiver.el4).toBeDefined()
+    expect(SpatialWebEvent.eventReceiver.get('el4')).toBeDefined()
     await e.destroy()
-    expect(SpatialWebEvent.eventReceiver.el4).toBeUndefined()
+    expect(SpatialWebEvent.eventReceiver.get('el4')).toBeUndefined()
   })
 })
 

--- a/packages/core/src/physicalMetrics.test.ts
+++ b/packages/core/src/physicalMetrics.test.ts
@@ -107,4 +107,43 @@ describe('physicalMetrics', () => {
     expect(m.getValue().meterToPtUnscaled).toBe(400)
     ;(window as any).__webspatialsdk__ = undefined
   })
+
+  test('subscribe supports multiple concurrent subscribers', async () => {
+    const m = await loadModule()
+    const { SpatialWebEvent } = await import('./SpatialWebEvent')
+    SpatialWebEvent.init()
+
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+    const unsubscribe1 = m.subscribe(cb1)
+    const unsubscribe2 = m.subscribe(cb2)
+
+    ;(window as any).__webspatialsdk__ = {
+      physicalMetrics: {
+        meterToPtScaled: 900,
+        meterToPtUnscaled: 800,
+      },
+    }
+    window.__SpatialWebEvent({ id: 'window', data: {} })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(m.getValue().meterToPtScaled).toBe(900)
+    expect(m.getValue().meterToPtUnscaled).toBe(800)
+
+    unsubscribe1()
+    ;(window as any).__webspatialsdk__ = {
+      physicalMetrics: {
+        meterToPtScaled: 700,
+        meterToPtUnscaled: 600,
+      },
+    }
+    window.__SpatialWebEvent({ id: 'window', data: {} })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(2)
+    expect(m.getValue().meterToPtScaled).toBe(700)
+    expect(m.getValue().meterToPtUnscaled).toBe(600)
+
+    unsubscribe2()
+    ;(window as any).__webspatialsdk__ = undefined
+  })
 })

--- a/packages/core/src/physicalMetrics.ts
+++ b/packages/core/src/physicalMetrics.ts
@@ -96,6 +96,7 @@ export function subscribe(cb: () => void) {
   // receive metrics update from native via SpatialWebEvent, id: "window"
   SpatialWebEvent.addEventReceiver('window', handler)
   return () => {
-    SpatialWebEvent.removeEventReceiver('window')
+    // Remove only this subscription's handler to avoid breaking other subscribers.
+    SpatialWebEvent.removeEventReceiver('window', handler)
   }
 }


### PR DESCRIPTION
## Summary

Fixes an issue where multiple React components using `useMetrics()` could break each other’s subscriptions to physical metrics updates.

Symptoms:

- The most recently mounted component would “win” and earlier subscribers stopped receiving updates.
- Unmounting any one subscriber could remove the shared listener and cause remaining subscribers to stop receiving updates.

## Root Cause

`PhysicalMetrics.subscribe()` registers to `SpatialWebEvent` using a fixed id (`"window"`).

Before this change, `SpatialWebEvent` only supported a single receiver per id:

- `addEventReceiver(id, cb)` overwrote any existing receiver for that id.
- `removeEventReceiver(id)` deleted the receiver for that id entirely.

With multiple `useSyncExternalStore` subscriptions, this resulted in receiver overwrite and accidental removal.

## Changes

- `SpatialWebEvent` now supports multiple receivers per id.
- `SpatialWebEvent.removeEventReceiver(id, callback?)` now accepts an optional `callback`:
  - If `callback` is provided: remove only that receiver; delete the id entry only when it becomes empty.
  - If `callback` is omitted: keep existing behavior and remove all receivers for that id.
- `PhysicalMetrics.subscribe()` now unsubscribes by removing only its own handler from the `"window"` receivers.

## Compatibility Notes

- Existing call sites using `removeEventReceiver(id)` continue to remove all receivers for the id.
- For ids that only register a single receiver (the common case), behavior remains effectively unchanged.

## Tests

- Added coverage to verify multiple concurrent `PhysicalMetrics.subscribe()` subscribers receive updates and unsubscribing one does not affect the other.

Commands:

```bash
pnpm -C packages/core run lint
pnpm test
```