### PR TITLE
feat: add lazy loading support to Model

### DIFF
--- a/.changeset/odd-frogs-rest.md
+++ b/.changeset/odd-frogs-rest.md
@@ -1,0 +1,9 @@
+---
+'@webspatial/platform-visionos': minor
+'web-content': minor
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': minor
+'ci-test': minor
+---
+
+Add lazy loading support to Model

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -151,6 +151,36 @@ function App() {
         </span>
       </section>
       <Logger logs={logs} clearLog={clearLog} />
+      <Model
+        enable-xr
+        autoPlay
+        loading="lazy"
+        style={{
+          height: '200px',
+          '--xr-depth': '100px',
+          '--xr-back': '50px',
+          marginBottom: '20px',
+        }}
+      >
+        <source
+          src="https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz"
+          type="model/vnd.usdz+zip"
+        />
+        <img
+          src="/img/toy_drummer.png"
+          className="w-full h-[200px] object-contain"
+        />
+      </Model>
+      <Model
+        poster="/img/toy_drummer.png"
+        enable-xr
+        style={{
+          height: '200px',
+          '--xr-depth': '100px',
+          '--xr-back': '50px',
+          marginBottom: '20px',
+        }}
+      />
     </div>
   )
 }

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -23,6 +23,7 @@ import {
   Vec3,
   AttachmentEntityOptions,
   AttachmentEntityUpdateOptions,
+  ModelLoadingMode,
   ModelSource,
   SpatialTextureResourceOptions,
 } from './types/types'
@@ -291,14 +292,20 @@ export class CreateSpatializedStatic3DElementCommand extends JSBCommand {
   constructor(
     readonly modelURL?: string,
     readonly sources?: ModelSource[],
+    readonly loading: ModelLoadingMode = 'eager',
   ) {
     super()
     this.modelURL = modelURL
     this.sources = sources
+    this.loading = loading
   }
 
   protected getParams() {
-    return { modelURL: this.modelURL, sources: this.sources }
+    return {
+      modelURL: this.modelURL,
+      sources: this.sources,
+      loading: this.loading,
+    }
   }
 }
 

--- a/packages/core/src/SpatialSession.ts
+++ b/packages/core/src/SpatialSession.ts
@@ -21,6 +21,7 @@ import {
   SpatialTextureResourceOptions,
   SpatialEntityUserData,
   AttachmentEntityOptions,
+  ModelLoadingMode,
   ModelSource,
 } from './types/types'
 import { SpatializedDynamic3DElement } from './SpatializedDynamic3DElement'
