### PR TITLE
[codex] Fix spatial child window style sync for CSS-in-JS updates

### DIFF
--- a/.changeset/sync-spatial-style-text.md
+++ b/.changeset/sync-spatial-style-text.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Sync CSS-in-JS style text updates into spatial child windows so dynamic class changes keep their matching styles in SpatialDiv and Attachment content.

--- a/.changeset/sync-spatial-style-text.md
+++ b/.changeset/sync-spatial-style-text.md
@@ -3,3 +3,5 @@
 ---
 
 Sync CSS-in-JS style text updates into spatial child windows so dynamic class changes keep their matching styles in SpatialDiv and Attachment content.
+
+Also scan the entire MutationObserver batch when deciding sync timing: if any record indicates an inline `<style>` change, the whole batch is scheduled as `immediate`, so a `<link rel=stylesheet>` record earlier in the same batch no longer downgrades co-occurring `<style>` text updates to the delayed path.

--- a/apps/test-server/src/pages/spatialStyleTest/StyledVisibilityComponent.tsx
+++ b/apps/test-server/src/pages/spatialStyleTest/StyledVisibilityComponent.tsx
@@ -2,36 +2,63 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import React from 'react'
 
-const Host = styled.div<{ $hidden?: boolean }>`
+const Panel = styled.div`
+  margin: 12px 0;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(18, 20, 30, 0.72);
+  color: #f8fafc;
+`
+
+const Title = styled.div`
+  margin-bottom: 8px;
+  font-weight: 600;
+`
+
+const Host = styled.div<{ $hidden?: boolean; $dimmed?: boolean }>`
   visibility: ${props => (props.$hidden ? 'hidden' : 'visible')};
+  opacity: ${props => (props.$dimmed ? 0.3 : 1)};
   position: relative;
   margin: 8px;
-  padding: 8px;
-  border-radius: 8px;
-  background: #eef;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  color: #0f172a;
+  background: #f8fafc;
   transform: ${props => (props.$hidden ? 'rotate(45deg)' : 'none')};
   --xr-back: ${props => (props.$hidden ? '24' : '100')};
 `
 
 const ToggleButton = styled.button`
-  margin: 8px 0;
-  padding: 6px 12px;
-  border: 1px solid #999;
+  margin: 8px 8px 8px 0;
+  padding: 7px 14px;
+  border: 1px solid #475569;
   border-radius: 6px;
