### PR TITLE
fix: Model animation bugs

### DIFF
--- a/.changeset/dark-nights-enter.md
+++ b/.changeset/dark-nights-enter.md
@@ -1,0 +1,6 @@
+---
+'@webspatial/platform-visionos': patch
+'web-content': patch
+---
+
+fix: Model animation bugs

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -58,11 +58,11 @@ function App() {
       >
         <source src="/modelasset/Fox_animated.glb" type="model/gltf-binary" />
         <source
-          src="https://developer.apple.com/augmented-reality/quick-look/models/biplane/toy_biplane_realistic.usdz"
+          src="https://webkit.org/demos/model-demos/models/stopwatch.usdz"
           type="model/vnd.usdz+zip"
         />
         <source
-          src="https://webkit.org/demos/model-demos/models/stopwatch.usdz"
+          src="https://developer.apple.com/augmented-reality/quick-look/models/biplane/toy_biplane_realistic.usdz"
           type="model/vnd.usdz+zip"
         />
         <img

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -89,11 +89,14 @@ struct SpatializedStatic3DView: View {
     /// Plays or pauses the model animation and sends an animation state to the web code
     private func onPlayback(isPaused: Bool) {
         guard let asset else {
-            // If the entity has not loaded yet then autoplay after load
-            spatializedStatic3DElement.autoplay = true
+            // If entity has not loaded yet and play is called then autoplay after load
+            if !isPaused { spatializedStatic3DElement.autoplay = true }
             return
         }
-        asset.selectedAnimation = asset.availableAnimations.first
+        // Setting selectedAnimation resets the animation and autoplays on first load
+        if asset.selectedAnimation == nil || asset.animationPlaybackController?.isComplete == true {
+            asset.selectedAnimation = asset.availableAnimations.first
+        }
         let controller = asset.animationPlaybackController
         isPaused ? controller?.pause() : controller?.resume()
         let duration = controller?.duration ?? 0
@@ -126,7 +129,11 @@ struct SpatializedStatic3DView: View {
         asset = result?.asset
         source = result?.url.absoluteString
         if spatializedStatic3DElement.autoplay {
-            spatializedStatic3DElement.animationPaused = false
+            // If animationPaused didn't change then SwiftUI will not trigger onChange so manually trigger playback
+            // This happens when play is called before load and autoplay is enabled
+            if spatializedStatic3DElement.animationPaused {
+                spatializedStatic3DElement.animationPaused = false
+            } else { onPlayback(isPaused: false) }
         }
         isLoading = false
     }


### PR DESCRIPTION
1. Pause command resets animation
2. If play is called before load then animation playback needs to be
triggered manually since there's no property change for SwiftUI to
trigger onChange.
3. Fix calling pause() before model load incorrectly autoplays animation


https://github.com/user-attachments/assets/ec554dd5-bb82-4d39-9bb0-282196c44246

