### PR TITLE
Coalesce rapid spatial transform updates to avoid bridge flooding (add repro & tests)

### DIFF
--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -69,6 +69,7 @@ import SpatialDivTest from './src/pages/spatialDivTest/index'
 import SpatialContentReadyThree from './src/pages/spatial-content-ready-three/index'
 import DropdownMenuTest from './src/pages/dropdown-menu-test/index'
 import RuntimeCapabilitiesPage from './src/pages/runtime-capabilities/index'
+import TranslateZRafRepro from './src/pages/translateZ-raf-repro/index'
 
 class ErrorBoundary extends React.Component<
   { children?: React.ReactNode },
@@ -240,6 +241,10 @@ function App() {
                 <Route path="/transform-verify" element={<TransformVerify />} />
                 <Route path="/static-3d-model" element={<Static3DModel />} />
                 <Route path="/visible-test" element={<VisibleTest />} />
+                <Route
+                  path="/translatez-raf-repro"
+                  element={<TranslateZRafRepro />}
+                />
                 <Route
                   path="/head-style-sync"
                   element={<HeadStyleSyncPage />}

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -100,6 +100,7 @@ export const routes = [
       { path: '/transform-verify', label: 'Transform Verify' },
       { path: '/static-3d-model', label: 'Static 3D Model' },
       { path: '/visible-test', label: 'Visible Test' },
+      { path: '/translatez-raf-repro', label: 'translateZ RAF Repro' },
     ],
   },
   {

--- a/apps/test-server/src/pages/translateZ-raf-repro/index.tsx
+++ b/apps/test-server/src/pages/translateZ-raf-repro/index.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { enableDebugTool } from '@webspatial/react-sdk'
+
+enableDebugTool()
+
+const finalZ = 200
+const totalFrames = 240
+const deltaZ = finalZ / totalFrames
+const deltaAngleY = 60 / totalFrames
+
+export default function TranslateZRafRepro() {
+  const divRef = useRef<HTMLDivElement>(null)
+  const rafRef = useRef<number | null>(null)
+  const [running, setRunning] = useState(false)
+  const [status, setStatus] = useState('Idle')
+
+  const stopAnimation = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    setRunning(false)
+  }, [])
+
+  const reset = useCallback(() => {
+    stopAnimation()
+    if (divRef.current) {
+      divRef.current.style.transform = 'translateZ(0px) rotateY(0deg)'
+    }
+    setStatus('Reset to translateZ(0px) rotateY(0deg)')
+  }, [stopAnimation])
+
+  const startAnimation = useCallback(() => {
+    stopAnimation()
+
+    let direction = 1
+    let z = 0
+    let yAngle = 0
+    let frame = 0
+    setRunning(true)
+
+    const tick = () => {
+      z += deltaZ * direction
+      yAngle += deltaAngleY * direction
+
+      if (divRef.current) {
+        divRef.current.style.transform = `translateZ(${z}px) rotateY(${yAngle}deg)`
+      }
+      setStatus(`frame=${frame} z=${z.toFixed(3)} angleY=${yAngle.toFixed(3)}`)
+
+      if (z >= finalZ) {
+        direction = -1
+      }
+
+      frame += 1
+      if (z > 0) {
+        rafRef.current = requestAnimationFrame(tick)
+      } else {
+        rafRef.current = null
+        setRunning(false)
+      }
+    }
+
+    tick()
+  }, [stopAnimation])
+
+  useEffect(() => stopAnimation, [stopAnimation])
+
+  return (
+    <div className="p-10 text-white min-h-screen">
+      <h1 className="text-2xl mb-4">translateZ RAF Repro</h1>
+      <p className="text-gray-300 mb-4 max-w-2xl">
+        Reproduces rapid requestAnimationFrame updates of a spatial div
+        transform from translateZ(0px) to translateZ(200px), with rotateY, and
+        back.
+      </p>
+      <div className="flex gap-3 mb-4">
+        <button
+          className="px-4 py-2 rounded bg-blue-600 disabled:bg-gray-600"
+          disabled={running}
+          onClick={startAnimation}
+        >
+          Start animation
+        </button>
+        <button className="px-4 py-2 rounded bg-gray-700" onClick={reset}>
+          Reset
+        </button>
+      </div>
+      <div className="text-sm text-gray-300 mb-8" data-testid="repro-status">
+        {status}
+      </div>
+      <div className="h-[360px] flex items-center justify-center border border-gray-700 rounded-lg bg-black/20">
+        <div
+          enable-xr
+          ref={divRef}
+          data-testid="translatez-raf-target"
+          className="w-64 h-64 rounded-xl bg-gradient-to-br from-green-400 to-emerald-700 shadow-2xl flex items-center justify-center text-black font-bold"
+          style={{ transform: 'translateZ(0px) rotateY(0deg)' }}
+        >
+          Spatial div
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/spatialized-container/context/PortalInstanceContext.coverage.test.ts
+++ b/packages/react/src/spatialized-container/context/PortalInstanceContext.coverage.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
 class DOMMatrixPolyfill {
+  input?: unknown
+
+  constructor(input?: unknown) {
+    this.input = input
+  }
+
   translate(x = 0, y = 0) {
     ;(this as any)._tx = ((this as any)._tx ?? 0) + x
     ;(this as any)._ty = ((this as any)._ty ?? 0) + y
@@ -20,6 +26,12 @@ class DOMMatrixPolyfill {
   }
 
   toFloat64Array() {
+    if (Array.isArray(this.input)) {
+      return new Float64Array(this.input as number[])
+    }
+    if (typeof this.input === 'number') {
+      return new Float64Array(16).fill(this.input)
+    }
     return new Float64Array(16)
   }
 }
@@ -123,6 +135,71 @@ describe('PortalInstanceObject', () => {
 
     expect((dom as any).__spatializedElement).toBe(spatializedElement)
     expect(typeof (dom as any).__innerSpatializedElement).toBe('function')
+  })
+
+  it('coalesces transform updates while bridge updates are in flight', async () => {
+    const { PortalInstanceObject } = await import('./PortalInstanceContext')
+    const computedStyle = makeComputedStyle({
+      position: 'fixed',
+      opacity: '1',
+      display: 'block',
+      '--xr-z-index': '0',
+      '--xr-back': '0',
+      '--xr-depth': '0',
+      'transform-origin': '0 0',
+      width: '100',
+      height: '50',
+    })
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue(computedStyle)
+
+    const callbacks: Record<string, any> = {}
+    const containerObject = {
+      onSpatialTransformVisibilityChange: vi.fn((id: string, cb: any) => {
+        callbacks[id] = cb
+      }),
+      offSpatialTransformVisibilityChange: vi.fn(),
+      querySpatialDomBySpatialId: vi.fn(),
+      queryParentSpatialDomBySpatialId: vi.fn(),
+    } as any
+
+    const dom = document.createElement('div')
+    dom.getBoundingClientRect = () => new DOMRect(0, 0, 100, 50)
+    containerObject.querySpatialDomBySpatialId.mockReturnValue(dom)
+
+    let resolveFirst!: () => void
+    const firstUpdate = new Promise<void>(resolve => {
+      resolveFirst = resolve
+    })
+    const spatializedElement = {
+      isDestroyed: false,
+      updateProperties: vi.fn(),
+      updateTransform: vi.fn(() => firstUpdate),
+    } as any
+
+    const portal = new PortalInstanceObject('sid', containerObject, null)
+    portal.init()
+    portal.attachSpatializedElement(spatializedElement)
+
+    const matrix = (value: number) =>
+      Array.from(new Float64Array(16).fill(value))
+
+    callbacks.sid({ transform: matrix(1), visibility: 'visible' })
+    portal.notify2DFrameChange()
+    callbacks.sid({ transform: matrix(2), visibility: 'visible' })
+    callbacks.sid({ transform: matrix(3), visibility: 'visible' })
+
+    expect(spatializedElement.updateTransform).toHaveBeenCalledTimes(1)
+
+    spatializedElement.updateTransform.mockResolvedValue(undefined)
+    resolveFirst()
+    await firstUpdate
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(spatializedElement.updateTransform).toHaveBeenCalledTimes(2)
+    const latestMatrix = spatializedElement.updateTransform.mock.calls[1]?.[0]
+    expect(Array.from(latestMatrix.toFloat64Array())).toEqual(
+      Array.from(new Float64Array(16).fill(3)),
+    )
   })
 
   it('adds fixed or root portal elements to scene', async () => {

--- a/packages/react/src/spatialized-container/context/PortalInstanceContext.ts
+++ b/packages/react/src/spatialized-container/context/PortalInstanceContext.ts
@@ -58,6 +58,8 @@ export class PortalInstanceObject {
 
   // cachedTransformVisibilityInfo used for cache transform visibility info
   private cachedTransformVisibilityInfo?: CachedTransformVisibilityInfo
+  private transformUpdateInFlight = false
+  private pendingTransformMatrix: DOMMatrix | null = null
   get transformMatrix() {
     return this.cachedTransformVisibilityInfo?.transformMatrix
   }
@@ -269,12 +271,52 @@ export class PortalInstanceObject {
     })
 
     // update transform
-    spatializedElement.updateTransform(this.transformMatrix!)
+    this.scheduleSpatializedElementTransformUpdate(
+      spatializedElement,
+      this.transformMatrix!,
+    )
 
     // assign spatializedElement to dom
     Object.assign(this.dom, {
       __spatializedElement: spatializedElement,
     })
+  }
+
+  private scheduleSpatializedElementTransformUpdate(
+    spatializedElement: SpatializedElement,
+    matrix: DOMMatrix,
+  ) {
+    this.pendingTransformMatrix = new DOMMatrix(
+      Array.from(matrix.toFloat64Array()),
+    )
+
+    if (this.transformUpdateInFlight) {
+      return
+    }
+
+    this.flushPendingTransformUpdate(spatializedElement)
+  }
+
+  private flushPendingTransformUpdate(spatializedElement: SpatializedElement) {
+    const matrix = this.pendingTransformMatrix
+    if (!matrix || spatializedElement.isDestroyed) {
+      this.pendingTransformMatrix = null
+      return
+    }
+
+    this.pendingTransformMatrix = null
+    this.transformUpdateInFlight = true
+
+    Promise.resolve(spatializedElement.updateTransform(matrix))
+      .catch(error => {
+        console.error('Failed to update spatialized element transform', error)
+      })
+      .finally(() => {
+        this.transformUpdateInFlight = false
+        if (this.pendingTransformMatrix && !spatializedElement.isDestroyed) {
+          this.flushPendingTransformUpdate(spatializedElement)
+        }
+      })
   }
 }
 


### PR DESCRIPTION
### Motivation
- Rapid `requestAnimationFrame` updates to a spatial element's CSS `transform` (e.g. `translateZ`) could race or flood the native bridge, causing the spatial div to disappear; the intent is to preserve the latest matrix while an in-flight bridge update completes.
- Provide an easy local repro to exercise the problem and add a regression test to prevent regressions.

### Description
- Implement coalescing of transform updates in `PortalInstanceObject` by introducing `pendingTransformMatrix` and `transformUpdateInFlight`, and replacing direct calls to `updateTransform` with `scheduleSpatializedElementTransformUpdate` / `flushPendingTransformUpdate` that only forwards the next update after the bridge call finishes; use `Array.from(matrix.toFloat64Array())` when storing the pending matrix.
- Add a unit test in `packages/react/src/spatialized-container/context/PortalInstanceContext.coverage.test.ts` that simulates an in-flight `updateTransform` and verifies multiple rapid transform events result in a single in-flight call and then a final call with the latest matrix.
- Add a test-server reproduction page `apps/test-server/src/pages/translateZ-raf-repro/index.tsx` that animates a spatial div from `translateZ(0px)` to `translateZ(200px)` (with `rotateY`) via `requestAnimationFrame`, and register the page in the SPA routes and sidebar for manual verification.

### Testing
- Ran the targeted unit tests: `pnpm --filter @webspatial/react-sdk test -- src/spatialized-container/context/PortalInstanceContext.coverage.test.ts`, and the test file passed (5 tests passed).
- Ran `prettier` and typecheck for the modified files; `prettier` formatted the modified files successfully and the react-package tests compiled for the targeted test file.
- Attempted full `tsc -p apps/test-server/tsconfig.json`; this failed due to existing unrelated CSS/SCSS side-effect import declaration errors in other test-server pages (missing ambient declarations for side-effect CSS imports) and not caused by these changes.
- Attempted a Puppeteer screenshot run to exercise the repro page, but the environment lacked system Chrome dependencies (`libatk-1.0.so.0`) so the headless browser could not be launched (this is an environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbef7e6f00832caa47035cf1bb46a1)