### PR TITLE
chore(visionos): bump package version to 1.7.0

### DIFF
--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/platform-visionos",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Used to publish WebSpatial projects to Apple Vision Pro",
   "type": "commonjs",
   "main": "package.json",


### PR DESCRIPTION
### Motivation
- Bump `packages/visionOS/package.json` version to `1.7.0` to make feature detection testing more convenient.

### Description
- Updated the `version` field in `packages/visionOS/package.json` from `1.6.1` to `1.7.0` and committed the change with message `chore(visionos): bump package version to 1.7.0`.

### Testing
- Pre-commit checks (`prettier`, `node ./tools/scripts/check-filesize.js`, `node ./tools/scripts/check-valid-characters.js`) ran successfully during `git commit`, the change was committed, and a PR was opened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec8320788832c937faa90bf92b500)