### PR TITLE
fix: incorrect display style for spatial containers

### DIFF
--- a/.changeset/thin-hoops-turn.md
+++ b/.changeset/thin-hoops-turn.md
@@ -1,0 +1,6 @@
+---
+'web-content': patch
+'@webspatial/react-sdk': patch
+---
+
+fix: incorrect display style for spatial containers

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -30,7 +30,6 @@ function App() {
       <CSSTransform onChange={setTransform} />
       <EntityTransform model={modelRef} />
       <Model
-        className="block"
         // src="/modelasset/cone.usdz"
         enable-xr
         autoPlay

--- a/docs/Model.md
+++ b/docs/Model.md
@@ -10,7 +10,7 @@ The `<Model>`component handles loading 3D assets, managing playback of embedded 
 
 ```jsx
 function Example() {
-  const style = { display: 'block', height: '200px', '--xr-depth': '100px' }
+  const style = { height: '200px', '--xr-depth': '100px' }
   return (
     <Model enable-xr autoPlay loop style={style}>
       <source src="/model/fox.usdz" type="model/vnd.usdz+zip" />

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1093,8 +1093,10 @@ describe('PortalSpatializedContainer', () => {
           this.parentPortalInstanceObject = parentPortalInstanceObject
           this.domRect = { width: 10, height: 20 }
           this.computedStyle = {
-            getPropertyValue: () => 'relative',
-            getPropertyPriority: () => 'block',
+            getPropertyValue: (prop: string) => {
+              if (prop === 'display') return 'block'
+              return 'relative'
+            },
           }
           this.dom = document.createElement('div')
         }

--- a/packages/react/src/spatialized-container/PortalSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/PortalSpatializedContainer.tsx
@@ -58,7 +58,7 @@ function renderPlaceholderInSubPortal(
 
   const { width, height } = portalInstanceObject.domRect
   const display =
-    portalInstanceObject.computedStyle!.getPropertyPriority('display')
+    portalInstanceObject.computedStyle!.getPropertyValue('display')
 
   const spatialIdProps = { [SpatialID]: spatialId }
   return (


### PR DESCRIPTION
getPropertyPriority returns "" or "important" (the CSS priority), not
the actual value. This caused the placeholder element's display to always
be set to an empty string, breaking layout when Model with enable-xr was
rendered inside a nested portal context.

Also updates the test mock to correctly simulate getPropertyValue returning
the display value, removing the incorrect getPropertyPriority mock.

https://claude.ai/code/session_01MKXurvwm7FR4j5cioFKG22