### PR TITLE
feat: add currentTime property to Model to read and seek animation time

### DIFF
--- a/.changeset/rude-days-search.md
+++ b/.changeset/rude-days-search.md
@@ -1,0 +1,8 @@
+---
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
+---
+
+Add currentTime property to Model to read and seek animation time

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -11,7 +11,7 @@ function App() {
   const [logs, logLine, clearLog] = useLogger()
   const [transform, setTransform] = useState('')
   const [dragTranslation, setDragTranslation] = useState({ x: 0, y: 0, z: 0 })
-  const [isPaused, setIsPaused] = useState(true)
+  const [currentTime, setCurrentTime] = useState(0.0)
   const [playbackRate, setPlaybackRate] = useState(1.0)
   const [loop, setLoop] = useState(true)
   useEffect(() => {
@@ -20,11 +20,11 @@ function App() {
   // Monitor duration and pause state since there is no playback lifecycle events
   useEffect(() => {
     const id = setInterval(
-      () => setIsPaused(modelRef.current?.paused ?? true),
+      () => setCurrentTime(modelRef.current?.currentTime ?? 0.0),
       200,
     )
     return () => clearInterval(id)
-  }, [setIsPaused])
+  }, [setCurrentTime])
 
   return (
     <div className="prose max-w-none p-10">
@@ -40,6 +40,7 @@ function App() {
           height: '200px',
           '--xr-depth': '100px',
           '--xr-back': '50px',
+          marginBottom: '20px',
           transform,
         }}
         ref={modelRef}
@@ -68,14 +69,14 @@ function App() {
         }}
       >
         <source
+          src="https://webkit.org/demos/model-demos/models/stopwatch.usdz"
+          type="model/vnd.usdz+zip"
+        />
+        <source
           src="https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz"
           type="model/vnd.usdz+zip"
         />
         <source src="/modelasset/Fox_animated.glb" type="model/gltf-binary" />
-        <source
-          src="https://webkit.org/demos/model-demos/models/stopwatch.usdz"
-          type="model/vnd.usdz+zip"
-        />
         <source
           src="https://developer.apple.com/augmented-reality/quick-look/models/biplane/toy_biplane_realistic.usdz"
           type="model/vnd.usdz+zip"
@@ -87,6 +88,16 @@ function App() {
       </Model>
       <section className="playbackControls">
         <button
+          className="btn m-1"
+          onClick={() => {
+            if (modelRef.current?.currentTime) {
+              modelRef.current.currentTime -= 10
+            }
+          }}
+        >
+          ⏪
+        </button>
+        <button
           className="btn btn-success m-1"
           onClick={() => modelRef.current?.play()}
         >
@@ -97,6 +108,16 @@ function App() {
           onClick={() => modelRef.current?.pause()}
         >
           ⏸
+        </button>
+        <button
+          className="btn m-1"
+          onClick={() => {
+            if (modelRef.current?.currentTime) {
+              modelRef.current.currentTime += 10
+            }
+          }}
+        >
+          ⏩
         </button>
         <label className="inline-flex items-center align-middle">
           <input
@@ -123,8 +144,10 @@ function App() {
           <option value={100.0}>100.0</option>
         </select>
         <span className="m-1">
-          Duration {modelRef.current?.duration?.toFixed(2)}s, Paused:{' '}
-          {`${isPaused}`}, Rate: {modelRef.current?.playbackRate}
+          Time: {currentTime.toFixed(2)}/
+          {modelRef.current?.duration?.toFixed(2)}s, Paused:{' '}
+          {`${modelRef.current?.paused ?? true}`}, Rate:{' '}
+          {modelRef.current?.playbackRate}
         </span>
       </section>
       <Logger logs={logs} clearLog={clearLog} />

--- a/docs/Model.md
+++ b/docs/Model.md
@@ -129,7 +129,7 @@ a read-only `double` reflecting the un-scaled total duration of the animation in
 
 `currentTime`
 
-a read-write `double` reflecting the un-scaled playback time of the model animation, if present. It is clamped to the duration of the animation, so for an animation with no animation, the value is always 0.
+a read-write `double` reflecting the un-scaled playback time of the model animation in seconds. It is clamped to the duration of the animation, so for an animation with no animation, the value is always 0.
 
 `playbackRate`
 

--- a/packages/core/src/SpatializedStatic3DElement.test.ts
+++ b/packages/core/src/SpatializedStatic3DElement.test.ts
@@ -136,4 +136,103 @@ describe('SpatializedStatic3DElement', () => {
     el.onReceiveEvent({ type: SpatialWebMsgType.modelloaded })
     await expect(p3).resolves.toBe(true)
   })
+
+  it('currentTime defaults to 0 before any sample', () => {
+    const el = new SpatializedStatic3DElement('ct1', 'a.glb')
+    expect(el.currentTime).toBe(0)
+  })
+
+  it('currentTime returns the anchor while paused', () => {
+    const el = new SpatializedStatic3DElement('ct2', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: true,
+        duration: 10,
+        currentTime: 4,
+        timestamp: Date.now(),
+      },
+    })
+    expect(el.currentTime).toBe(4)
+  })
+
+  it('currentTime extrapolates while playing using playbackRate', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const el = new SpatializedStatic3DElement('ct3', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: false,
+        duration: 10,
+        currentTime: 2,
+        timestamp: 1_000,
+      },
+    })
+    nowSpy.mockReturnValue(2_000) // +1s real time
+    // default rate 1 → +1s animation time
+    expect(el.currentTime).toBe(3)
+    nowSpy.mockRestore()
+  })
+
+  it('currentTime clamps extrapolation to duration', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const el = new SpatializedStatic3DElement('ct4', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: false,
+        duration: 5,
+        currentTime: 4,
+        timestamp: 1_000,
+      },
+    })
+    nowSpy.mockReturnValue(11_000) // +10s real time → would extrapolate to 14
+    expect(el.currentTime).toBe(5)
+    nowSpy.mockRestore()
+  })
+
+  it('setting currentTime optimistically updates the anchor', async () => {
+    const el = new SpatializedStatic3DElement('ct5', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: true,
+        duration: 10,
+        currentTime: 0,
+        timestamp: Date.now(),
+      },
+    })
+    el.currentTime = 7
+    expect(el.currentTime).toBe(7)
+  })
+
+  it('setting currentTime clamps negative values to 0', async () => {
+    const el = new SpatializedStatic3DElement('ct6', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: true,
+        duration: 10,
+        currentTime: 5,
+        timestamp: Date.now(),
+      },
+    })
+    el.currentTime = -3
+    expect(el.currentTime).toBe(0)
+  })
+
+  it('setting currentTime clamps values above duration', async () => {
+    const el = new SpatializedStatic3DElement('ct7', 'a.glb')
+    el.onReceiveEvent({
+      type: SpatialWebMsgType.animationstatechange,
+      detail: {
+        paused: true,
+        duration: 8,
+        currentTime: 0,
+        timestamp: Date.now(),
+      },
+    })
+    el.currentTime = 100
+    expect(el.currentTime).toBe(8)
+  })
 })

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -109,7 +109,19 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       this._loop = properties.loop
     }
     if (properties.playbackRate !== undefined) {
+      // Re-anchor so extrapolation uses the new rate only for future elapsed
+      // time, not the window between the last sample and this change.
+      if (!this._paused) {
+        this._currentTime = this.currentTime
+        this._anchorTimestamp = Date.now()
+      }
       this._playbackRate = properties.playbackRate
+    }
+    if (properties.currentTime !== undefined) {
+      // Optimistically update the local anchor so subsequent reads reflect
+      // the requested seek without waiting for the next native sample.
+      this._currentTime = properties.currentTime
+      this._anchorTimestamp = Date.now()
     }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