-  background: #fff;
+  color: #e2e8f0;
+  background: #1e293b;
+  cursor: pointer;
+
+  &:hover {
+    background: #334155;
+  }
 `
 
 export function StyledVisibilityComponent() {
-  const [hidden, setHidden] = useState(true)
+  const [hidden, setHidden] = useState(false)
+  const [dimmed, setDimmed] = useState(false)
   return (
-    <div>
-      <div>Styled-components visibility on host</div>
+    <Panel>
+      <Title>Styled-components visibility on host</Title>
       <ToggleButton onClick={() => setHidden(v => !v)}>
         {hidden ? 'Show' : 'Hide'}
       </ToggleButton>
-      <Host enable-xr $hidden={hidden}>
+      <ToggleButton onClick={() => setDimmed(v => !v)}>
+        {dimmed ? 'Opacity 1' : 'Opacity 0.3'}
+      </ToggleButton>
+      <Host enable-xr $hidden={hidden} $dimmed={dimmed}>
         <div>Portaled content should follow host visibility via class</div>
       </Host>
-    </div>
+    </Panel>
   )
 }

--- a/packages/react/src/reality/components/AttachmentEntity.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.tsx
@@ -124,7 +124,7 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
     }
   }, [ctx, attachmentName])
 
-  useSyncHeadStyles(childWindow, { subtree: false })
+  useSyncHeadStyles(childWindow)
 
   // Update position/size when they change
   useEffect(() => {

--- a/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
@@ -85,9 +85,7 @@ function SpatializedContent<P extends ElementType>(
   const spatialized2DElement = spatializedElement as Spatialized2DElement
   const { windowProxy } = spatialized2DElement
 
-  useSyncHeadStyles(windowProxy, {
-    subtree: false,
-  })
+  useSyncHeadStyles(windowProxy)
 
   const name: string = (restProps as any)['data-name'] || ''
   useSyncDocumentTitle(windowProxy, spatialized2DElement, name)

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -167,4 +167,60 @@ describe('useSyncHeadStyles', () => {
 
     expect(syncParentHeadToChild).not.toHaveBeenCalled()
   })
+
+  it('prefers immediate when a batch mixes link stylesheet and style text changes', async () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = 'https://example.com/a.css'
+
+    const style = document.createElement('style')
+    const text = document.createTextNode('.a{padding:12px;}')
+    style.appendChild(text)
+
+    act(() => {
+      observers[0].callback(
+        [
+          {
+            type: 'childList',
+            target: document.head,
+            addedNodes: [link] as unknown as NodeList,
+            removedNodes: [] as unknown as NodeList,
+          } as unknown as MutationRecord,
+          {
+            type: 'characterData',
+            target: text,
+            addedNodes: [],
+            removedNodes: [],
+          } as unknown as MutationRecord,
+        ],
+        observers[0] as unknown as MutationObserver,
+      )
+    })
+    expect(syncParentHeadToChild).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
+    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
+
+    vi.advanceTimersByTime(1000)
+    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
 })

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -1,0 +1,131 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSyncHeadStyles } from './useSyncHeadStyles'
+import { syncParentHeadToChild } from './windowStyleSync'
+
+vi.mock('./windowStyleSync', () => ({
+  syncParentHeadToChild: vi.fn(),
+}))
+
+describe('useSyncHeadStyles', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const observers: Array<{
+    callback: MutationCallback
+    observe: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+  }> = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    observers.length = 0
+    ;(globalThis as any).MutationObserver = class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+
+      constructor(public callback: MutationCallback) {
+        observers.push(this)
+      }
+    }
+    vi.mocked(syncParentHeadToChild).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.MutationObserver = originalMutationObserver
+  })
+
+  it('syncs stylesheet text changes before the next timer tick', async () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    expect(observers).toHaveLength(1)
+    expect(observers[0].observe).toHaveBeenCalledWith(
+      document.head,
+      expect.objectContaining({
+        childList: true,
+        characterData: true,
+        subtree: true,
+      }),
+    )
+
+    const style = document.createElement('style')
+    const text = document.createTextNode('.a{padding:12px;}')
+    style.appendChild(text)
+
+    act(() => {
+      observers[0].callback(
+        [
+          {
+            type: 'characterData',
+            target: text,
+            addedNodes: [],
+            removedNodes: [],
+          } as unknown as MutationRecord,
+        ],
+        observers[0] as unknown as MutationObserver,
+      )
+    })
+    expect(syncParentHeadToChild).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
+    unmount()
+  })
+
+  it('coalesces multiple immediate stylesheet text changes in one microtask', async () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    const style = document.createElement('style')
+    const text = document.createTextNode('.a{padding:12px;}')
+    style.appendChild(text)
+    const mutation = {
+      type: 'characterData',
+      target: text,
+      addedNodes: [],
+      removedNodes: [],
+    } as unknown as MutationRecord
+
+    act(() => {
+      observers[0].callback(
+        [mutation],
+        observers[0] as unknown as MutationObserver,
+      )
+      observers[0].callback(
+        [mutation],
+        observers[0] as unknown as MutationObserver,
+      )
+    })
+    expect(syncParentHeadToChild).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
+    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
+    unmount()
+  })
+})

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -128,4 +128,43 @@ describe('useSyncHeadStyles', () => {
     expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
     unmount()
   })
+
+  it('cancels queued immediate sync on unmount', async () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    const style = document.createElement('style')
+    const text = document.createTextNode('.a{padding:12px;}')
+    style.appendChild(text)
+
+    act(() => {
+      observers[0].callback(
+        [
+          {
+            type: 'characterData',
+            target: text,
+            addedNodes: [],
+            removedNodes: [],
+          } as unknown as MutationRecord,
+        ],
+        observers[0] as unknown as MutationObserver,
+      )
+      unmount()
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(syncParentHeadToChild).not.toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -11,6 +11,10 @@ type SyncTiming = 'immediate' | 'delayed'
 
 function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {
   if (!Array.isArray(mutations) || mutations.length === 0) return null
+  // Scan the whole batch and take the highest priority across all records.
+  // `immediate` (inline <style> changes) wins over `delayed` (<link rel=stylesheet>),
+  // so a mixed batch is never downgraded to `delayed` by record ordering.
+  let hasDelayed = false
   for (const mutation of mutations) {
     if (mutation.type === 'characterData') {
       const parent = mutation.target.parentElement
@@ -28,11 +32,11 @@ function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {
       if (tag === 'STYLE') return 'immediate'
       if (tag === 'LINK') {
         const { rel } = node as HTMLLinkElement
-        if (rel && rel.toLowerCase() === 'stylesheet') return 'delayed'
+        if (rel && rel.toLowerCase() === 'stylesheet') hasDelayed = true
       }
     }
   }
-  return null
+  return hasDelayed ? 'delayed' : null
 }
 
 export function useSyncHeadStyles(

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -7,24 +7,32 @@ interface Options {
   immediate?: boolean
 }
 
-function defaultShouldSync(mutations?: MutationRecord[] | null) {
-  if (!Array.isArray(mutations) || mutations.length === 0) return false
+type SyncTiming = 'immediate' | 'delayed'
+
+function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {
+  if (!Array.isArray(mutations) || mutations.length === 0) return null
   for (const mutation of mutations) {
+    if (mutation.type === 'characterData') {
+      const parent = mutation.target.parentElement
+      if (parent?.tagName === 'STYLE') return 'immediate'
+    }
+
     const nodes: Node[] = [
+      mutation.target,
       ...Array.from(mutation.addedNodes),
       ...Array.from(mutation.removedNodes),
     ]
     for (const node of nodes) {
       if (!(node instanceof Element)) continue
       const tag = node.tagName
-      if (tag === 'STYLE') return true
+      if (tag === 'STYLE') return 'immediate'
       if (tag === 'LINK') {
         const { rel } = node as HTMLLinkElement
-        if (rel && rel.toLowerCase() === 'stylesheet') return true
+        if (rel && rel.toLowerCase() === 'stylesheet') return 'delayed'
       }
     }
   }
-  return false
+  return null
 }
 
 export function useSyncHeadStyles(
@@ -32,15 +40,25 @@ export function useSyncHeadStyles(
   options?: Options,
 ) {
   const delayMs = 100
-  const subtree = options?.subtree ?? false
+  const subtree = options?.subtree ?? true
   const immediate = options?.immediate ?? true
 
   useEffect(() => {
     if (!childWindow) return
 
     let timer: number | undefined
-    const scheduleSync = () => {
+    let immediateQueued = false
+    const scheduleSync = (timing: SyncTiming = 'delayed') => {
       if (timer) window.clearTimeout(timer)
+      if (timing === 'immediate') {
+        if (immediateQueued) return
+        immediateQueued = true
+        queueMicrotask(() => {
+          immediateQueued = false
+          syncParentHeadToChild(childWindow)
+        })
+        return
+      }
       timer = window.setTimeout(() => {
         syncParentHeadToChild(childWindow)
       }, delayMs)
@@ -49,10 +67,15 @@ export function useSyncHeadStyles(
     if (immediate) scheduleSync()
 
     const observer = new MutationObserver(mutations => {
-      if (!defaultShouldSync(mutations)) return
-      scheduleSync()
+      const timing = getSyncTiming(mutations)
+      if (!timing) return
+      scheduleSync(timing)
     })
-    observer.observe(document.head, { childList: true, subtree })
+    observer.observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree,
+    })
 
     return () => {
       if (timer) window.clearTimeout(timer)

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -48,6 +48,7 @@ export function useSyncHeadStyles(
 
     let timer: number | undefined
     let immediateQueued = false
+    let disposed = false
     const scheduleSync = (timing: SyncTiming = 'delayed') => {
       if (timer) window.clearTimeout(timer)
       if (timing === 'immediate') {
@@ -55,11 +56,13 @@ export function useSyncHeadStyles(
         immediateQueued = true
         queueMicrotask(() => {
           immediateQueued = false
+          if (disposed) return
           syncParentHeadToChild(childWindow)
         })
         return
       }
       timer = window.setTimeout(() => {
+        if (disposed) return
         syncParentHeadToChild(childWindow)
       }, delayMs)
     }
@@ -78,6 +81,7 @@ export function useSyncHeadStyles(
     })
 
     return () => {
+      disposed = true
       if (timer) window.clearTimeout(timer)
       observer.disconnect()
     }


### PR DESCRIPTION
## Summary

Fixes #1175.

This updates the React SDK head-style sync used by spatial child windows so CSS-in-JS updates are reflected when an existing `<style>` tag changes text content.

## Root Cause

`enable-xr` content is portaled into a child window. Libraries like styled-components can update an existing `<style>` text node when toggling dynamic classes. The previous `useSyncHeadStyles` observer only watched `childList` changes, so the child window could receive the new class before receiving the updated CSS rule. In visionOS runtime this showed up as spatial div content briefly losing styles such as padding after clicking the opacity toggle.

## Changes

- Observe `characterData` mutations in `document.head` so existing `<style>` text changes trigger sync.
- Sync style-tag mutations via a coalesced microtask to avoid the previous 100ms stale-style window while still merging bursty CSS-in-JS updates.
- Keep stylesheet link changes on the delayed path.
- Use the new default subtree style sync for spatial 2D elements and attachments.
- Add regression coverage for style text mutation sync and microtask coalescing.

## Validation

- `pnpm -C packages/react test`