### PR TITLE
[codex] Fix React 19 type compatibility

### DIFF
--- a/.changeset/calm-react-compat.md
+++ b/.changeset/calm-react-compat.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Fix React 19 type compatibility for local builds by initializing internal `useRef` values explicitly while preserving React 18 support.

--- a/packages/react/src/reality/components/ModelAsset.tsx
+++ b/packages/react/src/reality/components/ModelAsset.tsx
@@ -19,7 +19,7 @@ const resolveAssetUrl = (url: string): string => {
 
 export const ModelAsset: React.FC<Props> = ({ children, ...options }) => {
   const ctx = useRealityContext()
-  const materialRef = useRef<SpatialModelAsset>()
+  const materialRef = useRef<SpatialModelAsset | undefined>(undefined)
   useEffect(() => {
     const controller = new AbortController()
     if (!ctx) return

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -14,7 +14,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
   ...options
 }) => {
   const ctx = useRealityContext()
-  const materialRef = useRef<SpatialUnlitMaterial>()
+  const materialRef = useRef<SpatialUnlitMaterial | undefined>(undefined)
   const isInitializedRef = useRef(false)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes React 19 type compatibility for `@webspatial/react-sdk` while preserving the existing React 18 development baseline and `react >=18.0.0` peer dependency range.

Closes #1162.

## Root Cause

React 19's type definitions require an initial value for `useRef<T>()`. The React SDK had two zero-argument refs that were accepted by React 18 types but fail declaration generation under React 19:

- `ModelAsset.tsx`
- `UnlitMaterial.tsx`

## Changes

- Replace zero-argument `useRef<T>()` calls with explicit `useRef<T | undefined>(undefined)`.
- Leave package React dev dependencies unchanged so the SDK still builds/tests against its current React 18 baseline.

## Validation

- `pnpm -C /Users/bytedance/github/webspatial-sdk/packages/react build`
- `pnpm -C /Users/bytedance/github/webspatial-sdk/packages/react test` — 80 tests passed
- React 19 linked consumer app: `npm run build`
- React 18 linked consumer app: `npm run build`

Note: the React 18 and React 19 consumer checks were run locally by switching the linked Vite app between React 18.3.x and React 19.x while keeping the SDK linked.