### PR TITLE
visionOS: fix asset cache keying and add AssetCache (disk cache foundation)

### DIFF
--- a/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
+++ b/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		2B06AF302E4C1AF8000327E9 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				AssetCache.swift,
 				AttachmentManager.swift,
 				Dynamic3DManager.swift,
 				FileCoordinator.swift,

--- a/packages/visionOS/web-spatial/manager/AssetCache.swift
+++ b/packages/visionOS/web-spatial/manager/AssetCache.swift
@@ -1,0 +1,101 @@
+import CryptoKit
+import Foundation
+
+enum AssetCacheError: LocalizedError {
+    case invalidURL(String)
+    case invalidLocalURL(String)
+    case httpStatus(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidURL(s):
+            return "Failed to create URL from string: \(s)"
+        case let .invalidLocalURL(s):
+            return "Local file is not found: \(s)"
+        case let .httpStatus(code):
+            return "HTTP Error \(code)"
+        }
+    }
+}
+
+/// Disk-backed cache for remote 3D assets (models, textures).
+///
+/// Files are keyed by `sha256(absoluteURL)` and stored under
+/// `Caches/AssetStore/<2-char-shard>/<hash>.<ext>`. Calls return the existing
+/// local file when present; otherwise the asset is downloaded once and
+/// atomically published via `FileManager.replaceItemAt`.
+///
+/// Responses carrying `Cache-Control: no-store` are honored: the downloaded
+/// file is returned but never moved into the cache directory.
+///
+/// `file://` URLs are passed through to `pwaManager.getLocalResourceURL` and
+/// are not cached.
+actor AssetCache {
+    static let shared = AssetCache()
+
+    private let session: URLSession
+    private let cacheRoot: URL
+    private let fileManager = FileManager.default
+
+    private init() {
+        session = URLSession(configuration: .default)
+        cacheRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("AssetStore", isDirectory: true)
+    }
+
+    func localFileURL(for urlString: String) async throws -> URL {
+        if urlString.starts(with: "file://") {
+            guard let localUrl = URL(string: pwaManager.getLocalResourceURL(url: urlString)) else {
+                throw AssetCacheError.invalidLocalURL(urlString)
+            }
+            return localUrl
+        }
+
+        guard let url = URL(string: urlString) else {
+            throw AssetCacheError.invalidURL(urlString)
+        }
+
+        let hash = Self.sha256Hex(url.absoluteString)
+        let shard = String(hash.prefix(2))
+        let ext = url.pathExtension.isEmpty ? "bin" : url.pathExtension
+        let shardDir = cacheRoot.appendingPathComponent(shard, isDirectory: true)
+        let cachePath = shardDir.appendingPathComponent("\(hash).\(ext)")
+
+        if let attrs = try? fileManager.attributesOfItem(atPath: cachePath.path),
+           let size = attrs[.size] as? NSNumber, size.intValue > 0
+        {
+            return cachePath
+        }
+
+        let (tempURL, response) = try await session.download(from: url)
+
+        if let httpResponse = response as? HTTPURLResponse {
+            guard (200 ... 299).contains(httpResponse.statusCode) else {
+                throw AssetCacheError.httpStatus(httpResponse.statusCode)
+            }
+            if let cacheControl = httpResponse.value(forHTTPHeaderField: "Cache-Control"),
+               cacheControl.lowercased().contains("no-store")
+            {
+                return tempURL
+            }
+        }
+
+        try fileManager.createDirectory(at: shardDir, withIntermediateDirectories: true)
+
+        let stagingURL = shardDir.appendingPathComponent("\(UUID().uuidString).tmp")
+        try fileManager.moveItem(at: tempURL, to: stagingURL)
+
+        if fileManager.fileExists(atPath: cachePath.path) {
+            _ = try fileManager.replaceItemAt(cachePath, withItemAt: stagingURL)
+        } else {
+            try fileManager.moveItem(at: stagingURL, to: cachePath)
+        }
+
+        return cachePath
+    }
+
+    private static func sha256Hex(_ s: String) -> String {
+        let digest = SHA256.hash(data: Data(s.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/packages/visionOS/web-spatial/manager/Dynamic3DManager.swift
+++ b/packages/visionOS/web-spatial/manager/Dynamic3DManager.swift
@@ -71,52 +71,13 @@ class Dynamic3DManager {
     }
 
     static func loadResourceToLocal(_ urlString: String, loadComplete: @escaping (Result<URL, Error>) -> Void) {
-        // load local file
-        if urlString.starts(with: "file://") {
-            guard let localUrl = URL(string: pwaManager.getLocalResourceURL(url: urlString)) else {
-                loadComplete(.failure(NSError(domain: "Download Error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Local file is not found"])))
-                return
-            }
-            loadComplete(.success(localUrl))
-            return
-        }
-        // load net file
-        guard let url = URL(string: urlString) else {
-            loadComplete(.failure(NSError(domain: "Invalid URL", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to create URL from string: \(urlString)"])))
-            return
-        }
-        // Use an immutable URL to avoid capturing a mutable var in concurrent code
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(url.lastPathComponent)
-        let session = URLSession(configuration: URLSessionConfiguration.default)
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        print("start load")
-        let task = session.downloadTask(with: request, completionHandler: { location, response, error in
-            if let error = error {
+        Task {
+            do {
+                let url = try await AssetCache.shared.localFileURL(for: urlString)
+                loadComplete(.success(url))
+            } catch {
                 loadComplete(.failure(error))
-                return
             }
-            if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
-                let error = NSError(domain: "HTTP Error", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP Error \(httpResponse.statusCode)"])
-                loadComplete(.failure(error))
-                return
-            }
-            guard let location = location else {
-                loadComplete(.failure(NSError(domain: "Download Error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Download location is nil"])))
-                return
-            }
-            Task {
-                do {
-                    try await FileCoordinator.shared.moveReplacingIfExists(from: location, to: documentsUrl)
-                    print("load complete")
-                    loadComplete(.success(documentsUrl))
-                } catch {
-                    print("File operation error: \(error)")
-                    loadComplete(.failure(error))
-                }
-            }
-
-        })
-        task.resume()
+        }
     }
 }


### PR DESCRIPTION
Replaces the disk logic in Dynamic3DManager.loadResourceToLocal with a new AssetCache actor.

**Changes**
Key cache by sha256(URL) instead of filename (avoids collisions)
Return existing file if present (no forced re-download)
Store under Caches/AssetStore/
Use shared URLSession
Atomic writes via replaceItemAt
Honor Cache-Control: no-store (skip persistence)

**Structure**
Adds AssetCache.swift
loadResourceToLocal(...) now delegates to AssetCache
Callback unchanged → no caller updates

**Scope**
Disk cache only (no in-memory tier, eviction, or coalescing)

**Context**
Previous implementation keyed by filename and rewrote on every load, preventing reuse

This establishes the base layer for the resource manager work.