### PR TITLE
fix: setting currentTime to greater than Model animation duration

### DIFF
--- a/.changeset/four-hotels-change.md
+++ b/.changeset/four-hotels-change.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+fix: setting currentTime to greater than Model animation duration

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -203,7 +203,8 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * forwards the request to native.
    */
   set currentTime(value: number) {
-    this.updateProperties({ currentTime: this.clampTime(value) })
+    const time = Number.isNaN(value) ? 0 : clamp(value, 0, this.duration)
+    this.updateProperties({ currentTime: time })
   }
 
   /**
@@ -345,6 +346,11 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     const modelTransform = Array.from(transform.toFloat64Array())
     this.updateProperties({ modelTransform })
   }
+}
+
+// Equivalent of proposed Math.clamp
+function clamp(num: number, min: number, max: number) {
+  return num <= min ? min : num >= max ? max : num
 }
 
 type Static3DReceiveEventData =


### PR DESCRIPTION
According to HTML media specifications if the new playback position is later than the end of the media resource, then let it be the end of the media resource

https://meego.larkoffice.com/pico/issue/detail/7204454539