@@ -149,6 +161,48 @@ export class SpatializedStatic3DElement extends SpatializedElement {
   }
 
   /**
+   * Last playback position sampled from native (seconds).
+   */
+  private _currentTime: number = 0
+
+  /**
+   * Unix epoch time (ms) corresponding to `_currentTime`. Sourced from the
+   * native `timestamp` on samples, or `Date.now()` on local seeks/transitions.
+   */
+  private _anchorTimestamp: number = 0
+
+  private clampTime(time: number): number {
+    if (!Number.isFinite(time) || time < 0) return 0
+    // When looping the current time is modulo the duration
+    if (time > this._duration) {
+      return this.loop && this.duration > 0
+        ? time % this._duration
+        : this.duration
+    }
+    return time
+  }
+
+  /**
+   * Returns the current (un-scaled) playback position in seconds. While
+   * playing, the value is extrapolated from the last anchor using
+   * `playbackRate` and clamped to `[0, duration]`; while paused it returns
+   * the anchor directly.
+   */
+  get currentTime(): number {
+    if (this._paused) return this._currentTime
+    const elapsed = (Date.now() - this._anchorTimestamp) / 1000
+    return this.clampTime(this._currentTime + elapsed * this._playbackRate)
+  }
+
+  /**
+   * Seeks the animation to `value` seconds (clamped to `[0, duration]`) and
+   * forwards the request to native.
+   */
+  set currentTime(value: number) {
+    this.updateProperties({ currentTime: this.clampTime(value) })
+  }
+
+  /**
    * Whether the animation is currently paused.
    */
   private _paused: boolean = true
