### PR TITLE
[codex] Fix runtime export of core global declarations

### DIFF
--- a/.changeset/fix-core-global-d-export.md
+++ b/.changeset/fix-core-global-d-export.md
@@ -1,0 +1,6 @@
+---
+'@webspatial/core-sdk': patch
+'@webspatial/react-sdk': patch
+---
+
+Avoid exporting `global.d.ts` as a runtime module from `@webspatial/core-sdk`, so stricter bundlers and local `file:`/workspace consumers can resolve the built package correctly.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="./types/global.d.ts" />
+export type {} from './types/global'
 
 export { SpatialObject } from './SpatialObject'
 export { Spatial } from './Spatial'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./types/global.d.ts" />
+
 export { SpatialObject } from './SpatialObject'
 export { Spatial } from './Spatial'
 export { SpatialSession } from './SpatialSession'
@@ -10,7 +12,6 @@ export * as PhysicalMetrics from './physicalMetrics'
 
 export * from './reality'
 export * from './types/types'
-export * from './types/global.d'
 export * from './runtime'
 
 // side effects

--- a/packages/core/src/types/global.ts
+++ b/packages/core/src/types/global.ts
@@ -1,7 +1,8 @@
 import type { PhysicalMetricsValueShape } from '../physicalMetrics'
+import type { SpatialSceneCreationOptions, SpatialSceneType } from './types'
 
 declare global {
-  declare const __WEBSPATIAL_CORE_SDK_VERSION__: string
+  const __WEBSPATIAL_CORE_SDK_VERSION__: string
 
   interface Window {
     xrCurrentSceneType: SpatialSceneType


### PR DESCRIPTION
## Summary
Fix `@webspatial/core-sdk` so global declarations stay available to downstream TypeScript consumers without being emitted as a runtime module.

## Root Cause
`packages/core/src/index.ts` re-exported `./types/global.d`, which is a declaration-only file. That caused the built runtime bundle to reference a non-resolvable path from `dist/index.js`.

A first-pass fix removed the runtime export, but it also dropped the bundled global DOM augmentations from the generated declaration surface. That broke downstream TypeScript consumers such as `packages/autoTest`, which rely on globals like `HTMLElement.xrOffsetBack`.

## What Changed
- removed the runtime re-export of `./types/global.d`
- moved the global augmentation file from `global.d.ts` to `global.ts`
- exported it as a type-only module via `export type {} from './types/global'`
- kept the global DOM/window augmentations in the bundled `dist/index.d.ts` while avoiding any runtime JS import/export

## Impact
This fixes both sides of the regression:
- stricter bundlers and local `file:` / workspace-style consumers no longer fail on a runtime import of `./types/global.d`
- downstream TypeScript consumers still receive the expected global DOM augmentations from the published type surface

Closes #1157.

## Validation
- built `packages/core` successfully with `pnpm -C packages/core build`
- reproduced the failing `packages/autoTest` TypeScript build locally
- verified the CI-like path passes after the fix:
  - `pnpm -C packages/autoTest exec sh -lc "pnpm -C ../core build >/dev/null && pnpm -C ../react build >/dev/null && pnpm build"`
- verified a downstream local-file consumer can start and build again after refreshing the dependency
- verified the downstream app loads its landing page and model detail route in the browser