### PR TITLE
fix a link nested issue

### DIFF
--- a/.changeset/fix-anchor-bubbling.md
+++ b/.changeset/fix-anchor-bubbling.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Fix anchor click interception in the scene polyfill when users click nested elements inside an anchor tag, such as images wrapped by links. The polyfill now uses the anchor found during event bubbling so target-based navigation handling still works for `_blank` and other non-`_self` links.

--- a/apps/test-server/src/pages/scene/index.tsx
+++ b/apps/test-server/src/pages/scene/index.tsx
@@ -189,7 +189,25 @@ export default function SceneTest() {
             >
               MDN
             </button>
+            {/* Click the nested image to reproduce anchor bubbling behavior in the polyfill. */}
+            <a
+              className={`${btnCls} inline-flex items-center gap-2`}
+              href="/#/reality"
+              target="sv"
+              rel="noreferrer"
+            >
+              <img
+                alt="nested link icon"
+                className="w-4 h-4 rounded-sm"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%234B5563'/%3E%3Cpath d='M5 8h6M8 5l3 3-3 3' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E"
+              />
+              <span>Nested Anchor Click</span>
+            </a>
           </div>
+          <p className="mt-3 text-xs text-gray-400">
+            Click the icon inside Nested Anchor Click to simulate a nested
+            target inside an anchor tag.
+          </p>
         </section>
 
         <section className="bg-[#1A1A1A] p-6 rounded-xl border border-gray-800">

--- a/docs/scene-polyfill-anchor-navigation.md
+++ b/docs/scene-polyfill-anchor-navigation.md
@@ -1,0 +1,21 @@
+# Scene Polyfill Anchor Navigation
+
+The scene polyfill installs a document click handler via `hijackWindowATag(...)` to handle navigation for anchor tags in a controlled way.
+
+## What It Does
+
+- It listens to `document.onclick` and walks up the DOM tree from the event target to find the nearest `<a>` element.
+- If the anchor has a `target` and `target !== '_self'`, it prevents the default navigation and calls `window.open(url, target)`.
+- If no special handling is needed, it lets the browser behavior continue.
+
+## Nested Clicks
+
+Clicks often originate from a nested element inside an anchor, for example:
+
+```html
+<a href="https://example.com" target="_blank">
+  <img src="..." />
+</a>
+```
+
+In this case the `event.target` is the `<img>`, not the `<a>`. The polyfill therefore uses the anchor found during event bubbling rather than relying on `event.target` being the anchor itself.

--- a/docs/webspatial-quirks.md
+++ b/docs/webspatial-quirks.md
@@ -1,14 +1,18 @@
-# Scene Polyfill Anchor Navigation
+# WebSpatial Quirks
+
+This document records abnormal behaviours that normal web developers would not expect when running inside the WebSpatial runtime. Each section describes one quirk, the root cause, and the polyfill/workaround applied.
+
+## Anchor Navigation
 
 The scene polyfill installs a document click handler via `hijackWindowATag(...)` to handle navigation for anchor tags in a controlled way.
 
-## What It Does
+### What It Does
 
 - It listens to `document.onclick` and walks up the DOM tree from the event target to find the nearest `<a>` element.
 - If the anchor has a `target` and `target !== '_self'`, it prevents the default navigation and calls `window.open(url, target)`.
 - If no special handling is needed, it lets the browser behavior continue.
 
-## Nested Clicks
+### Nested Clicks
 
 Clicks often originate from a nested element inside an anchor, for example:
 

--- a/packages/core/src/scene-polyfill.test.ts
+++ b/packages/core/src/scene-polyfill.test.ts
@@ -492,3 +492,35 @@ describe('hijackWindowATag', () => {
     expect(openSpy).toHaveBeenCalledWith('https://example.com/detail', '_blank')
   })
 })
+
+describe('hijackWindowATag – defaultPrevented', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.onclick = null
+    vi.restoreAllMocks()
+  })
+
+  it('does not open a new window when the click was already preventDefault-ed', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    hijackWindowATag(window)
+
+    const anchor = document.createElement('a')
+    anchor.href = 'https://example.com/detail'
+    anchor.target = '_blank'
+
+    const span = document.createElement('span')
+    anchor.appendChild(span)
+    document.body.appendChild(anchor)
+
+    // Simulate an app-level handler that cancels the click before the polyfill sees it.
+    span.addEventListener('click', ev => {
+      ev.preventDefault()
+    })
+
+    span.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    )
+
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/scene-polyfill.test.ts
+++ b/packages/core/src/scene-polyfill.test.ts
@@ -4,6 +4,7 @@ import {
   initScene,
   injectSceneHook,
   __getSceneConfigSnapshotForTest,
+  hijackWindowATag,
 } from './scene-polyfill'
 import { SpatialSceneCreationOptions } from './types/types'
 import { pointToPhysical } from './physicalMetrics'
