### PR TITLE
update Auto test package pipeline to use specific Puppeteer Chrome Version

### DIFF
--- a/.github/workflows/auto-test-pages.yml
+++ b/.github/workflows/auto-test-pages.yml
@@ -23,7 +23,9 @@ jobs:
     timeout-minutes: 20
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      START_TIME: ${{ github.run_started_at }}
       GITHUB_WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PUPPETEER_SKIP_DOWNLOAD: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,30 +41,20 @@ jobs:
           node-version: 'latest'
           cache: 'pnpm'
 
-      - name: Record START_TIME
-        run: echo "START_TIME=$(date -u '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+      - name: Setup Chrome for Puppeteer
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: 145.0.7632.77
+          install-dependencies: true
+
+      - name: Export Chrome path
+        run: |
+          echo "PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
       - name: Install autotest and build required packages
         run: pnpm -F autotest run setup-local
-
-      - name: Cache Puppeteer browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/puppeteer
-          key: ${{ runner.os }}-puppeteer-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Prune incomplete Puppeteer Chrome cache
-        run: |
-          if [ -d "$HOME/.cache/puppeteer/chrome" ]; then
-            find "$HOME/.cache/puppeteer/chrome" -mindepth 1 -maxdepth 1 -type d | while read -r browser_dir; do
-              if [ ! -x "$browser_dir/chrome-linux64/chrome" ]; then
-                rm -rf "$browser_dir"
-              fi
-            done
-          fi
-
-      - name: Install Chrome for Puppeteer
-        run: pnpm --filter autotest exec puppeteer browsers install chrome
 
       - name: Run mocha in autoTest package
         continue-on-error: true


### PR DESCRIPTION
- add `Setup Chrome for Puppeteer` in auto-test-page.yml
- install chrome for puppeteer before installing dependencies for autoTest package.