@@ -181,6 +235,10 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * @returns Promise resolving when the command is sent
    */
   async play(): Promise<void> {
+    if (this._paused) {
+      // Start extrapolating from the last known position on resume.
+      this._anchorTimestamp = Date.now()
+    }
     this._paused = false
     await this.updateProperties({ animationPaused: false })
   }
@@ -190,6 +248,12 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * @returns Promise resolving when the command is sent
    */
   async pause(): Promise<void> {
+    if (!this._paused) {
+      // Freeze the extrapolated position so reads remain stable until the
+      // next native sample arrives.
+      this._currentTime = this.currentTime
+      this._anchorTimestamp = Date.now()
+    }
     this._paused = true
     await this.updateProperties({ animationPaused: true })
   }
@@ -213,6 +277,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     } else if (data.type === SpatialWebMsgType.animationstatechange) {
       this._paused = data.detail.paused
       this._duration = data.detail.duration
+      // In unsupported environments currentTime is invalid
+      this._currentTime = data.detail.currentTime ?? 0
+      this._anchorTimestamp = data.detail.timestamp ?? Date.now()
       this._onAnimationStateChangeCallback?.(data.detail)
     } else {
       // Handle other spatial events using the base class implementation

--- a/packages/core/src/WebMsgCommand.ts
+++ b/packages/core/src/WebMsgCommand.ts
@@ -81,6 +81,16 @@ export interface ModelLoadFailure {
 export interface AnimationStateChangeDetail {
   paused: boolean
   duration: number
+  /**
+   * Sampled animation playback position in seconds at `timestamp`.
+   * Optional for compatibility with older native runtimes.
+   */
+  currentTime?: number
+  /**
+   * Unix epoch time in milliseconds at which `currentTime` was sampled.
+   * Used to extrapolate `currentTime` between samples while playing.
+   */
+  timestamp?: number
 }
 
 export interface AnimationStateChangeMsg {

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -109,6 +109,7 @@ export interface SpatializedStatic3DElementProperties
   loop?: boolean
   animationPaused?: boolean
   playbackRate?: number
+  currentTime?: number
   posterURL?: string
 }
 

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -226,6 +226,20 @@ function SpatializedStatic3DElementContainerBase(
             spatializedElement.playbackRate = value
           }
         },
+        get currentTime(): number {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          return spatializedElement?.currentTime ?? 0
+        },
+        set currentTime(value: number) {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          if (spatializedElement) {
+            spatializedElement.currentTime = value
+          }
+        },
       }
     },
     [],

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -129,6 +129,7 @@ export type SpatializedStatic3DElementRef = SpatializedDivElementRef & {
   readonly paused: boolean
   readonly duration: number
   playbackRate: number
+  currentTime: number
 }
 
 type CurrentTarget<T extends SpatializedElementRef> = {

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -267,6 +267,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
     let loop: Bool?
     let animationPaused: Bool?
     let playbackRate: Double?
+    let currentTime: Double?
     let posterURL: String?
 }
 

