### PR TITLE
test(react): cover in-operator support for extra ref props

### DIFF
--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -151,6 +151,24 @@ describe('SpatialContainerRefProxy', () => {
 
     expect((ref.current as any).foo).toBe('bar')
   })
+
+  it('supports the in operator for extra ref props', () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref, () => ({
+      get foo() {
+        return 'bar'
+      },
+    }))
+
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(dom)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+
+    expect('foo' in (ref.current as any)).toBe(true)
+    expect('missing' in (ref.current as any)).toBe(false)
+  })
 })
 
 describe('hijackGetComputedStyle', () => {


### PR DESCRIPTION
## Summary

Adds a regression test for issue #1140.

## Changes

- adds coverage for the `in` operator on ref proxy `extraRefProps`
- verifies injected ref properties are discoverable via proxy `has` semantics
- keeps production code unchanged because `main` already includes the runtime `has` trap fix

## Notes

This PR is intentionally test-only and documents the expected behavior so the issue does not regress.

Closes #1140