### PR TITLE
[codex] Align Node support policy

### DIFF
--- a/.changeset/fair-pugs-fry.md
+++ b/.changeset/fair-pugs-fry.md
@@ -8,8 +8,8 @@ longer resolves the vulnerable `jimp@0.22.x -> file-type@16.x` chain flagged
 by Dependabot. This keeps the existing icon loading and generation flow while
 refreshing the lockfile to patched transitive versions.
 
-The published package metadata now declares Node.js 20+ support to match the
-current dependency requirements, and CI verifies the workspace on Node.js 20
-and 22 instead of floating on `latest`.
+The published package metadata now declares Node.js 22+ support to match the
+current dependency requirements, and CI verifies the workspace on Node.js 22,
+24, and latest.
 
 Verified with `pnpm -C packages/cli test` and `pnpm audit --json`.

--- a/.changeset/fair-pugs-fry.md
+++ b/.changeset/fair-pugs-fry.md
@@ -1,10 +1,15 @@
 ---
 '@webspatial/builder': patch
+'@webspatial/platform-visionos': patch
 ---
 
 Upgrade the builder CLI image pipeline to `jimp` 1.x so the workspace no
 longer resolves the vulnerable `jimp@0.22.x -> file-type@16.x` chain flagged
 by Dependabot. This keeps the existing icon loading and generation flow while
 refreshing the lockfile to patched transitive versions.
+
+The published package metadata now declares Node.js 20+ support to match the
+current dependency requirements, and CI verifies the workspace on Node.js 20
+and 22 instead of floating on `latest`.
 
 Verified with `pnpm -C packages/cli test` and `pnpm audit --json`.

--- a/.github/workflows/auto-test-pages.yml
+++ b/.github/workflows/auto-test-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: 20
           cache: 'pnpm'
 
       - name: Record START_TIME

--- a/.github/workflows/auto-test-pages.yml
+++ b/.github/workflows/auto-test-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'latest'
           cache: 'pnpm'
 
       - name: Record START_TIME

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   version:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v4
@@ -26,7 +29,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       
       - name: Install dependencies and build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24, latest]
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v4

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       
       - name: Install dependencies and build

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
+          node-version: 20
           cache: 'pnpm'
       
       - name: Install dependencies and build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to WebSpatial! This document provide
 
 ### Required Tools
 
-- [Node.js 20+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
+- [Node.js 22+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
 - [XCode >= 15.4](https://apps.apple.com/us/app/xcode/id497799835?mt=12) (If building for VisionOS)
 - [VSCode](https://code.visualstudio.com/) Text editor (recommended)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to WebSpatial! This document provide
 
 ### Required Tools
 
-- [NodeJS/NPM](https://nodejs.org/en/download/package-manager) to run local test website
+- [Node.js 20+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
 - [XCode >= 15.4](https://apps.apple.com/us/app/xcode/id497799835?mt=12) (If building for VisionOS)
 - [VSCode](https://code.visualstudio.com/) Text editor (recommended)
 
@@ -30,10 +30,10 @@ git clone https://github.com/webspatial/webspatial-sdk.git
 cd webspatial-sdk
 ```
 
-2. Install pnpm and setup the project:
+2. Enable pnpm:
 ```sh
-npm install pnpm -g
-pnpm setup
+corepack enable
+corepack prepare pnpm@9.0.0 --activate
 ```
 
 3. Install packages and link to workspace for local development:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WebSpatial is a set of [minimal extensions to HTML/CSS/DOM APIs](https://tpac202
 
 ## Requirements
 
-- Node.js 20 or newer
+- Node.js 22 or newer
 - pnpm 9 or newer
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ WebSpatial is a set of [minimal extensions to HTML/CSS/DOM APIs](https://tpac202
 - [`@webspatial/builder`](./packages/cli/): tooling for previewing, building, and publishing packaged WebSpatial apps
 - [`@webspatial/platform-visionos`](./packages/visionOS/): the visionOS runtime package used by Builder
 
+## Requirements
+
+- Node.js 20 or newer
+- pnpm 9 or newer
+
 ## Documentation
 
 The current documentation lives at [webspatial.dev](https://webspatial.dev).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generateStaticSite": "./tools/scripts/generateWebsite.sh"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "pnpm": ">=9"
   },
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "changeset:pre-exit": "changeset pre exit alpha",
     "generateStaticSite": "./tools/scripts/generateWebsite.sh"
   },
+  "engines": {
+    "node": ">=20",
+    "pnpm": ">=9"
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Client CLI tool to Generate XRApp project for Apple Vision Pro",
   "type": "commonjs",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "bin": {
     "webspatial-builder": "bin/bundlepwa.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Client CLI tool to Generate XRApp project for Apple Vision Pro",
   "type": "commonjs",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=20"
   },
   "bin": {
     "webspatial-builder": "bin/bundlepwa.js"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,11 +12,13 @@ import { launch } from './lib/cmds/launch'
 import { shutdown } from './lib/cmds/shutdown'
 import { test } from './lib/cmds/test'
 
+const MIN_SUPPORTED_NODE_MAJOR = 20
+
 module.exports = async (): Promise<void> => {
-  if (major(process.versions.node) < 14) {
+  if (major(process.versions.node) < MIN_SUPPORTED_NODE_MAJOR) {
     throw new Error(
       `Current Node.js version is ${process.versions.node}.` +
-        ' Node.js version 14 or above is required to run XRAPP BUILDER.',
+        ` Node.js version ${MIN_SUPPORTED_NODE_MAJOR} or above is required to run XRAPP BUILDER.`,
     )
   }
   const program = new Command()

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,7 @@ import { launch } from './lib/cmds/launch'
 import { shutdown } from './lib/cmds/shutdown'
 import { test } from './lib/cmds/test'
 
-const MIN_SUPPORTED_NODE_MAJOR = 20
+const MIN_SUPPORTED_NODE_MAJOR = 22
 
 module.exports = async (): Promise<void> => {
   if (major(process.versions.node) < MIN_SUPPORTED_NODE_MAJOR) {

--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "package.json",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",

--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "package.json",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- declare Node.js 22+ and pnpm 9+ as the workspace requirements
- update published package `engines.node` metadata for Builder and the visionOS platform package
- align the Builder runtime Node guard with the new Node.js 22+ minimum
- verify main CI on Node 22, Node 24, and latest; keep release/preview workflows on Node 22
- keep the existing changeset at patch level per maintainer preference

## Verification
- `git diff --check`
- package JSON parse check for root, Builder, and visionOS manifests
- workflow YAML parse check for updated workflows
- `rg` check that old `Node.js 20`, `node-version: 20`, `>=20`, and stale Node guard references are gone
- `pnpm -C packages/cli test`