@@ -70,13 +71,16 @@ export class SpatialSession {
    * Creates a new static 3D element with an optional model URL.
    * Static 3D elements represent pre-built 3D models that can be loaded from a URL.
    * @param modelURL Optional URL to the 3D model to load
+   * @param sources Optional list of fallback model sources
+   * @param loading Whether the asset should fetch eagerly or be deferred (`'lazy'`)
    * @returns Promise resolving to a new SpatializedStatic3DElement instance
    */
   createSpatializedStatic3DElement(
     modelURL?: string,
     sources?: ModelSource[],
+    loading: ModelLoadingMode = 'eager',
   ): Promise<SpatializedStatic3DElement> {
-    return createSpatializedStatic3DElement(modelURL, sources)
+    return createSpatializedStatic3DElement(modelURL, sources, loading)
   }
 
   /**

--- a/packages/core/src/SpatializedElementCreator.ts
+++ b/packages/core/src/SpatializedElementCreator.ts
@@ -6,7 +6,7 @@ import { Spatialized2DElement } from './Spatialized2DElement'
 import { SpatializedStatic3DElement } from './SpatializedStatic3DElement'
 import { SpatializedDynamic3DElement } from './SpatializedDynamic3DElement'
 import { createNativeSpatialDiv } from './spatial-host'
-import { ModelSource } from './types/types'
+import { ModelLoadingMode, ModelSource } from './types/types'
 
 export async function createSpatialized2DElement(): Promise<Spatialized2DElement> {
   const result = await createNativeSpatialDiv()
@@ -24,16 +24,18 @@ export async function createSpatialized2DElement(): Promise<Spatialized2DElement
 export async function createSpatializedStatic3DElement(
   modelURL?: string,
   sources?: ModelSource[],
+  loading: ModelLoadingMode = 'eager',
 ): Promise<SpatializedStatic3DElement> {
   const result = await new CreateSpatializedStatic3DElementCommand(
     modelURL,
     sources,
+    loading,
   ).execute()
   if (!result.success) {
     throw new Error('createSpatializedStatic3DElement failed')
   } else {
     const { id } = result.data
-    return new SpatializedStatic3DElement(id, modelURL, sources)
+    return new SpatializedStatic3DElement(id, modelURL, sources, loading)
   }
 }
 

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -1,6 +1,7 @@
 import { UpdateSpatializedStatic3DElementProperties } from './JSBCommand'
 import { ReceiveEventData, SpatializedElement } from './SpatializedElement'
 import {
+  ModelLoadingMode,
   ModelSource,
   SpatializedStatic3DElementProperties,
 } from './types/types'
@@ -24,11 +25,18 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    * @param id Unique identifier for this element
    * @param modelURL URL of the 3D model
    * @param sources Optional fallback model sources
+   * @param loading Initial loading mode (`'eager'` by default)
    */
-  constructor(id: string, modelURL?: string, sources?: ModelSource[]) {
+  constructor(
+    id: string,
+    modelURL?: string,
+    sources?: ModelSource[],
+    loading: ModelLoadingMode = 'eager',
+  ) {
     super(id)
     this.modelURL = modelURL
     this.sources = sources
+    this._loading = loading
   }
 
   /**
@@ -126,6 +134,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       // the requested seek without waiting for the next native sample.
       this._currentTime = properties.currentTime
       this._anchorTimestamp = Date.now()
+    }
+    if (properties.loading !== undefined) {
+      this._loading = properties.loading
     }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
@@ -302,6 +313,16 @@ export class SpatializedStatic3DElement extends SpatializedElement {
    */
   get autoplay(): boolean {
     return this._autoplay
+  }
+
+  /**
+   * Asset fetch policy. `'lazy'` defers fetching until the host signals the
+   * element is in view; `'eager'` fetches immediately.
+   */
+  private _loading: ModelLoadingMode = 'eager'
+
+  get loading(): ModelLoadingMode {
+    return this._loading
   }
 
   /**

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -100,6 +100,8 @@ export interface ModelSource {
   type?: string
 }
 
+export type ModelLoadingMode = 'eager' | 'lazy'
+
 export interface SpatializedStatic3DElementProperties
   extends SpatializedElementProperties {
   modelURL: string
@@ -111,6 +113,7 @@ export interface SpatializedStatic3DElementProperties
   playbackRate?: number
   currentTime?: number
   posterURL?: string
+  loading?: ModelLoadingMode
 }
 
 export interface SpatialSceneCreationOptions {

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1891,6 +1891,7 @@ describe('SpatializedStatic3DElementContainer', () => {
     expect(createSpatializedStatic3DElement).toHaveBeenCalledWith(
       window.location.origin + '/m.glb',
       [],
+      'eager',
     )
 
     expect(updateProperties).toHaveBeenCalledWith({
@@ -1899,6 +1900,7 @@ describe('SpatializedStatic3DElementContainer', () => {
       autoplay: undefined,
       loop: undefined,
       posterURL: '',
+      loading: 'eager',
     })
 
     spatializedStatic3DElement.onLoadCallback?.()

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import { SpatializedContainer } from './SpatializedContainer'
 import { getSession } from '../utils'
@@ -18,7 +19,11 @@ import {
   SpatializedStatic3DContentProps,
   SpatializedStatic3DElementRef,
 } from './types'
-import { ModelSource, SpatializedStatic3DElement } from '@webspatial/core-sdk'
+import {
+  ModelLoadingMode,
+  ModelSource,
+  SpatializedStatic3DElement,
+} from '@webspatial/core-sdk'
 import { PortalInstanceContext } from './context/PortalInstanceContext'
 
 function getAbsoluteURL(url: string): string
@@ -92,13 +97,42 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
     onError,
     autoPlay,
     loop,
+    loading,
   } = props
-
   const portalInstanceObject = useContext(PortalInstanceContext)!
+  const [effectiveLoading, setEffectiveLoading] = useState<ModelLoadingMode>(
+    () => (loading === 'lazy' ? 'lazy' : 'eager'),
+  )
 
   const modelURL = useMemo(() => getAbsoluteURL(src), [src])
   const posterURL = useMemo(() => getAbsoluteURL(poster), [poster])
   const sources = useMemo(() => collectSources(children), [children])
+  const sourcesKey = useMemo(() => JSON.stringify(sources), [sources])
+
+  useEffect(() => {
+    setEffectiveLoading(loading === 'lazy' ? 'lazy' : 'eager')
+  }, [loading, modelURL, sourcesKey])
+
+  // `effectiveLoading` is `'lazy'` only while `loading === 'lazy'` and the
+  // portal element has not yet intersected the viewport. Once it flips to
+  // `'eager'` the observer disconnects and the value sticks until the sources
+  // change while still requested as lazy.
+  useEffect(() => {
+    if (effectiveLoading !== 'lazy') return
+    const target = portalInstanceObject.dom
+    if (!target || typeof IntersectionObserver === 'undefined') {
+      setEffectiveLoading('eager')
+      return
+    }
+    const observer = new IntersectionObserver(entries => {
+      if (entries.some(entry => entry.isIntersecting)) {
+        setEffectiveLoading('eager')
+        observer.disconnect()
+      }
+    })
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [effectiveLoading, portalInstanceObject])
 
   useEffect(() => {
     // If modelURL was previously set and now is undefined then a dummy
@@ -110,8 +144,9 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       autoplay: autoPlay,
       loop,
       posterURL: posterURL ?? '',
+      loading: effectiveLoading,
     })
-  }, [modelURL, JSON.stringify(sources), autoPlay, loop, posterURL])
+  }, [modelURL, sourcesKey, autoPlay, loop, posterURL, effectiveLoading])
 
   useEffect(() => {
     if (onLoad) {
@@ -154,6 +189,7 @@ function SpatializedStatic3DElementContainerBase(
     promiseRef.current = getSession()!.createSpatializedStatic3DElement(
       getAbsoluteURL(props.src),
       collectSources(props.children),
+      props.loading === 'lazy' ? 'lazy' : 'eager',
     )
     return promiseRef.current
   }, [])

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -1,6 +1,7 @@
 import React, { ElementType } from 'react'
 import { SpatialID } from './SpatialID'
 import {
+  ModelLoadingMode,
   SpatializedElement,
   SpatialTapEvent as CoreSpatialTapEvent,
   SpatialDragEvent as CoreSpatialDragEvent,
@@ -103,6 +104,7 @@ export type SpatializedStatic3DContainerProps =
       poster?: string
       autoPlay?: boolean
       loop?: boolean
+      loading?: ModelLoadingMode
       children?: React.ReactNode
       onLoad?: (event: ModelLoadEvent) => void
       onError?: (event: ModelLoadEvent) => void
@@ -115,6 +117,7 @@ export type SpatializedStatic3DContentProps = {
   poster?: string
   autoPlay?: boolean
   loop?: boolean
+  loading?: ModelLoadingMode
   children?: React.ReactNode
   onLoad?: (event: ModelLoadEvent) => void
   onError?: (event: ModelLoadEvent) => void

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -16,6 +16,7 @@ struct CreateSpatializedStatic3DElement: CommandDataProtocol {
     static let commandType: String = "CreateSpatializedStatic3DElement"
     let modelURL: String?
     let sources: [ModelSource]?
+    let loading: String?
 }
 
 struct CreateSpatializedDynamic3DElement: CommandDataProtocol {
@@ -276,6 +277,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
     let playbackRate: Double?
     let currentTime: Double?
     let posterURL: String?
+    let loading: String?
 }
 
 struct UpdateSpatializedDynamic3DElementProperties: SpatializedElementProperties {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -550,6 +550,9 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
         if let sources = command.sources {
             spatialObject.sources = sources
         }
+        if let loading = command.loading {
+            spatialObject.loading = loading
+        }
 
         resolve(.success(AddSpatializedElementReply(id: spatialObject.id)))
     }
@@ -637,6 +640,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
 
         if let posterURL = command.posterURL {
             spatializedElement.posterURL = posterURL.isEmpty ? nil : posterURL
+        }
+
+        if let loading = command.loading {
+            spatializedElement.loading = loading
         }
 
         resolve(.success(baseReplyData))

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -19,7 +19,11 @@ class SpatializedStatic3DElement: SpatializedElement {
     /// `SpatializedStatic3DView`, which clears it back to `nil`.
     var pendingSeekTime: Double?
     var posterURL: String?
+    /// `"eager"` (default) fetches the model immediately; `"lazy"` defers
+    /// fetching until the web layer flips it back to `"eager"`.
+    var loading: String = "eager"
     var allSources: [ModelSource] {
+        guard loading == "eager" else { return [] }
         return if let modelURL {
             [ModelSource(src: modelURL, type: nil)] + sources
         } else { sources }


### PR DESCRIPTION
Implement loading="lazy" so the asset isn't fetched until the portal element intersects the viewport. The React container uses an IntersectionObserver to flip effectiveLoading from lazy to eager (sticky) and forwards the value through JSB. The native visionOS layer gates allSources on loading == "eager", which lets the existing EmptyView() branch defer fetch, poster, and autoplay for free.

Closes #1190
https://claude.ai/code/session_01BKL86L3kDE3mmr2Rh97UiP

https://github.com/user-attachments/assets/6a4d6429-ea48-441c-82cb-b93956a1ffe7


