### PR TITLE
refactor(core): explicit spatial host APIs and adapter cleanup

### DIFF
--- a/.changeset/quick-peas-turn.md
+++ b/.changeset/quick-peas-turn.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Refactor spatial host integration by introducing explicit platform capability APIs and a shared `spatial-host` facade. This simplifies scene/div/attachment call paths, removes redundant command wrappers, and improves platform adapter robustness for VisionOS and Pico OS error handling.

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -1,5 +1,4 @@
-import { createPlatform } from './platform-adapter'
-import { WebSpatialProtocolResult } from './platform-adapter/interface'
+import { getPlatform } from './platform-runtime'
 import { SpatialComponent } from './reality/component/SpatialComponent'
 import { SpatialEntity } from './reality/entity/SpatialEntity'
 import { SpatialMaterial } from './reality/material/SpatialMaterial'
@@ -26,10 +25,7 @@ import {
   AttachmentEntityUpdateOptions,
   ModelSource,
 } from './types/types'
-import { SpatialSceneCreationOptionsInternal } from './types/internal'
 import { composeSRT } from './utils'
-
-const platform = createPlatform()
 
 abstract class JSBCommand {
   commandType: string = ''
@@ -38,6 +34,7 @@ abstract class JSBCommand {
   async execute() {
     const param = this.getParams()
     const msg = param ? JSON.stringify(param) : ''
+    const platform = await getPlatform()
     return platform.callJSB(this.commandType, msg)
   }
 }
@@ -606,88 +603,6 @@ export class CheckWebViewCanCreateCommand extends JSBCommand {
   }
 }
 
-/* WebSpatial Protocol Begin */
-abstract class WebSpatialProtocolCommand extends JSBCommand {
-  target?: string
-  features?: string
-
-  async execute(): Promise<WebSpatialProtocolResult> {
-    const query = this.getQuery()
-    return platform.callWebSpatialProtocol(
-      this.commandType,
-      query,
-      this.target,
-      this.features,
-    )
-  }
-
-  executeSync(): WebSpatialProtocolResult {
-    const query = this.getQuery()
-    return platform.callWebSpatialProtocolSync(
-      this.commandType,
-      query,
-      this.target,
-      this.features,
-    )
-  }
-
-  private getQuery() {
-    let query = undefined
-    const params = this.getParams()
-    if (params) {
-      query = Object.keys(params)
-        .map(key => {
-          const value = params[key]
-          const finalValue =
-            typeof value === 'object' ? JSON.stringify(value) : value
-          return `${key}=${encodeURIComponent(finalValue)}`
-        })
-        .join('&')
-    }
-
-    return query
-  }
-}
-
-export class createSpatialized2DElementCommand extends WebSpatialProtocolCommand {
-  commandType = 'createSpatialized2DElement'
-  constructor() {
-    super()
-  }
-  protected getParams() {
-    return {}
-  }
-}
-
-export class createSpatialSceneCommand extends WebSpatialProtocolCommand {
-  commandType = 'createSpatialScene'
-
-  constructor(
-    private url: string,
-    private config: SpatialSceneCreationOptionsInternal | undefined,
-    public target?: string,
-    public features?: string,
-  ) {
-    super()
-  }
-  protected getParams() {
-    return {
-      url: this.url,
-      config: this.config,
-    }
-  }
-}
-
-export class CreateAttachmentEntityCommand extends WebSpatialProtocolCommand {
-  commandType = 'createAttachment'
-  constructor(private options: AttachmentEntityOptions) {
-    super()
-  }
-  protected getParams() {
-    return {} // No metadata — just trigger engine/webview creation
-  }
-}
-
 export class InitializeAttachmentCommand extends JSBCommand {
   commandType = 'InitializeAttachment'
   constructor(
@@ -730,5 +645,3 @@ function uuid(): string {
     return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
   })
 }
-
-/* WebSpatial Protocol End */

--- a/packages/core/src/SpatializedElementCreator.ts
+++ b/packages/core/src/SpatializedElementCreator.ts
@@ -1,15 +1,15 @@
 import {
-  createSpatialized2DElementCommand,
   CreateSpatializedDynamic3DElementCommand,
   CreateSpatializedStatic3DElementCommand,
 } from './JSBCommand'
 import { Spatialized2DElement } from './Spatialized2DElement'
 import { SpatializedStatic3DElement } from './SpatializedStatic3DElement'
 import { SpatializedDynamic3DElement } from './SpatializedDynamic3DElement'