--- a/packages/visionOS/web-spatial/WebMsgCommand.swift
+++ b/packages/visionOS/web-spatial/WebMsgCommand.swift
@@ -119,6 +119,9 @@ struct ModelLoadFailure: Encodable {
 struct AnimationStateChangeDetail: Encodable {
     let paused: Bool
     let duration: Double
+    let currentTime: Double
+    /// Unix epoch time in milliseconds
+    let timestamp: Double
 }
 
 struct AnimationStateChangeEvent: Encodable {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -629,6 +629,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             spatializedElement.playbackRate = playbackRate
         }
 
+        if let currentTime = command.currentTime {
+            spatializedElement.pendingSeekTime = currentTime
+        }
+
         if let posterURL = command.posterURL {
             spatializedElement.posterURL = posterURL.isEmpty ? nil : posterURL
         }

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -15,6 +15,9 @@ class SpatializedStatic3DElement: SpatializedElement {
     var loop: Bool = false
     var animationPaused: Bool = true
     var playbackRate: Double = 1.0
+    /// Requested seek position in seconds. Setting it triggers a seek in
+    /// `SpatializedStatic3DView`, which clears it back to `nil`.
+    var pendingSeekTime: Double?
     var posterURL: String?
     var allSources: [ModelSource] {
         return if let modelURL {

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -82,6 +82,7 @@ struct SpatializedStatic3DView: View {
             }
             .onChange(of: spatializedStatic3DElement.animationPaused) { onPlayback(isPaused: $1) }
             .onChange(of: spatializedStatic3DElement.playbackRate) { asset?.animationPlaybackController?.speed = Float($1) }
+            .onChange(of: spatializedStatic3DElement.pendingSeekTime) { _, time in onSeek(time: time) }
             .task(id: spatializedStatic3DElement.allSources) { await loadSources() }
         } else {
             EmptyView()
@@ -123,12 +124,40 @@ struct SpatializedStatic3DView: View {
         }
         let controller = asset.animationPlaybackController
         controller?.speed = Float(spatializedStatic3DElement.playbackRate)
+        if let time = spatializedStatic3DElement.pendingSeekTime, let controller {
+            controller.time = time
+            spatializedStatic3DElement.pendingSeekTime = nil
+        }
         isPaused ? controller?.pause() : controller?.resume()
+        sendAnimationStateChange(isPaused: isPaused)
+    }
+
+    /// Seeks the underlying animation controller when a non-nil `time` is
+    /// requested, then clears `pendingSeekTime` so subsequent identical
+    /// requests still trigger a fresh seek.
+    private func onSeek(time: Double?) {
+        guard let controller = asset?.animationPlaybackController, let time else { return }
+        controller.time = time
+        spatializedStatic3DElement.pendingSeekTime = nil
+        sendAnimationStateChange(isPaused: spatializedStatic3DElement.animationPaused)
+    }
+
+    /// Emits the current animation state to the web layer, sampling the
+    /// controller's position and the wall clock together so the web side can
+    /// extrapolate between samples.
+    private func sendAnimationStateChange(isPaused: Bool) {
+        let controller = asset?.animationPlaybackController
         let duration = controller?.duration ?? 0
+        let currentTime = controller?.time ?? 0
         spatialScene.sendWebMsg(
             spatializedElement.id,
             AnimationStateChangeEvent(
-                detail: AnimationStateChangeDetail(paused: isPaused, duration: duration)
+                detail: AnimationStateChangeDetail(
+                    paused: isPaused,
+                    duration: duration,
+                    currentTime: currentTime,
+                    timestamp: Date().timeIntervalSince1970 * 1000
+                )
             )
         )
     }


### PR DESCRIPTION
Exposes currentTime on <Model> refs. Allows reading and seeking the animation playback time in seconds.
https://claude.ai/code/session_014JAW3oKPUVuVucqjLJzFLt

Closes #1132

https://github.com/user-attachments/assets/49171516-1ee7-48be-ac04-35448d01317a