@@ -462,5 +463,32 @@ describe('initScene callback chaining', () => {
     const cb2 = vi.fn().mockReturnValue({})
     initScene('sa-chain', cb2)
     expect(cb2).toHaveBeenCalledWith(firstReturn)
+  })
+})
+
+describe('hijackWindowATag', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.onclick = null
+    vi.restoreAllMocks()
+  })
+
+  it('handles clicks on nested elements inside anchor tags', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    hijackWindowATag(window)
+
+    const anchor = document.createElement('a')
+    anchor.href = 'https://example.com/detail'
+    anchor.target = '_blank'
+
+    const image = document.createElement('img')
+    anchor.appendChild(image)
+    document.body.appendChild(anchor)
+
+    image.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    )
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/detail', '_blank')
   })
 })

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -526,7 +526,7 @@ export function hijackWindowATag(openedWindow: WindowProxy) {
 
     // Look for <a> element in the clicked elements parents and if found override navigation behavior if needed
     while (element) {
-      if (element && element.tagName == 'A') {
+      if (element.tagName == 'A') {
         // When using libraries like react route's <Link> it sets an onclick event, when this happens we should do nothing and let that occur
 
         // if onClick is set for the element, the raw onclick will be noop() trapped so the onclick check is no longer trustable
@@ -538,7 +538,7 @@ export function hijackWindowATag(openedWindow: WindowProxy) {
 
         return true
       }
-      if (element && element.parentElement) {
+      if (element.parentElement) {
         element = element.parentElement
       } else {
         break
@@ -548,6 +548,8 @@ export function hijackWindowATag(openedWindow: WindowProxy) {
 }
 
 function handleATag(event: MouseEvent, link: HTMLAnchorElement) {
+  // Respect clicks that have already been cancelled (e.g. by app/router handlers).
+  if (event.defaultPrevented) return false
   // Use the anchor found during bubbling so nested clicks like <a><img /></a> are handled correctly.
   const target = link.target
   const url = link.href

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -523,17 +523,16 @@ export function hijackWindowOpen(window: WindowProxy) {
 export function hijackWindowATag(openedWindow: WindowProxy) {
   openedWindow!.document.onclick = function (e) {
     let element = e.target as HTMLElement | null
-    let found = false
 
     // Look for <a> element in the clicked elements parents and if found override navigation behavior if needed
-    while (!found) {
+    while (element) {
       if (element && element.tagName == 'A') {
         // When using libraries like react route's <Link> it sets an onclick event, when this happens we should do nothing and let that occur
 
         // if onClick is set for the element, the raw onclick will be noop() trapped so the onclick check is no longer trustable
         // we handle all the scenarios
 
-        if (handleATag(e)) {
+        if (handleATag(e, element as HTMLAnchorElement)) {
           return false // prevent default action and stop event propagation
         }
 
@@ -548,18 +547,15 @@ export function hijackWindowATag(openedWindow: WindowProxy) {
   }
 }
 
-function handleATag(event: MouseEvent) {
-  const targetElement = event.target as HTMLElement
-  if (targetElement.tagName === 'A') {
-    const link = targetElement as HTMLAnchorElement
-    const target = link.target
-    const url = link.href
+function handleATag(event: MouseEvent, link: HTMLAnchorElement) {
+  // Use the anchor found during bubbling so nested clicks like <a><img /></a> are handled correctly.
+  const target = link.target
+  const url = link.href
 
-    if (target && target !== '_self') {
-      event.preventDefault()
-      window.open(url, target)
-      return true
-    }
+  if (target && target !== '_self') {
+    event.preventDefault()
+    window.open(url, target)
+    return true
   }
 }
 


### PR DESCRIPTION
# Scene Polyfill Anchor Navigation

The scene polyfill installs a document click handler via `hijackWindowATag(...)` to handle navigation for anchor tags in a controlled way.

## What It Does

- It listens to `document.onclick` and walks up the DOM tree from the event target to find the nearest `<a>` element.
- If the anchor has a `target` and `target !== '_self'`, it prevents the default navigation and calls `window.open(url, target)`.
- If no special handling is needed, it lets the browser behavior continue.

## Nested Clicks

Clicks often originate from a nested element inside an anchor, for example:

```html
<a href="https://example.com" target="_blank">
  <img src="..." />
</a>
```

In this case the `event.target` is the `<img>`, not the `<a>`. The polyfill therefore uses the anchor found during event bubbling rather than relying on `event.target` being the anchor itself.