### PR TITLE
fix: Model ready promise not working

### DIFF
--- a/.changeset/lucky-drinks-press.md
+++ b/.changeset/lucky-drinks-press.md
@@ -1,0 +1,7 @@
+---
+'web-content': patch
+'@webspatial/react-sdk': patch
+'@webspatial/core-sdk': patch
+---
+
+Fix Model ready promise not working

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -15,7 +15,9 @@ function App() {
   const [playbackRate, setPlaybackRate] = useState(1.0)
   const [loop, setLoop] = useState(true)
   useEffect(() => {
-    modelRef.current!.ready?.then(() => logLine('ref.current.ready success'))
+    modelRef
+      .current!.ready?.then(() => logLine('ref.current.ready success'))
+      .catch(() => logLine('ref.current.ready error'))
   }, [logLine])
   // Monitor duration and pause state since there is no playback lifecycle events
   useEffect(() => {

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -42,6 +42,10 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * Used to reset the ready promise when the model URL changes.
    */
   private modelURL?: string
+  // @TODO: Deprecate modelURL property from Web and Swift code
+  get modelUrl(): string | undefined {
+    return this.modelURL
+  }
 
   /**
    * Caches the last sources array to detect changes.

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -108,7 +108,7 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
     // value needs to be sent to clear the old value
     // TODO: Can native side handle null instead of ''
     spatializedElement.updateProperties({
-      modelURL: modelURL ?? '',
+      modelURL: modelURL ?? (spatializedElement.modelUrl ? '' : modelURL),
       sources,
       autoplay: autoPlay,
       loop,


### PR DESCRIPTION
When src was not defined on a Model and a property changed the React code would send a blank value for the src parameter to clear out old values on the native side. But if there was no src defined to begin with this would incorrectly push a new source change update and reset the ready promise. When the src or sources property doesn't change the ready promise should not reset.