### PR TITLE
fix(core): split picoOS capability matrix; gate xrInnerDepth/xrOuterDepth on Pico

### DIFF
--- a/.changeset/pico-capability-matrix-split.md
+++ b/.changeset/pico-capability-matrix-split.md
@@ -1,0 +1,6 @@
+---
+'@webspatial/core-sdk': patch
+'@webspatial/react-sdk': patch
+---
+
+Split **picoOS** capability rows from visionOS in `CAPABILITY_TABLE`: `supports('xrInnerDepth')` and `supports('xrOuterDepth')` are **false** for PicoWebApp **0.1.1** and **0.1.2**; visionOS shell rows are unchanged.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor Changes
 
 - Runtime **capability matrix** (`CAPABILITY_TABLE` in `capability-data.ts`): visionOS **1.5.0** and **1.6.0**, picoOS **0.1.1** and **0.1.2**, transcribed from the product matrix (Model sub-tokens, Window/Volume/Material/SpatialRotateEvent). `supports()` continues to select the highest row with `row.version <=` shell semver from `WSAppShell` / `PicoWebApp`.
+- **picoOS** capability rows are built separately from visionOS: **`supports('xrInnerDepth')` / `supports('xrOuterDepth')` are false** for PicoWebApp **0.1.1** and **0.1.2**; visionOS rows unchanged.
 - Runtime **DOM depth key lists**: `ELEMENT_DOM_DEPTH_KEYS` (`xrClientDepth`, `xrOffsetBack`), `WINDOW_DOM_DEPTH_KEYS` (`xrInnerDepth`, `xrOuterDepth`), `DOM_DEPTH_KEYS`, exported from `@webspatial/core-sdk` runtime.
 - **`contract-review.test.ts`**: asserts window depth keys absent when unsupported (plain UA) and element depth keys not mirrored on `window`.
 ## 1.6.0

--- a/packages/core/src/runtime/capability-data.ts
+++ b/packages/core/src/runtime/capability-data.ts
@@ -1,6 +1,8 @@
 /**
  * Versioned capability rows transcribed from the product matrix (`capability-matrix.template.md`).
  * visionOS **WSAppShell/1.5.0** & **1.6.0**; picoOS **PicoWebApp/0.1.1** & **0.1.2** — see matrix in OpenSpec / product docs.
+ *
+ * **picoOS** rows use dedicated builders (alpha2.0 / alpha2.1 subtokens); visionOS rows are separate.
  */
 import { SUB_TOKENS_BY_NAME, TOP_LEVEL_KEYS } from './keys'
 
@@ -25,10 +27,10 @@ function baseTrueFlags(): Record<string, boolean> {
 }
 
 /**
- * visionOS 1.5.0 / picoOS 0.1.1 — alpha2.0 baseline.
+ * visionOS **WSAppShell/1.5.0**.
  * Model: only `ready`, `currentSrc`, `entityTransform` among tracked sub-tokens are Y; SpatialRotateEvent:constrainedToAxis Y.
  */