+import { createNativeSpatialDiv } from './spatial-host'
 import { ModelSource } from './types/types'
 
 export async function createSpatialized2DElement(): Promise<Spatialized2DElement> {
-  const result = await new createSpatialized2DElementCommand().execute()
+  const result = await createNativeSpatialDiv()
   if (!result.success) {
     throw new Error('createSpatialized2DElement failed')
   } else {

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -270,12 +270,7 @@ describe('platform adapters', () => {
     await expect(platform.callJSB('c', '{}')).resolves.toMatchObject({
       success: true,
     })
-    await expect(
-      platform.callWebSpatialProtocol('s', '', '', ''),
-    ).resolves.toMatchObject({
-      success: true,
-    })
-    expect(platform.callWebSpatialProtocolSync('s', '', '', '')).toMatchObject({
+    expect(platform.openSpatialSceneSync('s', undefined)).toMatchObject({
       success: true,
     })
   })
@@ -328,7 +323,7 @@ describe('platform adapters', () => {
       './platform-adapter/vision-os/VisionOSPlatform'
     )
     const platform = new VisionOSPlatform()
-    const r = await platform.callWebSpatialProtocol('open', 'a=1')
+    const r = await platform.createNativeSpatialDiv()
 
     expect(r.success).toBe(true)
     expect(r.data.id).toBe(uuid)
@@ -475,6 +470,14 @@ describe('SpatializedElementCreator', () => {
     const windowProxy: any = {
       document: { head: { innerHTML: '' } },
     }
+    vi.doMock('./spatial-host', () => ({
+      createNativeSpatialDiv: vi.fn().mockResolvedValue({
+        success: true,
+        data: { id: 'w1', windowProxy },
+        errorCode: '',
+        errorMessage: '',
+      }),
+    }))
 
     vi.doMock('./JSBCommand', () => {
       class OkCommand {
@@ -540,6 +543,15 @@ describe('SpatializedElementCreator', () => {
   })
 
   it('createSpatialized2DElement throws when command fails', async () => {
+    vi.doMock('./spatial-host', () => ({
+      createNativeSpatialDiv: vi.fn().mockResolvedValue({
+        success: false,
+        data: undefined,
+        errorCode: 'E',
+        errorMessage: 'bad',
+      }),
+    }))
+
     vi.doMock('./JSBCommand', () => {
       class OkCommand {
         execute() {
@@ -943,9 +955,25 @@ describe('platform-adapter', () => {
     })
 
     const { createPlatform } = await import('./platform-adapter')
-    const p = createPlatform() as any
+    const p = await createPlatform()
     expect(typeof p.callJSB).toBe('function')
-    expect(typeof p.callWebSpatialProtocol).toBe('function')
-    expect(typeof p.callWebSpatialProtocolSync).toBe('function')
+    expect(typeof p.openSpatialSceneSync).toBe('function')
+    expect(typeof p.createNativeSpatialDiv).toBe('function')
+    expect(typeof p.createNativeAttachment).toBe('function')
+  })
+
+  it('createPlatformSync uses SSR sync noop in SSR env', async () => {
+    vi.resetModules()
+    vi.doMock('./ssr-polyfill', () => {
+      return { isSSREnv: () => true }
+    })
+
+    const { createPlatformSync } = await import(
+      './platform-adapter/createPlatformSync'
+    )
+    const p = createPlatformSync()
+    const r = p.openSpatialSceneSync('https://x', undefined)
+    expect(r.success).toBe(true)
+    expect(r.data).toBeUndefined()
   })
 })

--- a/packages/core/src/jsbcommand.coverage.test.ts
+++ b/packages/core/src/jsbcommand.coverage.test.ts
@@ -55,12 +55,14 @@ class DOMMatrixPolyfill {
 
 const platformSpy = {
   callJSB: vi.fn(),
-  callWebSpatialProtocol: vi.fn(),
-  callWebSpatialProtocolSync: vi.fn(),
+  openSpatialSceneSync: vi.fn(),
+  createNativeSpatialDiv: vi.fn(),
+  createNativeAttachment: vi.fn(),
 }
 
 vi.mock('./platform-adapter', () => ({
-  createPlatform: () => platformSpy,
+  createPlatform: () => Promise.resolve(platformSpy),
+  createPlatformSync: () => platformSpy,
 }))
 
 function ok(data: any = {}) {
@@ -72,23 +74,20 @@ function ok(data: any = {}) {
   })
 }
 
-function parseQuery(q?: string) {
-  const sp = new URLSearchParams(q ?? '')
-  const out: Record<string, string> = {}
-  for (const [k, v] of sp.entries()) out[k] = v
-  return out
-}
-
 describe('JSBCommand', () => {
   beforeEach(() => {
     platformSpy.callJSB.mockReset()
-    platformSpy.callWebSpatialProtocol.mockReset()
-    platformSpy.callWebSpatialProtocolSync.mockReset()
+    platformSpy.openSpatialSceneSync.mockReset()
+    platformSpy.createNativeSpatialDiv.mockReset()
+    platformSpy.createNativeAttachment.mockReset()
     platformSpy.callJSB.mockImplementation(() => ok({ id: 'id-1' }))
-    platformSpy.callWebSpatialProtocol.mockImplementation(() =>
+    platformSpy.createNativeSpatialDiv.mockImplementation(() =>
       ok({ windowProxy: {}, id: 'spatial-1' }),
     )
-    platformSpy.callWebSpatialProtocolSync.mockImplementation(() => ({
+    platformSpy.createNativeAttachment.mockImplementation(() =>
+      ok({ windowProxy: {}, id: 'spatial-1' }),
+    )
+    platformSpy.openSpatialSceneSync.mockImplementation(() => ({
       success: true,
       data: { windowProxy: {}, id: 'spatial-1' },
       errorCode: '',
@@ -191,40 +190,6 @@ describe('JSBCommand', () => {
       'UpdateUnlitMaterialProperties',
       JSON.stringify({ id: 'so-1', color: '#fff' }),
     )
-  })
-
-  it('creates query string and calls WebSpatialProtocol', async () => {
-    const mod = await import('./JSBCommand')
-    const { createSpatialSceneCommand, createSpatialized2DElementCommand } = mod
-
-    await new createSpatialized2DElementCommand().execute()
-    expect(platformSpy.callWebSpatialProtocol).toHaveBeenCalledWith(
-      'createSpatialized2DElement',
-      '',
-      undefined,
-      undefined,
-    )
-
-    const cmd = new createSpatialSceneCommand(
-      'https://example.com/a?b=c',
-      { type: 'window', defaultSize: { width: 1, height: 2 } } as any,
-      '_self',
-      'popup=1',
-    )
-    await cmd.execute()
-    const call = platformSpy.callWebSpatialProtocol.mock.calls.at(-1)
-    expect(call?.[0]).toBe('createSpatialScene')
-    expect(call?.[2]).toBe('_self')
-    expect(call?.[3]).toBe('popup=1')
-    const q = parseQuery(call?.[1])
-    expect(q.url).toBe('https://example.com/a?b=c')
-    expect(JSON.parse(q.config)).toEqual({
-      type: 'window',
-      defaultSize: { width: 1, height: 2 },
-    })
-
-    cmd.executeSync()
-    expect(platformSpy.callWebSpatialProtocolSync).toHaveBeenCalled()
   })
 })
 

--- a/packages/core/src/platform-adapter/CommandResultUtils.ts
+++ b/packages/core/src/platform-adapter/CommandResultUtils.ts
@@ -1,6 +1,6 @@
 import { CommandResult } from './interface'
 
-export function CommandResultSuccess(data: any): CommandResult {
+export function CommandResultSuccess<TData>(data: TData): CommandResult<TData> {
   return {
     success: true,
     data,
@@ -12,7 +12,7 @@ export function CommandResultSuccess(data: any): CommandResult {
 export function CommandResultFailure(
   errorCode: string,
   errorMessage = '',
-): CommandResult {
+): CommandResult<undefined> {
   return {
     success: false,
     data: undefined,

--- a/packages/core/src/platform-adapter/createPlatformSync.ts
+++ b/packages/core/src/platform-adapter/createPlatformSync.ts
@@ -1,0 +1,34 @@
+import { resolveJsbAdapterPlatform } from '../runtime/jsbAdapterPlatform'
+import { isSSREnv } from '../ssr-polyfill'
+import { PlatformAbility } from './interface'
+import { PicoOSPlatform } from './pico-os/PicoOSPlatform'
+import { PuppeteerPlatform } from './puppeteer/PuppeteerPlatform'
+import { SSRPlatform } from './ssr/SSRPlatform'
+import { VisionOSPlatform } from './vision-os/VisionOSPlatform'
+
+function assertNever(_: never): never {
+  throw new Error('Unhandled jsb adapter platform kind')
+}
+
+/**
+ * Construct the JSB platform synchronously (static imports).
+ * Used by getPlatformSync (e.g. scene-polyfill openSpatialSceneSync) and kept
+ * consistent with async createPlatform so paths share one implementation.
+ */
+export function createPlatformSync(): PlatformAbility {
+  if (isSSREnv()) {
+    return new SSRPlatform()
+  }
+  const userAgent = window.navigator.userAgent
+  const kind = resolveJsbAdapterPlatform(userAgent)
+  switch (kind) {
+    case 'puppeteer':
+      return new PuppeteerPlatform()
+    case 'picoos':
+      return new PicoOSPlatform()
+    case 'visionos':
+      return new VisionOSPlatform()
+    default:
+      return assertNever(kind)
+  }
+}

--- a/packages/core/src/platform-adapter/index.ts
+++ b/packages/core/src/platform-adapter/index.ts
@@ -1,28 +1,7 @@
-import { resolveJsbAdapterPlatform } from '../runtime/jsbAdapterPlatform'
-import { isSSREnv } from '../ssr-polyfill'
-import { PlatformAbility } from './interface'
-import { SSRPlatform } from './ssr/SSRPlatform'
+export { createPlatformSync } from './createPlatformSync'
+import { createPlatformSync } from './createPlatformSync'
+import type { PlatformAbility } from './interface'
 
-export function createPlatform(): PlatformAbility {
-  if (isSSREnv()) {
-    return new SSRPlatform()
-  }
-  const userAgent = window.navigator.userAgent
-  const kind = resolveJsbAdapterPlatform(userAgent)
-  switch (kind) {
-    case 'puppeteer': {
-      const PuppeteerPlatform =
-        require('./puppeteer/PuppeteerPlatform').PuppeteerPlatform
-      return new PuppeteerPlatform()
-    }
-    case 'picoos': {
-      const PicoOSPlatform = require('./pico-os/PicoOSPlatform').PicoOSPlatform
-      return new PicoOSPlatform()
-    }
-    case 'visionos': {
-      const VisionOSPlatform =
-        require('./vision-os/VisionOSPlatform').VisionOSPlatform
-      return new VisionOSPlatform()
-    }
-  }
+export async function createPlatform(): Promise<PlatformAbility> {
+  return createPlatformSync()
 }

--- a/packages/core/src/platform-adapter/interface.ts
+++ b/packages/core/src/platform-adapter/interface.ts
@@ -1,36 +1,48 @@
-export interface CommandResult {
+import type { SpatialSceneCreationOptionsInternal } from '../types/internal'
+import type { AttachmentEntityOptions } from '../types/types'
+
+export interface CommandResult<TData = any> {
   success: boolean
-  data: any
+  data: TData
   errorCode: string | undefined
   errorMessage: string | undefined
 }
 
-export interface WebSpatialProtocolResult extends CommandResult {
-  success: boolean
-  data:
-    | {
-        windowProxy: WindowProxy
-        id: string
-      }
-    | undefined
-  errorCode: string | undefined
-  errorMessage: string | undefined
-}
+export type WebSpatialProtocolResult = CommandResult<
+  | {
+      // Platform-dependent window proxy shape:
+      // - browser WindowProxy (visionOS/PICO)
+      // - puppeteer simulated window object
+      // Keep broad to avoid over-constraining platform adapters/callers.
+      windowProxy: any
+      id: string
+    }
+  | undefined
+>
 
+/**
+ * Host/runtime bridge: JSB plus explicit spatial host capabilities.
+ * Implementations may use webspatial://, iframes, native events, etc.
+ */
 export interface PlatformAbility {
   callJSB(cmd: string, msg: string): Promise<CommandResult>
-  callWebSpatialProtocol(
-    schema: string,
-    query?: string,
-    target?: string,
-    features?: string,
-  ): Promise<WebSpatialProtocolResult>
 
-  callWebSpatialProtocolSync(
-    schema: string,
-    query?: string,
+  /**
+   * Open a spatial scene synchronously (e.g. window.open polyfill).
+   * Implementations may use webspatial://createSpatialScene under the hood.
+   */
+  openSpatialSceneSync(
+    url: string,
+    config: SpatialSceneCreationOptionsInternal | undefined,
     target?: string,
     features?: string,
-    resultCallback?: (result: CommandResult) => void,
   ): WebSpatialProtocolResult
+
+  /** Create a native-backed spatial 2D surface (spatial div). */
+  createNativeSpatialDiv(): Promise<WebSpatialProtocolResult>
+
+  /** Create a native attachment surface; options reserved for future protocol fields. */
+  createNativeAttachment(
+    options?: AttachmentEntityOptions,
+  ): Promise<WebSpatialProtocolResult>
 }

--- a/packages/core/src/platform-adapter/pico-os/PicoOSPlatform.ts
+++ b/packages/core/src/platform-adapter/pico-os/PicoOSPlatform.ts
@@ -1,22 +1,31 @@
-import { PlatformAbility, CommandResult } from '../interface'
+import {
+  PlatformAbility,
+  CommandResult,
+  WebSpatialProtocolResult,
+} from '../interface'
 import {
   CommandResultFailure,
   CommandResultSuccess,
 } from '../CommandResultUtils'
+import { buildSpatialSceneQuery } from '../spatialSceneQuery'
 import { SpatialWebEvent } from '../../SpatialWebEvent'
+import type { SpatialSceneCreationOptionsInternal } from '../../types/internal'
+import type { AttachmentEntityOptions } from '../../types/types'
 
 interface JSBResponse {
   success: boolean
   data: any
 }
 type JSBError = {
-  code: string
+  code?: string
   message: string
 }
 
 let requestId = 0
 
 const MAX_ID = 100000
+const DEFAULT_JSB_ERROR_CODE = 'E_PICO_JSB'
+const DEFAULT_JSB_ERROR_MESSAGE = 'Pico JSB execution failed'
 
 function nextRequestId() {
   requestId = (requestId + 1) % MAX_ID
@@ -28,51 +37,67 @@ export class PicoOSPlatform implements PlatformAbility {
   async callJSB(cmd: string, msg: string): Promise<CommandResult> {
     // swan JS Bridge interface only support sync invoking
     // in order to implement promise API, register every request by requestId and remove when resolve/reject.
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       try {
         const rId = nextRequestId()
 
         SpatialWebEvent.addEventReceiver(rId, (result: JSBResponse) => {
           SpatialWebEvent.removeEventReceiver(rId)
-          if (result.success) {
-            resolve(CommandResultSuccess(result.data))
-          } else {
-            const { code, message } = result.data as JSBError
-            resolve(CommandResultFailure(code, message))
-          }
+          resolve(this.toCommandResult(result))
         })
 
         const ans = window.webspatialBridge.postMessage(rId, cmd, msg)
         if (ans !== '') {
           SpatialWebEvent.removeEventReceiver(rId)
           // sync call
-          const result = JSON.parse(ans) as JSBResponse
-          if (result.success) {
-            resolve(CommandResultSuccess(result.data))
-          } else {
-            const { code, message } = result.data as JSBError
-            resolve(CommandResultFailure(code, message))
-          }
+          resolve(this.parseBridgeResponse(ans))
         }
       } catch (error: unknown) {
         console.error(`SwanPlatform cmd: ${cmd}, msg: ${msg} error: ${error}`)
-        const { code, message } = error as JSBError
+        const { code, message } = this.parseJSBError(error)
         resolve(CommandResultFailure(code, message))
       }
     })
   }
 
-  async callWebSpatialProtocol(
-    command: string,
-    query?: string,
+  openSpatialSceneSync(
+    url: string,
+    config: SpatialSceneCreationOptionsInternal | undefined,
     target?: string,
     features?: string,
-  ): Promise<CommandResult> {
-    // Waiting for request to create spatial div
-    return new Promise((resolve, reject) => {
+  ): WebSpatialProtocolResult {
+    const query = buildSpatialSceneQuery(url, config)
+    const { spatialId: id = '', windowProxy } = this.openWindow(
+      'createSpatialScene',
+      query,
+      target,
+      features,
+    )
+
+    return CommandResultSuccess({ windowProxy, id })
+  }
+
+  createNativeSpatialDiv(): Promise<WebSpatialProtocolResult> {
+    return this.waitForRidProtocolAsync('createSpatialized2DElement')
+  }
+
+  createNativeAttachment(
+    _options?: AttachmentEntityOptions,
+  ): Promise<WebSpatialProtocolResult> {
+    return this.waitForRidProtocolAsync('createAttachment')
+  }
+
+  /**
+   * Async path for createNativeSpatialDiv / createNativeAttachment: open webspatial URL
+   * with rid= correlation (Pico OS 6).
+   */
+  private waitForRidProtocolAsync(
+    command: string,
+  ): Promise<WebSpatialProtocolResult> {
+    return new Promise(resolve => {
       const createdId = nextRequestId()
       try {
-        let windowProxy: any = null
+        let windowProxy: WindowProxy | null = null
         SpatialWebEvent.addEventReceiver(
           createdId,
           (result: { spatialId: string }) => {
@@ -85,34 +110,13 @@ export class PicoOSPlatform implements PlatformAbility {
             SpatialWebEvent.removeEventReceiver(createdId)
           },
         )
-        windowProxy = this.openWindow(
-          command,
-          'rid=' + createdId,
-          target,
-          features,
-        ).windowProxy
+        windowProxy = this.openWindow(command, 'rid=' + createdId).windowProxy
       } catch (error: unknown) {
-        const { code, message } = error as JSBError
+        const { code, message } = this.parseJSBError(error)
         SpatialWebEvent.removeEventReceiver(createdId)
         resolve(CommandResultFailure(code, message))
       }
     })
-  }
-
-  callWebSpatialProtocolSync(
-    command: string,
-    query?: string,
-    target?: string,
-    features?: string,
-  ): CommandResult {
-    const { spatialId: id = '', windowProxy } = this.openWindow(
-      command,
-      query,
-      target,
-      features,
-    )
-
-    return CommandResultSuccess({ windowProxy, id })
   }
 
   private openWindow(
@@ -120,12 +124,40 @@ export class PicoOSPlatform implements PlatformAbility {
     query?: string,
     target?: string,
     features?: string,
-  ) {
-    const windowProxy = window.open(
-      `webspatial://${command}?${query || ''}`,
-      target,
-      features,
-    )
+  ): { spatialId: string; windowProxy: WindowProxy | null } {
+    const url = query
+      ? `webspatial://${command}?${query}`
+      : `webspatial://${command}`
+    const windowProxy = window.open(url, target, features)
     return { spatialId: '', windowProxy }
+  }
+
+  private parseBridgeResponse(ans: string): CommandResult {
+    try {
+      const result = JSON.parse(ans) as JSBResponse
+      return this.toCommandResult(result)
+    } catch {
+      return CommandResultFailure(
+        DEFAULT_JSB_ERROR_CODE,
+        'Invalid Pico JSB response payload',
+      )
+    }
+  }
+
+  private toCommandResult(result: JSBResponse): CommandResult {
+    if (result.success) {
+      return CommandResultSuccess(result.data)
+    }
+    const { code, message } = this.parseJSBError(result.data)
+    return CommandResultFailure(code, message)
+  }
+
+  private parseJSBError(error: unknown): { code: string; message: string } {
+    return {
+      code: (error as JSBError)?.code ?? DEFAULT_JSB_ERROR_CODE,
+      message:
+        (error as JSBError)?.message ??
+        (typeof error === 'string' ? error : DEFAULT_JSB_ERROR_MESSAGE),
+    }
   }
 }

--- a/packages/core/src/platform-adapter/puppeteer/PuppeteerPlatform.ts
+++ b/packages/core/src/platform-adapter/puppeteer/PuppeteerPlatform.ts
@@ -1,4 +1,11 @@
-import { PlatformAbility, CommandResult } from '../interface'
+import {
+  PlatformAbility,
+  CommandResult,
+  WebSpatialProtocolResult,
+} from '../interface'
+import { buildSpatialSceneQuery } from '../spatialSceneQuery'
+import type { SpatialSceneCreationOptionsInternal } from '../../types/internal'
+import type { AttachmentEntityOptions } from '../../types/types'
 import {
   CommandResultFailure,
   CommandResultSuccess,
@@ -20,8 +27,6 @@ declare global {
 type JSBError = {
   message: string
 }
-
-console.log('PuppeteerPlatform')
 
 export class PuppeteerPlatform implements PlatformAbility {
   // store iframe instance
@@ -85,12 +90,37 @@ export class PuppeteerPlatform implements PlatformAbility {
     }
   }
 
-  callWebSpatialProtocol(
+  openSpatialSceneSync(
+    url: string,
+    config: SpatialSceneCreationOptionsInternal | undefined,
+    target?: string,
+    features?: string,
+  ): WebSpatialProtocolResult {
+    const query = buildSpatialSceneQuery(url, config)
+    return this.runProtocolSync('createSpatialScene', query, target, features)
+  }
+
+  createNativeSpatialDiv(): Promise<WebSpatialProtocolResult> {
+    return this.runProtocolAsync(
+      'createSpatialized2DElement',
+      '',
+      undefined,
+      undefined,
+    )
+  }
+
+  createNativeAttachment(
+    _options?: AttachmentEntityOptions,
+  ): Promise<WebSpatialProtocolResult> {
+    return this.runProtocolAsync('createAttachment', '', undefined, undefined)
+  }
+
+  private runProtocolAsync(
     command: string,
     query?: string,
     target?: string,
     features?: string,
-  ): Promise<CommandResult> {
+  ): Promise<WebSpatialProtocolResult> {
     console.log(
       `PuppeteerPlatform: Calling webspatial protocol: webspatial://${command}${query ? `?${query}` : ''}`,
     )
@@ -124,12 +154,12 @@ export class PuppeteerPlatform implements PlatformAbility {
     })
   }
 
-  callWebSpatialProtocolSync(
+  private runProtocolSync(
     command: string,
     query?: string,
     target?: string,
     features?: string,
-  ): CommandResult {
+  ): WebSpatialProtocolResult {
     try {
       // create complete webspatial URL
       const webspatialUrl = `webspatial://${command}${query ? `?${query}` : ''}`

--- a/packages/core/src/platform-adapter/spatialSceneQuery.ts
+++ b/packages/core/src/platform-adapter/spatialSceneQuery.ts
@@ -1,0 +1,17 @@
+import type { SpatialSceneCreationOptionsInternal } from '../types/internal'
+
+/** Build query string for webspatial://createSpatialScene (url + config). */
+export function buildSpatialSceneQuery(
+  url: string,
+  config: SpatialSceneCreationOptionsInternal | undefined,
+): string {
+  const params: Record<string, any> = { url, config }
+  return Object.keys(params)
+    .map(key => {
+      const value = params[key]
+      const finalValue =
+        typeof value === 'object' ? JSON.stringify(value) : value
+      return `${key}=${encodeURIComponent(finalValue)}`
+    })
+    .join('&')
+}

--- a/packages/core/src/platform-adapter/ssr/SSRPlatform.ts
+++ b/packages/core/src/platform-adapter/ssr/SSRPlatform.ts
@@ -3,6 +3,8 @@ import {
   PlatformAbility,
   WebSpatialProtocolResult,
 } from '../interface'
+import type { SpatialSceneCreationOptionsInternal } from '../../types/internal'
+import type { AttachmentEntityOptions } from '../../types/types'
 
 export class SSRPlatform implements PlatformAbility {
   callJSB(cmd: string, msg: string): Promise<CommandResult> {
@@ -13,25 +15,12 @@ export class SSRPlatform implements PlatformAbility {
       errorMessage: undefined,
     })
   }
-  callWebSpatialProtocol(
-    schema: string,
-    query?: string,
-    target?: string,
-    features?: string,
-  ): Promise<WebSpatialProtocolResult> {
-    return Promise.resolve({
-      success: true,
-      data: undefined,
-      errorCode: undefined,
-      errorMessage: undefined,
-    })
-  }
-  callWebSpatialProtocolSync(
-    schema: string,
-    query?: string,
-    target?: string,
-    features?: string,
-    resultCallback?: (result: CommandResult) => void,
+
+  openSpatialSceneSync(
+    _url: string,
+    _config: SpatialSceneCreationOptionsInternal | undefined,
+    _target?: string,
+    _features?: string,
   ): WebSpatialProtocolResult {
     return {
       success: true,
@@ -39,5 +28,25 @@ export class SSRPlatform implements PlatformAbility {
       errorCode: undefined,
       errorMessage: undefined,
     }
+  }
+
+  createNativeSpatialDiv(): Promise<WebSpatialProtocolResult> {
+    return Promise.resolve({
+      success: true,
+      data: undefined,
+      errorCode: undefined,
+      errorMessage: undefined,
+    })
+  }
+
+  createNativeAttachment(
+    _options?: AttachmentEntityOptions,
+  ): Promise<WebSpatialProtocolResult> {
+    return Promise.resolve({
+      success: true,
+      data: undefined,
+      errorCode: undefined,
+      errorMessage: undefined,
+    })
   }
 }

--- a/packages/core/src/platform-adapter/vision-os/VisionOSPlatform.ts
+++ b/packages/core/src/platform-adapter/vision-os/VisionOSPlatform.ts
@@ -1,12 +1,23 @@
-import { PlatformAbility, CommandResult } from '../interface'
+import {
+  PlatformAbility,
+  CommandResult,
+  WebSpatialProtocolResult,
+} from '../interface'
 import {
   CommandResultFailure,
   CommandResultSuccess,
 } from '../CommandResultUtils'
+import { buildSpatialSceneQuery } from '../spatialSceneQuery'
+import type { SpatialSceneCreationOptionsInternal } from '../../types/internal'
+import type { AttachmentEntityOptions } from '../../types/types'
 
 type JSBError = {
+  code?: string
   message: string
 }
+
+const UUID_RE =
+  /\b([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\b/gi
 
 export class VisionOSPlatform implements PlatformAbility {
   async callJSB(cmd: string, msg: string): Promise<CommandResult> {
@@ -17,36 +28,20 @@ export class VisionOSPlatform implements PlatformAbility {
       return CommandResultSuccess(result)
     } catch (error: unknown) {
       // console.error(`VisionOSPlatform cmd: ${cmd}, msg: ${msg} error: ${error}`)
-      const { code, message } = JSON.parse((error as JSBError).message)
+      const { code, message } = this.parseJSBError(error)
       return CommandResultFailure(code, message)
     }
   }
 
-  callWebSpatialProtocol(
-    command: string,
-    query?: string,
+  openSpatialSceneSync(
+    url: string,
+    config: SpatialSceneCreationOptionsInternal | undefined,
     target?: string,
     features?: string,
-  ): Promise<CommandResult> {
-    const { spatialId: id, windowProxy } = this.openWindow(
-      command,
-      query,
-      target,
-      features,
-    )
-    return Promise.resolve(
-      CommandResultSuccess({ windowProxy: windowProxy, id }),
-    )
-  }
-
-  callWebSpatialProtocolSync(
-    command: string,
-    query?: string,
-    target?: string,
-    features?: string,
-  ): CommandResult {
+  ): WebSpatialProtocolResult {
+    const query = buildSpatialSceneQuery(url, config)
     const { spatialId: id = '', windowProxy } = this.openWindow(
-      command,
+      'createSpatialScene',
       query,
       target,
       features,
@@ -55,22 +50,58 @@ export class VisionOSPlatform implements PlatformAbility {
     return CommandResultSuccess({ windowProxy, id })
   }
 
+  createNativeSpatialDiv(): Promise<WebSpatialProtocolResult> {
+    return this.openProtocolAsync('createSpatialized2DElement')
+  }
+
+  createNativeAttachment(
+    _options?: AttachmentEntityOptions,
+  ): Promise<WebSpatialProtocolResult> {
+    return this.openProtocolAsync('createAttachment')
+  }
+
+  private async openProtocolAsync(
+    command: string,
+  ): Promise<WebSpatialProtocolResult> {
+    const { spatialId: id = '', windowProxy } = this.openWindow(
+      command,
+      '',
+      undefined,
+      undefined,
+    )
+    return CommandResultSuccess({ windowProxy, id })
+  }
+
   private openWindow(
     command: string,
     query?: string,
     target?: string,
     features?: string,
-  ) {
+  ): { spatialId?: string; windowProxy: WindowProxy | null } {
     const windowProxy = window.open(
       `webspatial://${command}?${query || ''}`,
       target,
       features,
     )
     const ua = windowProxy?.navigator.userAgent
-    const spatialId = ua?.match(
-      /\b([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})\b/gi,
-    )?.[0]
+    const spatialId = ua?.match(UUID_RE)?.[0]
 
     return { spatialId, windowProxy }
+  }
+
+  private parseJSBError(error: unknown): { code: string; message: string } {
+    try {
+      const parsed = JSON.parse((error as JSBError).message ?? '')
+      return {
+        code: parsed.code ?? 'E_VISIONOS_JSB',
+        message: parsed.message ?? 'VisionOS JSB execution failed',
+      }
+    } catch {
+      return {
+        code: 'E_VISIONOS_JSB',
+        message:
+          (error as JSBError)?.message ?? 'VisionOS JSB execution failed',
+      }
+    }
   }
 }

--- a/packages/core/src/platform-runtime.ts
+++ b/packages/core/src/platform-runtime.ts
@@ -1,0 +1,13 @@
+import { createPlatformSync } from './platform-adapter'
+import type { PlatformAbility } from './platform-adapter/interface'
+
+let platformResolved: PlatformAbility | undefined
+
+export function getPlatformSync(): PlatformAbility {
+  platformResolved ??= createPlatformSync()
+  return platformResolved
+}
+
+export async function getPlatform(): Promise<PlatformAbility> {
+  return getPlatformSync()
+}

--- a/packages/core/src/reality/Attachment.ts
+++ b/packages/core/src/reality/Attachment.ts
@@ -1,9 +1,9 @@
 import { SpatialObject } from '../SpatialObject'
 import {
-  CreateAttachmentEntityCommand,
   UpdateAttachmentEntityCommand,
   InitializeAttachmentCommand,
 } from '../JSBCommand'
+import { createNativeAttachment } from '../spatial-host'
 import {
   AttachmentEntityOptions,
   AttachmentEntityUpdateOptions,
@@ -37,7 +37,7 @@ export class Attachment extends SpatialObject {
 export async function createAttachmentEntity(
   options: AttachmentEntityOptions,
 ): Promise<Attachment> {
-  const result = await new CreateAttachmentEntityCommand(options).execute()
+  const result = await createNativeAttachment(options)
   if (!result.success) {
     throw new Error('createAttachmentEntity failed: ' + result?.errorMessage)
   }

--- a/packages/core/src/scene-polyfill.manifest.test.ts
+++ b/packages/core/src/scene-polyfill.manifest.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('./spatial-host', () => ({
+  openSpatialSceneSync: vi.fn().mockReturnValue({
+    success: true,
+    data: { id: 'scene-1', windowProxy: {} },
+  }),
+}))
+
 vi.mock('./JSBCommand', () => {
   return {
-    createSpatialSceneCommand: vi.fn().mockImplementation(() => ({
-      executeSync: vi.fn().mockReturnValue({
-        data: { id: 'scene-1', windowProxy: {} },
-      }),
-    })),
     FocusScene: vi.fn().mockImplementation(() => ({
       execute: vi.fn().mockResolvedValue(undefined),
     })),

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -1,4 +1,5 @@
-import { createSpatialSceneCommand, FocusScene } from './JSBCommand'
+import { FocusScene } from './JSBCommand'
+import { openSpatialSceneSync } from './spatial-host'
 import { SpatialScene } from './SpatialScene'
 import {
   SpatialSceneCreationOptions,
@@ -221,8 +222,12 @@ class SceneManager {
       cfg = { ...ans, type: 'window' }
     }
 
-    const cmd = new createSpatialSceneCommand(url!, cfg, target, features)
-    const result = cmd.executeSync()
+    const result = openSpatialSceneSync(
+      url!,
+      cfg as SpatialSceneCreationOptionsInternal,
+      target,
+      features,
+    )
 
     const id = result.data?.id
 

--- a/packages/core/src/spatial-host.ts
+++ b/packages/core/src/spatial-host.ts
@@ -1,0 +1,25 @@
+import type { WebSpatialProtocolResult } from './platform-adapter/interface'
+import { getPlatform, getPlatformSync } from './platform-runtime'
+import type { SpatialSceneCreationOptionsInternal } from './types/internal'
+import type { AttachmentEntityOptions } from './types/types'
+
+export async function createNativeSpatialDiv(): Promise<WebSpatialProtocolResult> {
+  const platform = await getPlatform()
+  return platform.createNativeSpatialDiv()
+}
+
+export async function createNativeAttachment(
+  options: AttachmentEntityOptions,
+): Promise<WebSpatialProtocolResult> {
+  const platform = await getPlatform()
+  return platform.createNativeAttachment(options)
+}
+
+export function openSpatialSceneSync(
+  url: string,
+  config: SpatialSceneCreationOptionsInternal | undefined,
+  target?: string,
+  features?: string,
+): WebSpatialProtocolResult {
+  return getPlatformSync().openSpatialSceneSync(url, config, target, features)
+}


### PR DESCRIPTION
## Why
This PR focuses on a structural refactor in core-sdk: making platform capabilities explicit, reducing layering ambiguity, and improving adapter/type robustness.

## What changed
### 1) Platform capability model refactor
- Reworked `PlatformAbility` protocol methods into explicit spatial host capabilities:
  - `openSpatialSceneSync(url, config, target?, features?)`
  - `createNativeSpatialDiv()`
  - `createNativeAttachment(options?)`
- Removed ambiguous generic protocol dispatch usage from higher-level flows.

### 2) Added shared spatial host facade
- Added `packages/core/src/spatial-host.ts` as a single entry for scene/div/attachment operations.
- Centralized platform access (`getPlatform` / `getPlatformSync`) behind facade helpers.
- Updated callers to use facade instead of touching platform runtime directly where appropriate.

### 3) Simplified call path and removed redundant wrappers
- Removed protocol command wrapper layer for scene/div/attachment flows (no redundant command indirection).
- `scene-polyfill` now opens scenes via the facade + `openSpatialSceneSync`.
- Updated related imports/exports and tests accordingly.

### 4) Adapter cleanup and robustness improvements
- VisionOS adapter:
  - safer JSB error parsing fallback
  - less duplicated async protocol open logic
  - clearer `openWindow` typing and UUID extraction constant
- Pico OS adapter:
  - deduplicated JSB response-to-result conversion
  - safer bridge response parse and error fallback
  - cleaner URL construction and reduced redundant args
- SSR/Puppeteer paths aligned with explicit capability interface.

### 5) Type modeling improvements
- Made `CommandResult` generic (`CommandResult<T>`).
- Derived `WebSpatialProtocolResult` from generic result type to avoid duplicated field declarations.
- Relaxed `windowProxy` payload typing to support real browser proxies and puppeteer simulated proxy objects without cross-package type conflicts.

### 6) Release metadata
- Added changeset for `@webspatial/core-sdk` patch release:
  - `.changeset/quick-peas-turn.md`

## Key files touched
- `packages/core/src/platform-adapter/interface.ts`
- `packages/core/src/platform-adapter/CommandResultUtils.ts`
- `packages/core/src/platform-adapter/{vision-os,pico-os,puppeteer,ssr}/*`
- `packages/core/src/platform-runtime.ts`
- `packages/core/src/spatial-host.ts`
- `packages/core/src/scene-polyfill.ts`
- `packages/core/src/SpatializedElementCreator.ts`
- `packages/core/src/reality/Attachment.ts`
- associated core tests

## Testing
- [x] `npx vitest run` in `packages/core`
- [x] `npm run build` in `packages/core`
- [x] `pnpm test --filter @webspatial/react-sdk`

## Notes
- This is a refactor-focused PR; behavior is preserved while API boundaries and internals are clarified.
- PR now contains one squashed commit for easier review.