### PR TITLE
fix: skip changeset checks for stable sync PRs

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -104,7 +104,9 @@ jobs:
           body: |
             This pull request was created automatically by GitHub Actions.
             It merges the latest release from `stable` into `main` again.
+            No additional changeset is required because this PR only syncs
+            commits that were already versioned and released from `stable`.
           branch: 'stable-merge-main'
           base: 'main'
-          labels: 'BranchAutoMerge'
+          labels: 'BranchAutoMerge,skip-changeset'
           delete-branch: true

--- a/.github/workflows/validate-changeset.yml
+++ b/.github/workflows/validate-changeset.yml
@@ -45,5 +45,8 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
           SKIP_CHANGESET: ${{ steps.label.outputs.skip }}
         run: bash tools/scripts/validate-pr-changeset.sh

--- a/tools/scripts/validate-pr-changeset.sh
+++ b/tools/scripts/validate-pr-changeset.sh
@@ -3,8 +3,33 @@
 # (not README.md). Set SKIP_CHANGESET=1 when the PR has label skip-changeset.
 set -euo pipefail
 
+is_stable_merge_pr() {
+  local head_ref="${PR_HEAD_REF:-}"
+  local title="${PR_TITLE:-}"
+  local body="${PR_BODY:-}"
+
+  if [[ "$head_ref" == "stable" || "$head_ref" == stable-merge-* ]]; then
+    return 0
+  fi
+
+  if [[ "$title" =~ ^Merge[[:space:]]+stable[[:space:]]+into[[:space:]]+main$ ]]; then
+    return 0
+  fi
+
+  if [[ "$body" == *"from \`stable\` into \`main\`"* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ "${SKIP_CHANGESET:-0}" == "1" ]]; then
   echo "Skipping changeset check (skip-changeset)."
+  exit 0
+fi
+
+if is_stable_merge_pr; then
+  echo "Skipping changeset check (stable merge PR)."
   exit 0
 fi
 

--- a/tools/scripts/validate-pr-changeset.test.ts
+++ b/tools/scripts/validate-pr-changeset.test.ts
@@ -1,0 +1,93 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const scriptPath = path.resolve('tools/scripts/validate-pr-changeset.sh')
+
+function makeRepo() {
+  const repoDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'validate-pr-changeset-'),
+  )
+
+  const run = (args: string[]) =>
+    execFileSync('git', args, {
+      cwd: repoDir,
+      stdio: 'pipe',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'Codex',
+        GIT_AUTHOR_EMAIL: 'codex@example.com',
+        GIT_COMMITTER_NAME: 'Codex',
+        GIT_COMMITTER_EMAIL: 'codex@example.com',
+      },
+    }).trim()
+
+  run(['init'])
+  run(['checkout', '-b', 'main'])
+
+  fs.mkdirSync(path.join(repoDir, 'packages/core'), { recursive: true })
+  fs.writeFileSync(
+    path.join(repoDir, 'packages/core/package.json'),
+    '{"name":"core"}\n',
+  )
+  run(['add', '.'])
+  run(['commit', '-m', 'base'])
+  const baseSha = run(['rev-parse', 'HEAD'])
+
+  fs.writeFileSync(
+    path.join(repoDir, 'packages/core/package.json'),
+    '{"name":"core","version":"1.0.1"}\n',
+  )
+  run(['add', '.'])
+  run(['commit', '-m', 'change packages'])
+  const headSha = run(['rev-parse', 'HEAD'])
+
+  return { repoDir, baseSha, headSha }
+}
+
+function runValidation(env: Record<string, string>) {
+  return spawnSync('bash', [scriptPath], {
+    cwd: env.REPO_DIR,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+    },
+  })
+}
+
+afterEach(() => {
+  // Nothing to clean up here because each test uses a unique OS temp dir.
+})
+
+describe('validate-pr-changeset.sh', () => {
+  it('requires a changeset for normal package changes', () => {
+    const { repoDir, baseSha, headSha } = makeRepo()
+    const result = runValidation({
+      REPO_DIR: repoDir,
+      BASE_SHA: baseSha,
+      HEAD_SHA: headSha,
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr + result.stdout).toContain('require a changeset')
+  })
+
+  it('skips the requirement for stable merge PRs', () => {
+    const { repoDir, baseSha, headSha } = makeRepo()
+    const result = runValidation({
+      REPO_DIR: repoDir,
+      BASE_SHA: baseSha,
+      HEAD_SHA: headSha,
+      PR_HEAD_REF: 'stable-merge-main',
+      PR_TITLE: 'Merge stable into main',
+      PR_BODY: 'This pull request was created automatically by GitHub Actions.',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Skipping changeset check')
+  })
+})


### PR DESCRIPTION
## Summary
- skip the repo changeset validation workflow for auto-generated `stable -> main` sync PRs
- pass PR metadata into the validation script and cover the stable-sync exemption with a Vitest test
- label auto-created sync PRs with `skip-changeset` and explain in the PR body why no extra changeset is needed

## Testing
- `pnpm exec vitest run tools/scripts/validate-pr-changeset.test.ts`