-function matrixVision_1_5_0_Pico_0_1_1_Flags(): Record<string, boolean> {
+function matrixVision_1_5_0_Flags(): Record<string, boolean> {
   const flags = baseTrueFlags()
   const modelNo = [
     'autoplay',
@@ -52,10 +54,10 @@ function matrixVision_1_5_0_Pico_0_1_1_Flags(): Record<string, boolean> {
 }
 
 /**
- * visionOS 1.6.0 / picoOS 0.1.2 — WebSpatial April / alpha2.0 playback expansion.
+ * visionOS **WSAppShell/1.6.0** — WebSpatial April / playback expansion (see product matrix).
  * Model: `stagemode`, `poster`, `loading`, `currentTime` remain N; rest of tracked Model sub-tokens Y.
  */
-function matrixVision_1_6_0_Pico_0_1_2_Flags(): Record<string, boolean> {
+function matrixVision_1_6_0_Flags(): Record<string, boolean> {
   const flags = baseTrueFlags()
   for (const t of ['stagemode', 'poster', 'loading', 'currentTime'] as const) {
     flags[`Model:${t}`] = false
@@ -64,20 +66,42 @@ function matrixVision_1_6_0_Pico_0_1_2_Flags(): Record<string, boolean> {
   return flags
 }
 
+/**
+ * picoOS **PicoWebApp/0.1.1** — alpha2.0 baseline (product matrix).
+ * WindowScene / VolumeScene / Material subtokens Y; Model sub-tokens per matrix; **`xrInnerDepth` / `xrOuterDepth` N**.
+ */
+function matrixPico_0_1_1_Flags(): Record<string, boolean> {
+  const flags = matrixVision_1_5_0_Flags()
+  flags.xrInnerDepth = false
+  flags.xrOuterDepth = false
+  return flags
+}
+
+/**
+ * picoOS **PicoWebApp/0.1.2** — alpha2.1 playback expansion (product matrix).
+ * **`xrInnerDepth` / `xrOuterDepth` N** (same as 0.1.1).
+ */
+function matrixPico_0_1_2_Flags(): Record<string, boolean> {
+  const flags = matrixVision_1_6_0_Flags()
+  flags.xrInnerDepth = false
+  flags.xrOuterDepth = false
+  return flags
+}
+
 function visionOsRow_1_5_0(): CapabilityVersionRow {
-  return { version: '1.5.0', flags: matrixVision_1_5_0_Pico_0_1_1_Flags() }
+  return { version: '1.5.0', flags: matrixVision_1_5_0_Flags() }
 }
 
 function visionOsRow_1_6_0(): CapabilityVersionRow {
-  return { version: '1.6.0', flags: matrixVision_1_6_0_Pico_0_1_2_Flags() }
+  return { version: '1.6.0', flags: matrixVision_1_6_0_Flags() }
 }
 
 function picoOsRow_0_1_1(): CapabilityVersionRow {
-  return { version: '0.1.1', flags: matrixVision_1_5_0_Pico_0_1_1_Flags() }
+  return { version: '0.1.1', flags: matrixPico_0_1_1_Flags() }
 }
 
 function picoOsRow_0_1_2(): CapabilityVersionRow {
-  return { version: '0.1.2', flags: matrixVision_1_6_0_Pico_0_1_2_Flags() }
+  return { version: '0.1.2', flags: matrixPico_0_1_2_Flags() }
 }
 
 export const CAPABILITY_TABLE: {

--- a/packages/core/src/runtime/supports.test.ts
+++ b/packages/core/src/runtime/supports.test.ts
@@ -59,6 +59,8 @@ describe('getRuntime / supports', () => {
     expect(rt.type).toBe('visionos')
     expect(rt.shellVersion).toBe('1.5.0')
     expect(supports('Model')).toBe(true)
+    expect(supports('xrInnerDepth')).toBe(true)
+    expect(supports('xrOuterDepth')).toBe(true)
     expect(supports('UnknownThing' as any)).toBe(false)
   })
 
@@ -75,6 +77,8 @@ describe('getRuntime / supports', () => {
     expect(supports('Model', ['ready', 'currentSrc'])).toBe(true)
     expect(supports('Model', ['stagemode'])).toBe(false)
     expect(supports('WindowScene', ['defaultSize', 'resizability'])).toBe(true)
+    expect(supports('xrInnerDepth')).toBe(false)
+    expect(supports('xrOuterDepth')).toBe(false)
   })
 
   test('pico UA PicoWebApp/0.1.2: matrix playback row (alpha2.0)', async () => {
@@ -87,6 +91,8 @@ describe('getRuntime / supports', () => {
     expect(supports('Model', ['autoplay', 'loop', 'source'])).toBe(true)
     expect(supports('Model', ['currentTime'])).toBe(false)
     expect(supports('Model', ['poster'])).toBe(false)
+    expect(supports('xrInnerDepth')).toBe(false)
+    expect(supports('xrOuterDepth')).toBe(false)
   })
 
   test('alias Box → BoxEntity', async () => {


### PR DESCRIPTION
## Summary

- Split **picoOS** capability rows from visionOS in `CAPABILITY_TABLE`: `supports('xrInnerDepth')` and `supports('xrOuterDepth')` are **false** for PicoWebApp **0.1.1** and **0.1.2**. visionOS shell rows unchanged.
- Tests: Pico UAs assert window depth keys unsupported; visionOS asserts supported.
- **Changeset**: patch bump for `@webspatial/core-sdk` + `@webspatial/react-sdk`.

## Notes

Aligned with product matrix for Pico alpha2.0 / alpha2.1 (window depth not exposed on Pico browser runtime).


Made with [Cursor](https://cursor.com)