### PR TITLE
fix(react): make spatial container ref a real DOM node

### DIFF
--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -15,6 +15,8 @@ Internally, the standard host's hidden-placeholder appearance (`visibility: hidd
 
 The hidden-host stylesheet is now injected into each host's containing tree root on mount (including `ShadowRoot`s used by web components / micro-frontends / shadow-isolated design systems). Without this, the document-level stylesheet would not cross shadow boundaries and the bare 2D placeholder would show through — a side-effect of moving the hidden-placeholder rules out of inline style. The injection is idempotent per root via a `data-xr-spatial-default-style` marker on the `<style>` element. As an incidental fix, the `--xr-back` / `--xr-depth` / `--xr-z-index` / `--xr-background-material` defaults now also reach spatial containers mounted inside shadow roots.
 
+Known limitation: the per-mount injection is currently keyed on `root === document` and so does not cover spatial hosts mounted inside same-origin iframes / other foreign `Document` instances — those will see the bare 2D placeholder until [#1197](https://github.com/webspatial/webspatial-sdk/issues/1197) ships. As a workaround, call `injectSpatialDefaultStyle()` once from inside the iframe's own realm.
+
 The architectural invariants behind the standard-host / probe split, the spatial style proxy, and the `xr-spatial-default` / `data-xr-host` contracts are documented in `packages/react/src/spatialized-container/ARCHITECTURE.md` for future maintainers.
 
 Note: the previously undocumented `ref.current.__raw` field is removed; use `ref.current` directly.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -13,4 +13,6 @@ Spatial behavior (auto `xr-spatial-default` className, `style.transform` / `styl
 
 Internally, the standard host's hidden-placeholder appearance (`visibility: hidden`, `transition: none`, `transform: none | translateZ(0)`) is no longer written as inline style — it is now applied via CSS rules keyed on the new `data-xr-host` and `data-xr-transform-active` attributes. This is required so that React commits do not write through the spatial style proxy and clobber the user's `style.transform` value on the probe. Visual behavior is unchanged.
 
+The architectural invariants behind the standard-host / probe split, the spatial style proxy, and the `xr-spatial-default` / `data-xr-host` contracts are documented in `packages/react/src/spatialized-container/ARCHITECTURE.md` for future maintainers.
+
 Note: the previously undocumented `ref.current.__raw` field is removed; use `ref.current` directly.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -13,6 +13,8 @@ Spatial behavior (auto `xr-spatial-default` className, `style.transform` / `styl
 
 Internally, the standard host's hidden-placeholder appearance (`visibility: hidden`, `transition: none`, `transform: none | translateZ(0)`) is no longer written as inline style — it is now applied via CSS rules keyed on the new `data-xr-host` and `data-xr-transform-active` attributes. This is required so that React commits do not write through the spatial style proxy and clobber the user's `style.transform` value on the probe. Visual behavior is unchanged.
 
+The hidden-host stylesheet is now injected into each host's containing tree root on mount (including `ShadowRoot`s used by web components / micro-frontends / shadow-isolated design systems). Without this, the document-level stylesheet would not cross shadow boundaries and the bare 2D placeholder would show through — a side-effect of moving the hidden-placeholder rules out of inline style. The injection is idempotent per root via a `data-xr-spatial-default-style` marker on the `<style>` element. As an incidental fix, the `--xr-back` / `--xr-depth` / `--xr-z-index` / `--xr-background-material` defaults now also reach spatial containers mounted inside shadow roots.
+
 The architectural invariants behind the standard-host / probe split, the spatial style proxy, and the `xr-spatial-default` / `data-xr-host` contracts are documented in `packages/react/src/spatialized-container/ARCHITECTURE.md` for future maintainers.
 
 Note: the previously undocumented `ref.current.__raw` field is removed; use `ref.current` directly.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -2,6 +2,13 @@
 '@webspatial/react-sdk': patch
 ---
 
-Make spatial container `ref.current` a real DOM node. The standard host element is no longer wrapped in a `Proxy`; spatial behavior (style proxy for `transform` / `visibility`, auto-applied `xr-spatial-default` className, `xrClientDepth` / `xrOffsetBack` accessors, `extraRefProps`) is now installed on the underlying `HTMLElement` via `Object.defineProperty`.
+`ref.current` on spatial containers (`SpatialDiv`, `Model`, `Spatialized2DElementContainer`, `Reality` entities) is now the real underlying `HTMLElement` instead of a `Proxy` wrapper. As a result:
 
-This fixes native DOM API usage on `ref.current` (`instanceof Node`, `parent.contains`, `getComputedStyle`, `MutationObserver`, etc.) and removes the need for the global `getComputedStyle` hijack and the private `__raw` / `__targetProxy` indirection. As a side effect, `el.removeAttribute('id' /* or any non-spatial name */)` now correctly delegates to the native call instead of being silently dropped.
+- `ref.current instanceof HTMLElement` (and `instanceof Node`) is `true`.
+- `parent.contains(ref.current)`, `document.querySelector(...) === ref.current`, `MutationObserver.observe(ref.current)`, and `getComputedStyle(ref.current)` work without any polyfill.
+- `ref.current.removeAttribute('id' /* or any name other than 'style' / 'class' */)` now correctly removes the attribute — previously it was silently dropped.
+- `ref.current.style.setProperty('transform', value, 'important')` now preserves the `priority` argument when forwarding to the spatial transform layer.
+
+Spatial behavior (auto `xr-spatial-default` className, `style.transform` / `style.visibility` proxying, `xrClientDepth` / `xrOffsetBack` accessors, `extraRefProps`) is unchanged.
+
+Note: the previously undocumented `ref.current.__raw` field is removed; use `ref.current` directly.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Make spatial container `ref.current` a real DOM node. The standard host element is no longer wrapped in a `Proxy`; spatial behavior (style proxy for `transform` / `visibility`, auto-applied `xr-spatial-default` className, `xrClientDepth` / `xrOffsetBack` accessors, `extraRefProps`) is now installed on the underlying `HTMLElement` via `Object.defineProperty`.
+
+This fixes native DOM API usage on `ref.current` (`instanceof Node`, `parent.contains`, `getComputedStyle`, `MutationObserver`, etc.) and removes the need for the global `getComputedStyle` hijack and the private `__raw` / `__targetProxy` indirection. As a side effect, `el.removeAttribute('id' /* or any non-spatial name */)` now correctly delegates to the native call instead of being silently dropped.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -11,4 +11,6 @@
 
 Spatial behavior (auto `xr-spatial-default` className, `style.transform` / `style.visibility` proxying, `xrClientDepth` / `xrOffsetBack` accessors, `extraRefProps`) is unchanged.
 
+Internally, the standard host's hidden-placeholder appearance (`visibility: hidden`, `transition: none`, `transform: none | translateZ(0)`) is no longer written as inline style — it is now applied via CSS rules keyed on the new `data-xr-host` and `data-xr-transform-active` attributes. This is required so that React commits do not write through the spatial style proxy and clobber the user's `style.transform` value on the probe. Visual behavior is unchanged.
+
 Note: the previously undocumented `ref.current.__raw` field is removed; use `ref.current` directly.

--- a/.changeset/spatial-ref-real-dom-node.md
+++ b/.changeset/spatial-ref-real-dom-node.md
@@ -5,7 +5,7 @@
 `ref.current` on spatial containers (`SpatialDiv`, `Model`, `Spatialized2DElementContainer`, `Reality` entities) is now the real underlying `HTMLElement` instead of a `Proxy` wrapper. As a result:
 
 - `ref.current instanceof HTMLElement` (and `instanceof Node`) is `true`.
-- `parent.contains(ref.current)`, `document.querySelector(...) === ref.current`, `MutationObserver.observe(ref.current)`, and `getComputedStyle(ref.current)` work without any polyfill.
+- Native APIs that brand-check `Element` now accept `ref.current` directly — `ResizeObserver.observe(ref.current)` (#1067), `IntersectionObserver.observe(ref.current)`, `MutationObserver.observe(ref.current, …)`, `parent.contains(ref.current)`, `document.querySelector(...) === ref.current`, and `getComputedStyle(ref.current)` all work without any polyfill.
 - `ref.current.removeAttribute('id' /* or any name other than 'style' / 'class' */)` now correctly removes the attribute — previously it was silently dropped.
 - `ref.current.style.setProperty('transform', value, 'important')` now preserves the `priority` argument when forwarding to the spatial transform layer.
 

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -617,7 +617,7 @@ describe('spatialized-container-monitor', () => {
 })
 
 describe('StandardSpatializedContainer', () => {
-  it('applies default style and reacts to transform visibility updates', () => {
+  it('applies default class + data attributes and toggles data-xr-transform-active', () => {
     let handler: ((v: any) => void) | undefined
     const spatializedContainerObject = {
       onSpatialTransformVisibilityChange: vi.fn((id: string, fn: any) => {
@@ -646,25 +646,36 @@ describe('StandardSpatializedContainer', () => {
     expect(el).toBeTruthy()
     expect(el.className).toContain('xr-spatial-default')
     expect(el.className).toContain('c')
-    expect(el.style.visibility).toBe('hidden')
-    expect(el.style.transition).toBe('none')
-    expect(el.style.transform).toBe('none')
+    expect(el.getAttribute('data-xr-host')).toBe('')
+
+    // Spatial host appearance is now driven by CSS rules on `data-xr-host`
+    // rather than inline style; otherwise React commits would clobber the
+    // probe via styleProxy. Inline transform/visibility/transition must be
+    // empty on the host.
+    expect(el.style.transform).toBe('')
+    expect(el.style.visibility).toBe('')
+    expect(el.style.transition).toBe('')
+
+    expect(el.hasAttribute('data-xr-transform-active')).toBe(false)
 
     act(() => {
       handler?.({ transform: [], visibility: 'visible' })
     })
-    expect(el.style.transform).toContain('translateZ')
+    expect(el.hasAttribute('data-xr-transform-active')).toBe(true)
+    expect(el.style.transform).toBe('')
 
     r.unmount()
   })
 
-  it('injectSpatialDefaultStyle adds style tag into head', () => {
+  it('injectSpatialDefaultStyle adds style tag with data-xr-host rules', () => {
     const before = document.head.querySelectorAll('style').length
     injectSpatialDefaultStyle()
     const after = document.head.querySelectorAll('style').length
     expect(after).toBe(before + 1)
     const last = document.head.querySelectorAll('style')[after - 1]
     expect(last?.innerHTML).toContain('xr-spatial-default')
+    expect(last?.innerHTML).toContain('[data-xr-host]')
+    expect(last?.innerHTML).toContain('translateZ(0)')
   })
 })
 

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -667,14 +667,16 @@ describe('StandardSpatializedContainer', () => {
     r.unmount()
   })
 
-  it('injectSpatialDefaultStyle adds style tag with data-xr-host rules', () => {
+  it('injectSpatialDefaultStyle adds style tag with class-scoped data-xr-host rules', () => {
     const before = document.head.querySelectorAll('style').length
     injectSpatialDefaultStyle()
     const after = document.head.querySelectorAll('style').length
     expect(after).toBe(before + 1)
     const last = document.head.querySelectorAll('style')[after - 1]
     expect(last?.innerHTML).toContain('xr-spatial-default')
-    expect(last?.innerHTML).toContain('[data-xr-host]')
+    // Hidden-host rules are scoped to the spatial class so unrelated DOM
+    // carrying `data-xr-host` is not affected.
+    expect(last?.innerHTML).toContain('.xr-spatial-default[data-xr-host]')
     expect(last?.innerHTML).toContain('translateZ(0)')
   })
 })

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -715,17 +715,23 @@ describe('StandardSpatializedContainer', () => {
     r.unmount()
   })
 
-  it('injectSpatialDefaultStyle adds style tag with class-scoped data-xr-host rules', () => {
-    const before = document.head.querySelectorAll('style').length
+  it('injectSpatialDefaultStyle is idempotent and emits class-scoped data-xr-host rules', () => {
+    // Idempotent across repeated calls — required so per-mount calls from
+    // SpatialContainerRefProxy do not pile up duplicate <style> elements.
     injectSpatialDefaultStyle()
-    const after = document.head.querySelectorAll('style').length
-    expect(after).toBe(before + 1)
-    const last = document.head.querySelectorAll('style')[after - 1]
-    expect(last?.innerHTML).toContain('xr-spatial-default')
+    injectSpatialDefaultStyle()
+    injectSpatialDefaultStyle()
+
+    const styles = document.head.querySelectorAll(
+      'style[data-xr-spatial-default-style]',
+    )
+    expect(styles.length).toBe(1)
+    const css = styles[0]?.innerHTML ?? ''
+    expect(css).toContain('xr-spatial-default')
     // Hidden-host rules are scoped to the spatial class so unrelated DOM
     // carrying `data-xr-host` is not affected.
-    expect(last?.innerHTML).toContain('.xr-spatial-default[data-xr-host]')
-    expect(last?.innerHTML).toContain('translateZ(0)')
+    expect(css).toContain('.xr-spatial-default[data-xr-host]')
+    expect(css).toContain('translateZ(0)')
   })
 })
 

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1740,7 +1740,7 @@ describe('SpatializedStatic3DElementContainer', () => {
     const onLoad = vi.fn()
     const onError = vi.fn()
     const portalInstanceObject = {
-      dom: { __targetProxy: { tid: 1 } },
+      dom: { tid: 1 },
     } as any
 
     const { SpatializedStatic3DElementContainer } = await import(
@@ -1847,7 +1847,7 @@ describe('SpatializedStatic3DElementContainer', () => {
     render(
       React.createElement(
         PortalInstanceContext.Provider,
-        { value: { dom: { __targetProxy: {} } } as any },
+        { value: { dom: {} } as any },
         React.createElement(SpatializedStatic3DElementContainer as any, {
           src: '/m2.glb',
         }),

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -667,6 +667,54 @@ describe('StandardSpatializedContainer', () => {
     r.unmount()
   })
 
+  // PR #1194 review (P2 from Codex): user-supplied props must not clobber
+  // SDK-controlled `data-xr-host` / `data-xr-transform-active` attributes,
+  // otherwise the 2D placeholder could un-hide or the stacking-context
+  // state could diverge from the spatial transform watcher.
+  it('SDK data attributes are not overridable via spatial element props', () => {
+    let handler: ((v: any) => void) | undefined
+    const spatializedContainerObject = {
+      onSpatialTransformVisibilityChange: vi.fn((_id: string, fn: any) => {
+        handler = fn
+        fn({ transform: 'none', visibility: 'visible' })
+      }),
+      offSpatialTransformVisibilityChange: vi.fn(),
+    } as any
+
+    const props: any = {
+      component: 'div',
+      inStandardSpatializedContainer: true,
+      [SpatialID]: 's2',
+      // These are exactly the values that would break the SDK contract
+      // if they were applied to the host: undefined would drop
+      // `data-xr-host` (un-hiding the placeholder) and a hard-coded value
+      // for `data-xr-transform-active` would force the translateZ stacking
+      // state regardless of the spatial transform watcher.
+      'data-xr-host': undefined,
+      'data-xr-transform-active': 'forced',
+    }
+
+    const r = render(
+      React.createElement(
+        SpatializedContainerContext.Provider,
+        { value: spatializedContainerObject },
+        React.createElement(StandardSpatializedContainer, props),
+      ),
+    )
+
+    const el = r.container.querySelector('div') as HTMLDivElement
+    expect(el).toBeTruthy()
+    expect(el.getAttribute('data-xr-host')).toBe('')
+    expect(el.hasAttribute('data-xr-transform-active')).toBe(false)
+
+    act(() => {
+      handler?.({ transform: 'matrix(1,0,0,1,0,0)', visibility: 'visible' })
+    })
+    expect(el.getAttribute('data-xr-transform-active')).toBe('')
+
+    r.unmount()
+  })
+
   it('injectSpatialDefaultStyle adds style tag with class-scoped data-xr-host rules', () => {
     const before = document.head.querySelectorAll('style').length
     injectSpatialDefaultStyle()

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -136,7 +136,7 @@ These are the contracts the rest of the architecture **depends on**. Future code
 - **Enforced at three layers:**
   1. **JSX render** in [`StandardSpatializedContainer.tsx`](./StandardSpatializedContainer.tsx) always merges `xr-spatial-default` into the className prop.
   2. **`className` descriptor** in [`hooks/useDomProxy.ts`](./hooks/useDomProxy.ts) re-appends the token via `classList.add` after applying the user's value.
-  3. **MutationObserver self-heal** (`SpatialContainerRefProxy.ensureSpatialDefaultClass`) re-appends if any native path (`setAttribute('class', …)`, `classList.remove(...)`, `classList.replace(...)`, third-party DOM helpers) strips it — see [Flow 2](#flow-2--class-invariant-self-heal). Asynchronous (one microtask) but bounded; no paint occurs in between.
+  3. **MutationObserver self-heal** (`SpatialContainerRefProxy.ensureSpatialDefaultClass`) re-appends if any native path (`setAttribute('class', …)`, `classList.remove(...)`, `classList.replace(...)`, third-party DOM helpers) strips it — see [Flow 2](#flow-2--class-invariant-self-heal). Asynchronous (one microtask) but bounded; no paint occurs in between. The observer is **attached before the ref is published to user code** so synchronous native-API mutations performed inside a user callback ref are still caught.
 - **Token vs substring:** the check **MUST** use `classList.contains` / `classList.add`, never `indexOf`, otherwise values like `foo-xr-spatial-default-theme` would falsely satisfy the invariant. The CSS selector keys on the token, not the substring.
 
 ### I2. The host always carries `data-xr-host=""`
@@ -183,6 +183,7 @@ These are the patterns Codex review on [PR #1194](https://github.com/webspatial/
 | Trust `el.className =` to be the only class write path | I1 — `setAttribute('class', …)` / `classList.remove(...)` / `classList.replace(...)` bypass it | PR #1194 P2 |
 | Drop `xr-spatial-default` when `className = ''` | I1 — un-hides the host | PR #1194 P2 |
 | Trust the document-level stylesheet to apply inside shadow roots | I7 — shadow boundaries do not let document CSS through; the host shows the bare 2D placeholder | PR #1194 P2 |
+| Publish the ref before attaching the class observer | I1 — synchronous user-side class mutations from a callback ref escape the self-heal | PR #1194 P2 |
 
 ## Known limitations
 
@@ -209,6 +210,7 @@ Each invariant has at least one regression test pinned in this directory:
 | Class invariant: `className = ''` keeps token (I1) | `useDomProxy.coverage.test.ts` — *"preserves xr-spatial-default when className is cleared"* |
 | Class invariant: native paths self-heal (I1) | `useDomProxy.coverage.test.ts` — *"restores xr-spatial-default after native class mutations strip it"* |
 | Class invariant: token, not substring (I1) | `useDomProxy.coverage.test.ts` — *"treats xr-spatial-default as a class token, not a substring"* |
+| Class observer attached before ref publish (I1) | `useDomProxy.coverage.test.ts` — *"attaches class observer before publishing the ref so user-side native mutations self-heal"* |
 | CSS rule is class-scoped, not global (I2) | `coverage-boost.test.ts` — *"injectSpatialDefaultStyle is idempotent and emits class-scoped data-xr-host rules"* |
 | Stylesheet injected per host root incl. shadow roots (I7) | `useDomProxy.coverage.test.ts` — *"injects spatial default stylesheet into the host shadow root"* |
 | Stylesheet injection is idempotent per root (I7) | `coverage-boost.test.ts` — same as above (asserts `length === 1` after three calls) |

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -164,6 +164,12 @@ These are the contracts the rest of the architecture **depends on**. Future code
 
 - The proxy is over `dom.style` itself; reads of non-spatial properties pass through with `Reflect.get`. This guarantees that `getComputedStyle`, layout, and CSS variable resolution remain identical to a vanilla `HTMLElement`.
 
+### I7. The hidden-host stylesheet must be reachable from each host's tree root
+
+- **Why:** I1–I5 all rely on the CSS rules in `injectSpatialDefaultStyle` (the spatial CSS variable defaults and the class-scoped hiding rules). Document-level stylesheets do not cross shadow boundaries, so a host mounted inside a `ShadowRoot` would otherwise miss them and show the bare 2D placeholder.
+- **Enforced by:** `SpatialContainerRefProxy.updateStandardSpatializedContainerDom` calls `ensureSpatialDefaultStyleInRoot(dom.getRootNode())` whenever a non-null host is attached. The helper is **idempotent per root** via the `data-xr-spatial-default-style` marker attribute on the inserted `<style>` element, so per-mount calls never accumulate duplicates.
+- **Why per-mount, not just `initPolyfill`:** the document is covered by `initPolyfill` at module load, but shadow roots are created at runtime by host applications (web components, micro-frontends, design-system shadow wrappers). The polyfill cannot eagerly enumerate every shadow root that will ever exist; piggy-backing on host attach is the cheapest way to react to them.
+
 ## Anti-patterns (do **not** do these)
 
 These are the patterns Codex review on [PR #1194](https://github.com/webspatial/webspatial-sdk/pull/1194) explicitly caught. Each maps to one or more of the invariants above.
@@ -176,6 +182,7 @@ These are the patterns Codex review on [PR #1194](https://github.com/webspatial/
 | Use `indexOf('xr-spatial-default')` to test class presence | I1 — false positive on `foo-xr-spatial-default-theme` | PR #1194 P2 |
 | Trust `el.className =` to be the only class write path | I1 — `setAttribute('class', …)` / `classList.remove(...)` / `classList.replace(...)` bypass it | PR #1194 P2 |
 | Drop `xr-spatial-default` when `className = ''` | I1 — un-hides the host | PR #1194 P2 |
+| Trust the document-level stylesheet to apply inside shadow roots | I7 — shadow boundaries do not let document CSS through; the host shows the bare 2D placeholder | PR #1194 P2 |
 
 ## Test coverage map
 
@@ -192,7 +199,9 @@ Each invariant has at least one regression test pinned in this directory:
 | Class invariant: `className = ''` keeps token (I1) | `useDomProxy.coverage.test.ts` — *"preserves xr-spatial-default when className is cleared"* |
 | Class invariant: native paths self-heal (I1) | `useDomProxy.coverage.test.ts` — *"restores xr-spatial-default after native class mutations strip it"* |
 | Class invariant: token, not substring (I1) | `useDomProxy.coverage.test.ts` — *"treats xr-spatial-default as a class token, not a substring"* |
-| CSS rule is class-scoped, not global (I2) | `coverage-boost.test.ts` — *"injectSpatialDefaultStyle adds style tag with class-scoped data-xr-host rules"* |
+| CSS rule is class-scoped, not global (I2) | `coverage-boost.test.ts` — *"injectSpatialDefaultStyle is idempotent and emits class-scoped data-xr-host rules"* |
+| Stylesheet injected per host root incl. shadow roots (I7) | `useDomProxy.coverage.test.ts` — *"injects spatial default stylesheet into the host shadow root"* |
+| Stylesheet injection is idempotent per root (I7) | `coverage-boost.test.ts` — same as above (asserts `length === 1` after three calls) |
 
 ## Quick reference for new contributors
 
@@ -204,4 +213,5 @@ If you are adding behavior to the standard host:
 4. **For class-token tests, use `classList.contains` / `classList.add`.** Never `indexOf`.
 5. **For class-attribute mutations from any source, assume someone bypasses the descriptor.** Rely on the `MutationObserver` self-heal in `SpatialContainerRefProxy.attachStandardClassObserver`.
 6. **For new SDK-controlled CSS rules**, scope them via `.xr-spatial-default[data-xr-host]` (or stricter) so unrelated DOM is unaffected. Add `!important` only when the contract truly requires "user CSS cannot override us".
-7. **Add at least one regression test per new invariant**, and update the table above.
+7. **Bundle any new SDK-controlled CSS into `injectSpatialDefaultStyle` / `ensureSpatialDefaultStyleInRoot`** so it ships into the same per-root injection path. Don't add a parallel global `<style>`; that path skips shadow roots.
+8. **Add at least one regression test per new invariant**, and update the table above.

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -1,0 +1,131 @@
+# Spatialized Container Architecture
+
+> Internal architecture notes for `@webspatial/react-sdk`'s spatialized container layer (`SpatialDiv`, `Model`, `Reality` entities, `Spatialized2DElementContainer`). Audience: SDK maintainers. Users of the SDK should never need to read this — see the package README and [openspec specs](../../../../openspec/specs/) instead.
+
+## Two-DOM split: standard host + probe
+
+A spatial container is rendered as **two** cooperating DOM elements:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  StandardSpatializedContainer  →  the standard host                  │
+│    visible 2D placeholder (always visually hidden via CSS)            │
+│    real HTMLElement, exposed as `ref.current`                         │
+│    has spatialized style proxy installed via Object.defineProperty    │
+│    has SDK-controlled `data-xr-host` (always) and                    │
+│    `data-xr-transform-active` (when transform != 'none')             │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│  TransformVisibilityTaskContainer  →  the probe                      │
+│    portal'd into a hidden `cssParserDivContainer` in <body>          │
+│    not part of the spatial host's tree                               │
+│    has user's `transform` / `visibility` written to its inline style  │
+│    `useSpatialTransformVisibility` reads `getComputedStyle(probe)`    │
+│    and broadcasts (transform, visibility) to platform subscribers    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Why split?** The standard host is what the user can see/measure in the page (layout, sibling order, scroll context, etc.), and the probe is the source of truth for what the spatial layer renders. Decoupling them lets the host stay invisible (so the page doesn't render duplicate 2D placeholders) while the probe carries the user's spatial transform/visibility through the CSS engine to the platform side.
+
+## What `ref.current` is
+
+`ref.current` is **the real standard-host `HTMLElement`** (`instanceof Node === true`, `parent.contains(ref.current) === true`, `getComputedStyle(ref.current)` works, `ResizeObserver.observe(ref.current)` works, etc.).
+
+`SpatialContainerRefProxy.installSpatialRefBehavior` (in [`hooks/useDomProxy.ts`](./hooks/useDomProxy.ts)) installs a few spec-correct property descriptors on top of that element:
+
+| Property | Behavior on the host |
+| --- | --- |
+| `style` (getter) | Returns a `Proxy<CSSStyleDeclaration>` over the raw style. |
+| `style.transform` / `style.visibility` (set/get) | **Forwarded to the probe.** Reads return the probe's value; writes are applied to the probe. |
+| `style.setProperty` / `removeProperty` / `getPropertyValue` | Same forwarding for `'transform'` / `'visibility'`; preserves the `priority` argument; falls through to native for everything else. |
+| `style.cssText` (set) | Spatial properties (`transform`, `visibility`) extracted and applied to the probe; remainder applied to the host raw style alongside `transform: none; visibility: hidden;`. |
+| `style[SpatialCustomStyleVars.*]` (set) | Applied directly to the host's raw style (CSS custom properties). |
+| `className` (set) | Always preserves the `xr-spatial-default` class **token** (see invariants). |
+| `removeAttribute('style')` | Resets the host inline style to `'visibility: hidden; transition: none; transform: none;'` and clears `transform`/`visibility` on the probe. |
+| `removeAttribute('class')` | Resets className to `'xr-spatial-default'`. |
+| `removeAttribute(otherName)` | Falls through to native `removeAttribute`. |
+| `xrClientDepth` / `xrOffsetBack` (getter) | Reads `--xr-depth` / `--xr-back` from the host's raw style. Installed only when `supports(...)` is true at mount time. |
+| `extraRefProps` keys | Installed as own properties with get/set delegating to the user-supplied factory. |
+
+These descriptors are removed (`Object.defineProperty` with `configurable: true`) when the standard host is swapped or the component unmounts (`clearInstalledProperties`).
+
+## Invariants on the standard host
+
+These are the contracts the rest of the architecture **depends on**. Future code in this directory MUST preserve them.
+
+### I1. The host always carries `xr-spatial-default` as a class token
+
+- **Why:** The hidden-placeholder CSS rule is keyed on `.xr-spatial-default[data-xr-host]`. Losing the token un-hides the 2D placeholder and drops the spatial CSS variables (`--xr-back`, `--xr-depth`, `--xr-z-index`, `--xr-background-material`).
+- **Enforced at three layers:**
+  1. **JSX render** in [`StandardSpatializedContainer.tsx`](./StandardSpatializedContainer.tsx) always merges `xr-spatial-default` into the className prop.
+  2. **`className` descriptor** in [`hooks/useDomProxy.ts`](./hooks/useDomProxy.ts) re-appends the token via `classList.add` after applying the user's value.
+  3. **MutationObserver self-heal** (`SpatialContainerRefProxy.ensureSpatialDefaultClass`) re-appends if any native path (`setAttribute('class', …)`, `classList.remove(...)`, `classList.replace(...)`, third-party DOM helpers) strips it. Asynchronous (one microtask) but bounded — no paint occurs in between.
+- **Token vs substring:** the check **MUST** use `classList.contains` / `classList.add`, never `indexOf`, otherwise values like `foo-xr-spatial-default-theme` would falsely satisfy the invariant. The CSS selector keys on the token, not the substring.
+
+### I2. The host always carries `data-xr-host=""`
+
+- **Why:** Same hidden-placeholder rule depends on this attribute. CSS rules in [`injectSpatialDefaultStyle`](./StandardSpatializedContainer.tsx) are scoped to `.xr-spatial-default[data-xr-host]` — class+attribute pair — so unrelated DOM in the host application that happens to use either marker alone is unaffected.
+- **Enforced by JSX prop ordering:** the SDK-controlled attribute is placed **after** `{...restProps}` so user-supplied `data-xr-host={undefined}` / `=…` cannot override it. See `StandardSpatializedContainerBase`.
+
+### I3. `data-xr-transform-active` reflects the spatial transform watcher exclusively
+
+- The attribute is added to the host iff `useSpatialTransformVisibilityWatcher` reports a non-`'none'` transform. The CSS rule `.xr-spatial-default[data-xr-host][data-xr-transform-active] { transform: translateZ(0) !important; }` then promotes the host into its own stacking context.
+- **Why it must not be user-overridable:** a user-forced value would diverge the host's stacking-context state from the spatial transform watcher, leading to incorrect compositing.
+- Enforced by the same JSX prop ordering as I2.
+
+### I4. The probe never carries `data-xr-host` / `data-xr-transform-active`
+
+- The class observer mirrors `class` only (`attributeFilter: ['class']`), so SDK-controlled `data-*` attributes do not bleed onto the probe.
+- This is what lets the hidden-host CSS rules apply only to the host while the probe is left to render its own (user-driven) spatial style.
+
+### I5. Host CSS appearance is driven by class rules, NOT inline style
+
+- `StandardSpatializedContainer` MUST NOT write `transform`, `visibility`, or `transition` as inline style on the host. Doing so triggers the host's spatialized style proxy and forwards the React-internal value to the probe, clobbering the user's spatial transform.
+- Mechanism: `data-xr-host` / `data-xr-transform-active` data attributes (set via `setAttribute`, which bypasses the style proxy) gate CSS rules with `!important` to preserve the legacy "user inline style cannot un-hide the host" contract.
+
+### I6. styleProxy on the host MUST be a `CSSStyleDeclaration` proxy, not a wrapper around a different node
+
+- The proxy is over `dom.style` itself; reads of non-spatial properties pass through with `Reflect.get`. This guarantees that `getComputedStyle`, layout, and CSS variable resolution remain identical to a vanilla `HTMLElement`.
+
+## Anti-patterns (do **not** do these)
+
+These are the patterns Codex review on [PR #1194](https://github.com/webspatial/webspatial-sdk/pull/1194) explicitly caught. Each maps to one or more of the invariants above.
+
+| ❌ Anti-pattern | What it breaks | Caught in |
+| --- | --- | --- |
+| Write `host.style.transform = 'translateZ(0)'` (or `visibility`/`transition`) inline from React | I5 — forwards to probe, clobbers user's transform | PR #1194 P1 |
+| Use unscoped CSS like `[data-xr-host] { … !important }` | I2 — would hide unrelated DOM in the host application | PR #1194 P2 |
+| Place SDK-controlled attributes **before** `{...restProps}` | I2/I3 — user can override and un-hide the host | PR #1194 P2 |
+| Use `indexOf('xr-spatial-default')` to test class presence | I1 — false positive on `foo-xr-spatial-default-theme` | PR #1194 P2 |
+| Trust `el.className =` to be the only class write path | I1 — `setAttribute('class', …)` / `classList.remove(...)` / `classList.replace(...)` bypass it | PR #1194 P2 |
+| Drop `xr-spatial-default` when `className = ''` | I1 — un-hides the host | PR #1194 P2 |
+
+## Test coverage map
+
+Each invariant has at least one regression test pinned in this directory:
+
+| Invariant / behavior | Test |
+| --- | --- |
+| `ref.current instanceof Element` (no Proxy wrapper) | `useDomProxy.coverage.test.ts` — *"writes the native dom element as ref only when both doms exist"* |
+| `ResizeObserver.observe(ref.current)` brand check | `useDomProxy.coverage.test.ts` — *"ref.current passes Element brand checks"* |
+| Host data-attr writes do not perturb probe (I5) | `useDomProxy.coverage.test.ts` — *"host data-\* attribute writes do not clobber probe transform"* |
+| Host has no inline `transform`/`visibility`/`transition` (I5) | `coverage-boost.test.ts` — *"applies default class + data attributes and toggles data-xr-transform-active"* |
+| `data-xr-transform-active` toggles with watcher (I3) | same as above |
+| SDK attributes are not overridable (I2/I3) | `coverage-boost.test.ts` — *"SDK data attributes are not overridable via spatial element props"* |
+| Class invariant: `className = ''` keeps token (I1) | `useDomProxy.coverage.test.ts` — *"preserves xr-spatial-default when className is cleared"* |
+| Class invariant: native paths self-heal (I1) | `useDomProxy.coverage.test.ts` — *"restores xr-spatial-default after native class mutations strip it"* |
+| Class invariant: token, not substring (I1) | `useDomProxy.coverage.test.ts` — *"treats xr-spatial-default as a class token, not a substring"* |
+| CSS rule is class-scoped, not global (I2) | `coverage-boost.test.ts` — *"injectSpatialDefaultStyle adds style tag with class-scoped data-xr-host rules"* |
+
+## Quick reference for new contributors
+
+If you are adding behavior to the standard host:
+
+1. **Read this doc first.** Identify which invariants your change touches.
+2. **Don't write `transform` / `visibility` / `transition` inline on the host.** Use a class or a `data-*` attribute that gates a CSS rule.
+3. **Don't trust user-supplied props for SDK-controlled attributes.** Place them after `{...restProps}` in JSX.
+4. **For class-token tests, use `classList.contains` / `classList.add`.** Never `indexOf`.
+5. **For class-attribute mutations from any source, assume someone bypasses the descriptor.** Rely on the `MutationObserver` self-heal in `SpatialContainerRefProxy.attachStandardClassObserver`.
+6. **For new SDK-controlled CSS rules**, scope them via `.xr-spatial-default[data-xr-host]` (or stricter) so unrelated DOM is unaffected. Add `!important` only when the contract truly requires "user CSS cannot override us".
+7. **Add at least one regression test per new invariant**, and update the table above.

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -2,31 +2,50 @@
 
 > Internal architecture notes for `@webspatial/react-sdk`'s spatialized container layer (`SpatialDiv`, `Model`, `Reality` entities, `Spatialized2DElementContainer`). Audience: SDK maintainers. Users of the SDK should never need to read this — see the package README and [openspec specs](../../../../openspec/specs/) instead.
 
+## TL;DR — 30-second mental model
+
+If you forget everything else, remember these five points:
+
+1. **Two DOMs, one ref.** Each spatial container renders a *standard host* (in the page tree, what `ref.current` points to) and a *probe* (off-screen, portaled to a hidden CSS-parser div). The probe is the platform's source of truth for `transform` / `visibility`.
+2. **`ref.current` is a real `HTMLElement`.** No Proxy wrapper. Native APIs (`instanceof Node`, `parent.contains(...)`, `ResizeObserver.observe(...)`, …) all just work.
+3. **`ref.current.style.transform` / `style.visibility` writes are silently re-routed to the probe** by descriptors installed via `Object.defineProperty`. Reads return the probe's value too.
+4. **The host is hidden via CSS rules, not inline style.** Inline `transform`/`visibility` writes from anyone (including React's own commits) would leak through the styleProxy and clobber the probe. The CSS rule is keyed on `.xr-spatial-default[data-xr-host]` so unrelated DOM is unaffected.
+5. **Two markers are non-negotiable on the host:** the class token `xr-spatial-default` and the data attribute `data-xr-host`. Three layers — JSX render, `className` descriptor, MutationObserver self-heal — keep them present even if user code or third-party libraries strip them.
+
 ## Two-DOM split: standard host + probe
 
-A spatial container is rendered as **two** cooperating DOM elements:
+```mermaid
+flowchart LR
+    User["User code<br/>(refs / JSX / side effects)"]
 
+    subgraph DOM["page DOM tree"]
+        Host["<b>Standard host</b><br/>= ref.current<br/>real HTMLElement<br/>class: xr-spatial-default<br/>attr: data-xr-host<br/>+ styleProxy descriptors"]
+    end
+
+    subgraph Hidden["off-screen / portal"]
+        Probe["<b>Probe</b><br/>portal'd into<br/>cssParserDivContainer<br/>(not in host's tree)"]
+    end
+
+    Watcher["useSpatial-<br/>TransformVisibility"]
+    Platform["spatial platform<br/>(window proxy / native)"]
+
+    User -->|"style.transform / className /<br/>native APIs (contains, instanceof, …)"| Host
+    Host -.->|"styleProxy:<br/>forwards transform / visibility"| Probe
+    Host -.->|"class observer:<br/>mirrors class only"| Probe
+    Probe -->|"getComputedStyle"| Watcher
+    Watcher -->|"broadcast"| Platform
+    Watcher -->|"setTransformExist →<br/>toggle data-xr-transform-active"| Host
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│  StandardSpatializedContainer  →  the standard host                  │
-│    visible 2D placeholder (always visually hidden via CSS)            │
-│    real HTMLElement, exposed as `ref.current`                         │
-│    has spatialized style proxy installed via Object.defineProperty    │
-│    has SDK-controlled `data-xr-host` (always) and                    │
-│    `data-xr-transform-active` (when transform != 'none')             │
-└──────────────────────────────────────────────────────────────────────┘
 
-┌──────────────────────────────────────────────────────────────────────┐
-│  TransformVisibilityTaskContainer  →  the probe                      │
-│    portal'd into a hidden `cssParserDivContainer` in <body>          │
-│    not part of the spatial host's tree                               │
-│    has user's `transform` / `visibility` written to its inline style  │
-│    `useSpatialTransformVisibility` reads `getComputedStyle(probe)`    │
-│    and broadcasts (transform, visibility) to platform subscribers    │
-└──────────────────────────────────────────────────────────────────────┘
-```
+**Why split?** The standard host is what the user can see/measure in the page (layout, sibling order, scroll context, etc.), and the probe is the source of truth for what the spatial layer renders. Decoupling them lets the host stay invisible (so the page doesn't show duplicate 2D placeholders) while the probe carries the user's spatial transform/visibility through the CSS engine to the platform side.
 
-**Why split?** The standard host is what the user can see/measure in the page (layout, sibling order, scroll context, etc.), and the probe is the source of truth for what the spatial layer renders. Decoupling them lets the host stay invisible (so the page doesn't render duplicate 2D placeholders) while the probe carries the user's spatial transform/visibility through the CSS engine to the platform side.
+| | Standard host | Probe |
+| --- | --- | --- |
+| Where | In the page tree, owned by `StandardSpatializedContainer` | Portal'd into a hidden `cssParserDivContainer` in `<body>` |
+| Visible? | Always hidden via CSS (`.xr-spatial-default[data-xr-host]` rule) | Off-screen (`left/top: -10000`, `opacity: 0`) |
+| `ref.current` | **Yes** — exposed to user code | No |
+| `style.transform` / `visibility` | Written via `setAttribute` (data-attr toggle), never inline | Holds the **user's** spatial values inline |
+| Class | `xr-spatial-default` + user classes; mirrored to probe | Mirrored from host (class only, not data-\*) |
 
 ## What `ref.current` is
 
@@ -50,6 +69,63 @@ A spatial container is rendered as **two** cooperating DOM elements:
 
 These descriptors are removed (`Object.defineProperty` with `configurable: true`) when the standard host is swapped or the component unmounts (`clearInstalledProperties`).
 
+## Critical data flows
+
+The hard part of this architecture isn't the static structure — it's the **time ordering** between user code, the styleProxy, the probe, the `useSpatialTransformVisibility` watcher, and React's own re-renders. Two flows are worth visualizing because the bugs they prevent are non-obvious from reading the code in isolation.
+
+### Flow 1 — user sets a spatial transform
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant H as Standard host<br/>(= ref.current)
+    participant SP as styleProxy
+    participant P as Probe
+    participant W as useSpatial-<br/>TransformVisibility
+    participant R as React<br/>(StandardSpatial-<br/>izedContainer)
+
+    U->>H: ref.current.style.transform = 'rotate(45deg)'
+    H->>SP: set('transform', 'rotate(45deg)')
+    SP->>P: probe.style.setProperty('transform', 'rotate(45deg)')
+    Note over H,P: probe inline = 'rotate(45deg)'<br/>host inline = (untouched)
+
+    Note over P,W: microtask: MutationObserver fires
+    W->>P: getComputedStyle(probe).transform
+    W-->>R: setTransformExist(true)
+
+    Note over R: React re-renders host
+    R->>H: setAttribute('data-xr-transform-active', '')
+
+    Note over H: CSS rule applies:<br/>host computed transform = translateZ(0)<br/>probe inline still 'rotate(45deg)' ✅
+```
+
+**What the fix is preventing.** In the broken pre-fix design, step 7 above was `host.style.transform = 'translateZ(0)'` (inline) instead of `setAttribute('data-xr-transform-active', '')`. That inline write would have hit the styleProxy and re-routed `'translateZ(0)'` to the probe, clobbering the user's `'rotate(45deg)'` and making the platform see an identity transform. The fix uses a `data-*` attribute (which goes through `setAttribute`, bypassing the proxy) plus a class-scoped CSS rule, so the host's stacking context is upgraded **without** any inline write reaching the proxy. See [PR #1194](https://github.com/webspatial/webspatial-sdk/pull/1194), Codex review P1.
+
+### Flow 2 — class invariant self-heal
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor C as External code<br/>(user / 3rd-party)
+    participant H as Standard host
+    participant O as Class<br/>MutationObserver
+
+    C->>H: classList.remove('xr-spatial-default')<br/>or setAttribute('class', 'foo')<br/>or el.className = '…'
+    Note over H: class attr now lacks the<br/>xr-spatial-default token
+
+    Note over H,O: microtask: MutationObserver fires
+    O->>H: classList.contains('xr-spatial-default') ?
+    alt token missing
+        O->>H: classList.add('xr-spatial-default')
+        Note over H: invariant restored<br/>(no paint between strip and restore)
+    else token present
+        Note over O: no-op; sync class to probe
+    end
+```
+
+The window between the strip and the restore is bounded by one microtask, and browsers paint at frame boundaries — so no frame is ever painted with the bare placeholder. This same observer also runs the existing host → probe class mirror; both responsibilities share one MutationObserver registration.
+
 ## Invariants on the standard host
 
 These are the contracts the rest of the architecture **depends on**. Future code in this directory MUST preserve them.
@@ -60,7 +136,7 @@ These are the contracts the rest of the architecture **depends on**. Future code
 - **Enforced at three layers:**
   1. **JSX render** in [`StandardSpatializedContainer.tsx`](./StandardSpatializedContainer.tsx) always merges `xr-spatial-default` into the className prop.
   2. **`className` descriptor** in [`hooks/useDomProxy.ts`](./hooks/useDomProxy.ts) re-appends the token via `classList.add` after applying the user's value.
-  3. **MutationObserver self-heal** (`SpatialContainerRefProxy.ensureSpatialDefaultClass`) re-appends if any native path (`setAttribute('class', …)`, `classList.remove(...)`, `classList.replace(...)`, third-party DOM helpers) strips it. Asynchronous (one microtask) but bounded — no paint occurs in between.
+  3. **MutationObserver self-heal** (`SpatialContainerRefProxy.ensureSpatialDefaultClass`) re-appends if any native path (`setAttribute('class', …)`, `classList.remove(...)`, `classList.replace(...)`, third-party DOM helpers) strips it — see [Flow 2](#flow-2--class-invariant-self-heal). Asynchronous (one microtask) but bounded; no paint occurs in between.
 - **Token vs substring:** the check **MUST** use `classList.contains` / `classList.add`, never `indexOf`, otherwise values like `foo-xr-spatial-default-theme` would falsely satisfy the invariant. The CSS selector keys on the token, not the substring.
 
 ### I2. The host always carries `data-xr-host=""`
@@ -81,7 +157,7 @@ These are the contracts the rest of the architecture **depends on**. Future code
 
 ### I5. Host CSS appearance is driven by class rules, NOT inline style
 
-- `StandardSpatializedContainer` MUST NOT write `transform`, `visibility`, or `transition` as inline style on the host. Doing so triggers the host's spatialized style proxy and forwards the React-internal value to the probe, clobbering the user's spatial transform.
+- `StandardSpatializedContainer` MUST NOT write `transform`, `visibility`, or `transition` as inline style on the host. Doing so triggers the host's spatialized style proxy and forwards the React-internal value to the probe, clobbering the user's spatial transform — see [Flow 1](#flow-1--user-sets-a-spatial-transform).
 - Mechanism: `data-xr-host` / `data-xr-transform-active` data attributes (set via `setAttribute`, which bypasses the style proxy) gate CSS rules with `!important` to preserve the legacy "user inline style cannot un-hide the host" contract.
 
 ### I6. styleProxy on the host MUST be a `CSSStyleDeclaration` proxy, not a wrapper around a different node

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -184,6 +184,16 @@ These are the patterns Codex review on [PR #1194](https://github.com/webspatial/
 | Drop `xr-spatial-default` when `className = ''` | I1 — un-hides the host | PR #1194 P2 |
 | Trust the document-level stylesheet to apply inside shadow roots | I7 — shadow boundaries do not let document CSS through; the host shows the bare 2D placeholder | PR #1194 P2 |
 
+## Known limitations
+
+### iframe / foreign-Document hosts ([#1197](https://github.com/webspatial/webspatial-sdk/issues/1197))
+
+The per-mount stylesheet injection in `SpatialContainerRefProxy.updateStandardSpatializedContainerDom` currently uses `root === document` to detect Document roots, which only matches the **module's own global document**. A spatial host rendered (or portaled) into a same-origin `<iframe>`'s `contentDocument` — or any other foreign `Document` instance — would not get the stylesheet, and the bare 2D placeholder would show through.
+
+This is a niche scenario (it requires React + WebSpatial inside an iframe, not just the iframe itself), and was deliberately deferred from PR #1194 to keep scope focused. The fix path is described in #1197 (switch the discriminator from `root === document` to `root.nodeType === 9`, plus a regression test against `iframe.contentDocument`).
+
+**Workaround in the meantime:** call `injectSpatialDefaultStyle()` once from inside the iframe's own realm (e.g. an entry script that runs there). Cross-origin iframes are out of scope — the SDK cannot reach across origins anyway.
+
 ## Test coverage map
 
 Each invariant has at least one regression test pinned in this directory:

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -118,7 +118,7 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       spatializedElement.onLoadCallback = () => {
         onLoad(
           createLoadSuccessEvent(
-            () => (portalInstanceObject.dom as any).__targetProxy,
+            () => portalInstanceObject.dom as SpatializedStatic3DElementRef,
           ),
         )
       }
@@ -132,7 +132,7 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       spatializedElement.onLoadFailureCallback = () => {
         onError(
           createLoadFailureEvent(
-            () => (portalInstanceObject.dom as any).__targetProxy,
+            () => portalInstanceObject.dom as SpatializedStatic3DElementRef,
           ),
         )
       }

--- a/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
@@ -77,13 +77,14 @@ export function StandardSpatializedContainerBase(
     : 'xr-spatial-default'
 
   // Apply spatial host appearance (visibility / transition / transform) via a
-  // CSS rule keyed on `data-xr-host`, NOT via inline style. The standard host
-  // has a styleProxy installed on it (see SpatialContainerRefProxy) that
-  // forwards `style.transform` / `style.visibility` writes to the probe so
-  // user code like `ref.current.style.transform = 'rotate(45deg)'` reaches
-  // the platform layer. If we wrote `transform: translateZ(0)` inline here,
-  // React's commit would hit that proxy and clobber the user's value on the
-  // probe (https://github.com/webspatial/webspatial-sdk/pull/1194).
+  // CSS rule scoped to `.xr-spatial-default[data-xr-host]`, NOT via inline
+  // style. The standard host has a styleProxy installed on it (see
+  // SpatialContainerRefProxy) that forwards `style.transform` /
+  // `style.visibility` writes to the probe so user code like
+  // `ref.current.style.transform = 'rotate(45deg)'` reaches the platform
+  // layer. If we wrote `transform: translateZ(0)` inline here, React's commit
+  // would hit that proxy and clobber the user's value on the probe
+  // (https://github.com/webspatial/webspatial-sdk/pull/1194).
   return (
     <Component
       ref={refInternalCallback}
@@ -107,14 +108,17 @@ export const StandardSpatializedContainer = forwardRef(
 export function injectSpatialDefaultStyle() {
   // inject xr-spatial-default style to head
   //
-  // The `[data-xr-host]` rules apply only to the visible 2D placeholder
+  // The hidden-host rules apply only to the visible 2D placeholder
   // (StandardSpatializedContainer's host element). They are intentionally
   // NOT written as inline style on that element — see the comment in
-  // StandardSpatializedContainerBase. `!important` matches the previous
-  // inline-style behavior where user-supplied inline visibility/transform
-  // could not override the host's hidden / stacking-context state.
-  // The class observer mirrors `class` (not `data-*`) onto the probe, so
-  // `[data-xr-host]` rules do not accidentally affect the probe element.
+  // StandardSpatializedContainerBase. The selector is scoped via
+  // `.xr-spatial-default` (always present on a spatial host) so that
+  // unrelated DOM that happens to carry a `data-xr-host` attribute is not
+  // affected. `!important` matches the previous inline-style behavior
+  // where user-supplied inline visibility/transform could not override the
+  // host's hidden / stacking-context state. The class observer mirrors
+  // `class` (not `data-*`) onto the probe, so the probe never matches
+  // because it lacks `data-xr-host`.
   const styleElement = document.createElement('style')
   styleElement.type = 'text/css'
   styleElement.innerHTML = `
@@ -124,12 +128,12 @@ export function injectSpatialDefaultStyle() {
       --xr-z-index: 0;
       --xr-background-material: none;
     }
-    [data-xr-host] {
+    .xr-spatial-default[data-xr-host] {
       visibility: hidden !important;
       transition: none !important;
       transform: none !important;
     }
-    [data-xr-host][data-xr-transform-active] {
+    .xr-spatial-default[data-xr-host][data-xr-transform-active] {
       transform: translateZ(0) !important;
     }
   `

--- a/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
@@ -72,22 +72,25 @@ export function StandardSpatializedContainerBase(
   }
   const transformExist = useSpatialTransformVisibilityWatcher(props[SpatialID])
 
-  const extraStyle = {
-    visibility: 'hidden',
-    transition: 'none',
-    transform: transformExist ? 'translateZ(0)' : 'none',
-  }
-  const style = { ...inStyle, ...extraStyle }
-
   const classNames = className
     ? `${className} xr-spatial-default`
     : 'xr-spatial-default'
 
+  // Apply spatial host appearance (visibility / transition / transform) via a
+  // CSS rule keyed on `data-xr-host`, NOT via inline style. The standard host
+  // has a styleProxy installed on it (see SpatialContainerRefProxy) that
+  // forwards `style.transform` / `style.visibility` writes to the probe so
+  // user code like `ref.current.style.transform = 'rotate(45deg)'` reaches
+  // the platform layer. If we wrote `transform: translateZ(0)` inline here,
+  // React's commit would hit that proxy and clobber the user's value on the
+  // probe (https://github.com/webspatial/webspatial-sdk/pull/1194).
   return (
     <Component
       ref={refInternalCallback}
-      style={style}
+      style={inStyle}
       className={classNames}
+      data-xr-host=""
+      data-xr-transform-active={transformExist ? '' : undefined}
       {...restProps}
     />
   )
@@ -103,9 +106,32 @@ export const StandardSpatializedContainer = forwardRef(
 
 export function injectSpatialDefaultStyle() {
   // inject xr-spatial-default style to head
+  //
+  // The `[data-xr-host]` rules apply only to the visible 2D placeholder
+  // (StandardSpatializedContainer's host element). They are intentionally
+  // NOT written as inline style on that element — see the comment in
+  // StandardSpatializedContainerBase. `!important` matches the previous
+  // inline-style behavior where user-supplied inline visibility/transform
+  // could not override the host's hidden / stacking-context state.
+  // The class observer mirrors `class` (not `data-*`) onto the probe, so
+  // `[data-xr-host]` rules do not accidentally affect the probe element.
   const styleElement = document.createElement('style')
   styleElement.type = 'text/css'
-  styleElement.innerHTML =
-    ' :where(.xr-spatial-default) {  --xr-back: 0; --xr-depth: 0; --xr-z-index: 0; --xr-background-material: none;  } '
+  styleElement.innerHTML = `
+    :where(.xr-spatial-default) {
+      --xr-back: 0;
+      --xr-depth: 0;
+      --xr-z-index: 0;
+      --xr-background-material: none;
+    }
+    [data-xr-host] {
+      visibility: hidden !important;
+      transition: none !important;
+      transform: none !important;
+    }
+    [data-xr-host][data-xr-transform-active] {
+      transform: translateZ(0) !important;
+    }
+  `
   document.head.appendChild(styleElement)
 }

--- a/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
@@ -116,37 +116,81 @@ export const StandardSpatializedContainer = forwardRef(
   },
 ) => React.ReactElement | null
 
-export function injectSpatialDefaultStyle() {
-  // inject xr-spatial-default style to head
-  //
-  // The hidden-host rules apply only to the visible 2D placeholder
-  // (StandardSpatializedContainer's host element). They are intentionally
-  // NOT written as inline style on that element — see the comment in
-  // StandardSpatializedContainerBase. The selector is scoped via
-  // `.xr-spatial-default` (always present on a spatial host) so that
-  // unrelated DOM that happens to carry a `data-xr-host` attribute is not
-  // affected. `!important` matches the previous inline-style behavior
-  // where user-supplied inline visibility/transform could not override the
-  // host's hidden / stacking-context state. The class observer mirrors
-  // `class` (not `data-*`) onto the probe, so the probe never matches
-  // because it lacks `data-xr-host`.
-  const styleElement = document.createElement('style')
+/**
+ * The hidden-host rules apply only to the visible 2D placeholder
+ * (StandardSpatializedContainer's host element). They are intentionally
+ * NOT written as inline style on that element — see the comment in
+ * StandardSpatializedContainerBase. The selector is scoped via
+ * `.xr-spatial-default` (always present on a spatial host) so that
+ * unrelated DOM that happens to carry a `data-xr-host` attribute is not
+ * affected. `!important` matches the previous inline-style behavior
+ * where user-supplied inline visibility/transform could not override the
+ * host's hidden / stacking-context state. The class observer mirrors
+ * `class` (not `data-*`) onto the probe, so the probe never matches
+ * because it lacks `data-xr-host`.
+ */
+const SPATIAL_DEFAULT_STYLE_CSS = `
+  :where(.xr-spatial-default) {
+    --xr-back: 0;
+    --xr-depth: 0;
+    --xr-z-index: 0;
+    --xr-background-material: none;
+  }
+  .xr-spatial-default[data-xr-host] {
+    visibility: hidden !important;
+    transition: none !important;
+    transform: none !important;
+  }
+  .xr-spatial-default[data-xr-host][data-xr-transform-active] {
+    transform: translateZ(0) !important;
+  }
+`
+
+/**
+ * Marker attribute used to dedupe injected stylesheets per root.
+ * Anyone querying for `style[data-xr-spatial-default-style]` should be able
+ * to find the SDK's stylesheet and skip re-injecting.
+ */
+const SPATIAL_DEFAULT_STYLE_MARKER = 'data-xr-spatial-default-style'
+
+/**
+ * Idempotently install the spatial default stylesheet into a tree root.
+ *
+ * Document-level stylesheets do not cross shadow boundaries, so a spatial
+ * container rendered inside a `ShadowRoot` would miss the
+ * `.xr-spatial-default[data-xr-host]` hiding rule and show the bare 2D
+ * placeholder. Calling this for each host's root (Document or ShadowRoot)
+ * keeps the rules reachable wherever the host actually lives.
+ *
+ * Safe to call repeatedly for the same root — uses an attribute marker on
+ * the inserted `<style>` element to short-circuit duplicates.
+ */
+export function ensureSpatialDefaultStyleInRoot(root: Document | ShadowRoot) {
+  const queryRoot = root === document ? document.head : root
+  if (queryRoot.querySelector(`style[${SPATIAL_DEFAULT_STYLE_MARKER}]`)) {
+    return
+  }
+  const ownerDoc =
+    root === document
+      ? document
+      : (root as ShadowRoot).ownerDocument || document
+  const styleElement = ownerDoc.createElement('style')
   styleElement.type = 'text/css'
-  styleElement.innerHTML = `
-    :where(.xr-spatial-default) {
-      --xr-back: 0;
-      --xr-depth: 0;
-      --xr-z-index: 0;
-      --xr-background-material: none;
-    }
-    .xr-spatial-default[data-xr-host] {
-      visibility: hidden !important;
-      transition: none !important;
-      transform: none !important;
-    }
-    .xr-spatial-default[data-xr-host][data-xr-transform-active] {
-      transform: translateZ(0) !important;
-    }
-  `
-  document.head.appendChild(styleElement)
+  styleElement.setAttribute(SPATIAL_DEFAULT_STYLE_MARKER, '')
+  styleElement.innerHTML = SPATIAL_DEFAULT_STYLE_CSS
+  if (root === document) {
+    document.head.appendChild(styleElement)
+  } else {
+    ;(root as ShadowRoot).appendChild(styleElement)
+  }
+}
+
+/**
+ * Polyfill entry point: ensure the document carries the spatial default
+ * stylesheet. Hosts mounted inside shadow roots are covered by a separate
+ * per-mount call from `SpatialContainerRefProxy`. Kept as a stable export
+ * because it is referenced by `initPolyfill`.
+ */
+export function injectSpatialDefaultStyle() {
+  ensureSpatialDefaultStyleInRoot(document)
 }

--- a/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
@@ -1,3 +1,8 @@
+// Renders the standard host: the visible 2D placeholder of a spatial
+// container. The host is permanently hidden via class-scoped CSS rules
+// (`.xr-spatial-default[data-xr-host]`) and exposed to consumers as
+// `ref.current`. See `./ARCHITECTURE.md` for the invariants this component
+// must preserve and the reasoning behind the data-attribute / CSS approach.
 import {
   SpatializedElementRef,
   SpatialTransformVisibility,

--- a/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/StandardSpatializedContainer.tsx
@@ -85,14 +85,20 @@ export function StandardSpatializedContainerBase(
   // layer. If we wrote `transform: translateZ(0)` inline here, React's commit
   // would hit that proxy and clobber the user's value on the probe
   // (https://github.com/webspatial/webspatial-sdk/pull/1194).
+  //
+  // The SDK-controlled `data-xr-host` / `data-xr-transform-active` attributes
+  // are placed AFTER `restProps` so user-supplied values cannot override
+  // them — losing `data-xr-host` would un-hide the 2D placeholder, and
+  // forcing `data-xr-transform-active` would diverge the host's stacking
+  // state from the spatial transform watcher.
   return (
     <Component
       ref={refInternalCallback}
       style={inStyle}
       className={classNames}
+      {...restProps}
       data-xr-host=""
       data-xr-transform-active={transformExist ? '' : undefined}
-      {...restProps}
     />
   )
 }

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -290,6 +290,42 @@ describe('SpatialContainerRefProxy', () => {
     expect(task.className).toBe(dom.className)
   })
 
+  // PR #1194 review (P2 from Codex): the class observer must be attached
+  // BEFORE the ref is published to user code. Otherwise a user-supplied
+  // callback ref that synchronously mutates the class via a native API
+  // (setAttribute / classList) lands its MutationRecord before the
+  // observer starts watching, escaping the self-heal — and the spatial
+  // class invariant gets quietly dropped on the first mount.
+  it('attaches class observer before publishing the ref so user-side native mutations self-heal', async () => {
+    let refDispatchedWith: HTMLElement | null = null
+    const ref = (el: HTMLElement | null) => {
+      refDispatchedWith = el
+      if (el) {
+        // Native APIs bypass the className descriptor, so only the
+        // observer self-heal can restore xr-spatial-default in time.
+        el.setAttribute('class', 'user-set-class')
+      }
+    }
+    const proxy = new SpatialContainerRefProxy<any>(ref as any)
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    // Reverse the typical React mount order so the ref is actually
+    // published from inside updateStandardSpatializedContainerDom (probe
+    // is already set), which is the exact path where the race lived.
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+    proxy.updateStandardSpatializedContainerDom(dom)
+
+    expect(refDispatchedWith).toBe(dom)
+    expect(dom.getAttribute('class')).toBe('user-set-class')
+
+    await flushClassSyncMicrotasks()
+
+    expect(dom.classList.contains('xr-spatial-default')).toBe(true)
+    expect(dom.classList.contains('user-set-class')).toBe(true)
+    expect(task.className).toBe(dom.className)
+  })
+
   it('deduplicates repeated null callback ref dispatches', () => {
     const fn = vi.fn()
     const proxy = new SpatialContainerRefProxy<any>(fn as any)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@webspatial/core-sdk'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { hijackGetComputedStyle, SpatialContainerRefProxy } from './useDomProxy'
+import { SpatialContainerRefProxy } from './useDomProxy'
 import { SpatialCustomStyleVars } from '../types'
 
 /** Class mirror uses queueMicrotask coalescing; flush before asserting on task.className. */
@@ -9,19 +9,22 @@ async function flushClassSyncMicrotasks() {
 }
 
 describe('SpatialContainerRefProxy', () => {
-  it('writes ref only when both doms exist', () => {
+  it('writes the native dom element as ref only when both doms exist', () => {
     const ref = { current: null as any }
     const proxy = new SpatialContainerRefProxy<any>(ref)
 
     const dom = document.createElement('div')
     const task = document.createElement('div')
+    const parent = document.createElement('section')
+    parent.appendChild(dom)
 
     proxy.updateStandardSpatializedContainerDom(dom)
     expect(ref.current).toBe(null)
 
     proxy.updateTransformVisibilityTaskContainerDom(task)
-    expect(ref.current).not.toBe(null)
-    expect((ref.current as any).__raw).toBe(dom)
+    expect(ref.current).toBe(dom)
+    expect(ref.current).toBeInstanceOf(window.Node)
+    expect(parent.contains(ref.current)).toBe(true)
   })
 
   it('proxies style visibility/transform to task container', () => {
@@ -83,8 +86,8 @@ describe('SpatialContainerRefProxy', () => {
     expect(task.style.getPropertyValue('transform')).toBe('translateX(10px)')
     expect(task.style.getPropertyValue('visibility')).toBe('visible')
     expect(dom.style.getPropertyValue('color')).toBe('red')
-    expect(dom.style.getPropertyValue('transform')).toBe('none')
-    expect(dom.style.getPropertyValue('visibility')).toBe('hidden')
+    expect(dom.getAttribute('style')).toContain('transform: none')
+    expect(dom.getAttribute('style')).toContain('visibility: hidden')
   })
 
   it('intercepts removeAttribute for style and class', async () => {
@@ -108,8 +111,8 @@ describe('SpatialContainerRefProxy', () => {
     expect(task.style.transform).toBe('translateX(1px)')
 
     domProxy.removeAttribute('style')
-    expect(dom.style.getPropertyValue('visibility')).toBe('hidden')
-    expect(dom.style.getPropertyValue('transform')).toBe('none')
+    expect(dom.getAttribute('style')).toContain('visibility: hidden')
+    expect(dom.getAttribute('style')).toContain('transform: none')
     expect(task.style.getPropertyValue('visibility')).toBe('')
     expect(task.style.getPropertyValue('transform')).toBe('')
 
@@ -239,27 +242,5 @@ describe('spatialized ref: xrClientDepth / xrOffsetBack', () => {
     expect('xrOffsetBack' in domProxy).toBe(true)
     expect(domProxy.xrClientDepth).toBe('9px')
     expect(domProxy.xrOffsetBack).toBe('8px')
-  })
-})
-
-describe('hijackGetComputedStyle', () => {
-  it('routes proxy elements to raw dom', () => {
-    const raw = vi.fn().mockReturnValue({} as any)
-    const orig = window.getComputedStyle
-    window.getComputedStyle = raw as any
-
-    hijackGetComputedStyle()
-
-    const ref = { current: null as any }
-    const proxy = new SpatialContainerRefProxy<any>(ref)
-    const dom = document.createElement('div')
-    const task = document.createElement('div')
-    proxy.updateStandardSpatializedContainerDom(dom)
-    proxy.updateTransformVisibilityTaskContainerDom(task)
-
-    window.getComputedStyle(ref.current as any)
-    expect(raw).toHaveBeenCalledWith(dom, undefined)
-
-    window.getComputedStyle = orig
   })
 })

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -351,6 +351,52 @@ describe('SpatialContainerRefProxy', () => {
 
     expect((ref.current as any).foo).toBe('bar')
   })
+
+  // PR #1194 review (P2 from Codex): document-level stylesheets do not
+  // cross shadow boundaries, so a spatial container mounted inside a
+  // ShadowRoot would lose the `.xr-spatial-default[data-xr-host]` hiding
+  // rule and show the bare 2D placeholder. The proxy must inject the
+  // stylesheet into the host's actual root tree on attach.
+  it('injects spatial default stylesheet into the host shadow root', () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+
+    const shadowMount = document.createElement('div')
+    document.body.appendChild(shadowMount)
+    const shadowRoot = shadowMount.attachShadow({ mode: 'open' })
+
+    const host = document.createElement('div')
+    shadowRoot.appendChild(host)
+    const task = document.createElement('div')
+
+    expect(
+      shadowRoot.querySelector('style[data-xr-spatial-default-style]'),
+    ).toBeNull()
+
+    proxy.updateStandardSpatializedContainerDom(host)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+
+    const injected = shadowRoot.querySelector(
+      'style[data-xr-spatial-default-style]',
+    )
+    expect(injected).not.toBeNull()
+    expect(injected?.innerHTML).toContain('.xr-spatial-default[data-xr-host]')
+    expect(injected?.innerHTML).toContain('translateZ(0)')
+
+    // Idempotent: a second mount into the same shadow root must not add a
+    // second copy.
+    const host2 = document.createElement('div')
+    shadowRoot.appendChild(host2)
+    const proxy2 = new SpatialContainerRefProxy<any>({ current: null })
+    proxy2.updateStandardSpatializedContainerDom(host2)
+
+    expect(
+      shadowRoot.querySelectorAll('style[data-xr-spatial-default-style]')
+        .length,
+    ).toBe(1)
+
+    document.body.removeChild(shadowMount)
+  })
 })
 
 describe('spatialized ref: xrClientDepth / xrOffsetBack', () => {

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -27,6 +27,37 @@ describe('SpatialContainerRefProxy', () => {
     expect(parent.contains(ref.current)).toBe(true)
   })
 
+  // Regression test for https://github.com/webspatial/webspatial-sdk/issues/1067
+  // Native APIs like ResizeObserver/IntersectionObserver brand-check `Element`
+  // and reject ECMAScript Proxy wrappers that lack the host internal slot.
+  it('ref.current passes Element brand checks (e.g. ResizeObserver.observe)', () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(dom)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+
+    expect(ref.current).toBeInstanceOf(window.Element)
+    expect(ref.current).toBeInstanceOf(window.HTMLElement)
+
+    class FakeResizeObserver {
+      observe(target: unknown) {
+        if (!(target instanceof window.Element)) {
+          throw new TypeError(
+            "Argument 1 ('target') to ResizeObserver.observe must be an instance of Element",
+          )
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    const ro = new FakeResizeObserver()
+    expect(() => ro.observe(ref.current)).not.toThrow()
+  })
+
   it('proxies style visibility/transform to task container', () => {
     const ref = { current: null as any }
     const proxy = new SpatialContainerRefProxy<any>(ref)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -58,6 +58,36 @@ describe('SpatialContainerRefProxy', () => {
     expect(() => ro.observe(ref.current)).not.toThrow()
   })
 
+  // Regression test for the bug Codex flagged on
+  // https://github.com/webspatial/webspatial-sdk/pull/1194 :
+  // Because the style proxy is installed directly on the standard host element
+  // (which React owns), any inline `style.transform = …` write that React
+  // performs during a commit would be redirected to the probe and would
+  // clobber the user's spatial transform. The fix in
+  // StandardSpatializedContainer is to drive `transform` / `visibility` /
+  // `transition` via CSS rules keyed on a `data-xr-host` attribute, which
+  // React applies through `setAttribute` (bypassing the style proxy).
+  // This test pins that contract: writes through `setAttribute` on the host
+  // must not perturb the probe's inline style.
+  it('host data-* attribute writes do not clobber probe transform', () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+    const host = document.createElement('div')
+    const probe = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(host)
+    proxy.updateTransformVisibilityTaskContainerDom(probe)
+
+    ref.current.style.transform = 'rotate(45deg)'
+    expect(probe.style.getPropertyValue('transform')).toBe('rotate(45deg)')
+
+    host.setAttribute('data-xr-host', '')
+    host.setAttribute('data-xr-transform-active', '')
+
+    expect(probe.style.getPropertyValue('transform')).toBe('rotate(45deg)')
+    expect(host.getAttribute('style')).toBeNull()
+  })
+
   it('proxies style visibility/transform to task container', () => {
     const ref = { current: null as any }
     const proxy = new SpatialContainerRefProxy<any>(ref)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -263,6 +263,33 @@ describe('SpatialContainerRefProxy', () => {
     expect(task.className).toBe(dom.className)
   })
 
+  // PR #1194 review (P2 from Codex): the spatial class invariant is checked
+  // as a class TOKEN, not a substring. A value like `foo-xr-spatial-default`
+  // contains the literal substring but is not the real class token, so the
+  // CSS selector `.xr-spatial-default` would not match and the placeholder
+  // would un-hide. The className setter and the observer self-heal must
+  // both append the real token in this case.
+  it('treats xr-spatial-default as a class token, not a substring', async () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(dom)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+    const domProxy = ref.current as any
+
+    domProxy.className = 'foo-xr-spatial-default-theme'
+    expect(dom.classList.contains('xr-spatial-default')).toBe(true)
+    expect(dom.classList.contains('foo-xr-spatial-default-theme')).toBe(true)
+
+    dom.setAttribute('class', 'bar-xr-spatial-default-extra')
+    await flushClassSyncMicrotasks()
+    expect(dom.classList.contains('xr-spatial-default')).toBe(true)
+    expect(dom.classList.contains('bar-xr-spatial-default-extra')).toBe(true)
+    expect(task.className).toBe(dom.className)
+  })
+
   it('deduplicates repeated null callback ref dispatches', () => {
     const fn = vi.fn()
     const proxy = new SpatialContainerRefProxy<any>(fn as any)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -225,6 +225,44 @@ describe('SpatialContainerRefProxy', () => {
     expect(task.className).toBe(dom.className)
   })
 
+  // PR #1194 review (P2 from Codex): the className descriptor only intercepts
+  // `el.className =` assignments; native paths like setAttribute, classList
+  // and third-party DOM helpers must not be able to strip the spatial class
+  // because the hidden-placeholder CSS now depends on it.
+  it('restores xr-spatial-default after native class mutations strip it', async () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(dom)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+    const domProxy = ref.current as any
+
+    domProxy.className = 'a'
+    expect(dom.className).toContain('xr-spatial-default')
+
+    // classList.remove bypasses the className descriptor.
+    dom.classList.remove('xr-spatial-default')
+    await flushClassSyncMicrotasks()
+    expect(dom.className).toContain('xr-spatial-default')
+    expect(task.className).toBe(dom.className)
+
+    // setAttribute also bypasses the descriptor.
+    dom.setAttribute('class', 'b')
+    await flushClassSyncMicrotasks()
+    expect(dom.className).toContain('xr-spatial-default')
+    expect(dom.className).toContain('b')
+    expect(task.className).toBe(dom.className)
+
+    // classList.replace, the typical "swap classes" helper.
+    dom.classList.replace('xr-spatial-default', 'c')
+    await flushClassSyncMicrotasks()
+    expect(dom.className).toContain('xr-spatial-default')
+    expect(dom.className).toContain('c')
+    expect(task.className).toBe(dom.className)
+  })
+
   it('deduplicates repeated null callback ref dispatches', () => {
     const fn = vi.fn()
     const proxy = new SpatialContainerRefProxy<any>(fn as any)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.coverage.test.ts
@@ -182,6 +182,31 @@ describe('SpatialContainerRefProxy', () => {
     expect(domProxy.className).toBe('xr-spatial-default')
   })
 
+  // PR #1194 review (P2 from Codex): clearing className imperatively must keep
+  // `xr-spatial-default`, otherwise the host loses both the spatial CSS vars
+  // and the `.xr-spatial-default[data-xr-host]` hidden-placeholder rule.
+  it('preserves xr-spatial-default when className is cleared', async () => {
+    const ref = { current: null as any }
+    const proxy = new SpatialContainerRefProxy<any>(ref)
+    const dom = document.createElement('div')
+    const task = document.createElement('div')
+
+    proxy.updateStandardSpatializedContainerDom(dom)
+    proxy.updateTransformVisibilityTaskContainerDom(task)
+    const domProxy = ref.current as any
+
+    domProxy.className = 'foo bar'
+    expect(dom.className).toContain('xr-spatial-default')
+
+    domProxy.className = ''
+    expect(dom.className).toBe('xr-spatial-default')
+    await flushClassSyncMicrotasks()
+    expect(task.className).toBe('xr-spatial-default')
+
+    domProxy.className = 'baz'
+    expect(dom.className).toBe('baz xr-spatial-default')
+  })
+
   it('syncs classList changes to task container', async () => {
     const ref = { current: null as any }
     const proxy = new SpatialContainerRefProxy<any>(ref)

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -267,9 +267,13 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
         return dom.getAttribute('class') ?? ''
       },
       set(value) {
+        // Always preserve `xr-spatial-default`. Without it the host loses
+        // both the spatial CSS vars and the `.xr-spatial-default[data-xr-host]`
+        // hidden-placeholder rule, which would un-hide the 2D host. Mirror
+        // the symmetry already provided by removeAttribute('class').
         let next = String(value)
-        if (next && next.indexOf('xr-spatial-default') === -1) {
-          next = `${next} xr-spatial-default`
+        if (next.indexOf('xr-spatial-default') === -1) {
+          next = next ? `${next} xr-spatial-default` : 'xr-spatial-default'
         }
         dom.setAttribute('class', next)
         self.scheduleSyncTransformClassFromStandard()

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -52,12 +52,31 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
       return
     }
     this.standardClassObserver = new MutationObserver(() => {
+      // The hidden-placeholder CSS rule is scoped to
+      // `.xr-spatial-default[data-xr-host]`, so any native path that strips
+      // the class (`setAttribute('class', …)`, `classList.remove(...)`,
+      // `classList.replace(...)`, third-party DOM helpers) would un-hide the
+      // 2D host. The className descriptor only intercepts `el.className =`
+      // assignment; restore the class here so all attribute-mutation paths
+      // converge on the same invariant.
+      this.ensureSpatialDefaultClass()
       this.scheduleSyncTransformClassFromStandard()
     })
     this.standardClassObserver.observe(this.standardRawDom, {
       attributes: true,
       attributeFilter: ['class'],
     })
+  }
+
+  private ensureSpatialDefaultClass() {
+    const dom = this.standardRawDom
+    if (!dom) return
+    const cls = dom.getAttribute('class') ?? ''
+    if (cls.indexOf('xr-spatial-default') !== -1) return
+    dom.setAttribute(
+      'class',
+      cls ? `${cls} xr-spatial-default` : 'xr-spatial-default',
+    )
   }
 
   /**

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -3,6 +3,23 @@ import { SpatialCustomStyleVars, SpatializedElementRef } from '../types'
 import { supports } from '@webspatial/core-sdk'
 import { extractAndRemoveCustomProperties, joinToCSSText } from '../utils'
 
+/**
+ * Owns the spatialized behavior installed on the standard host element and
+ * keeps the host ↔ probe pair (`StandardSpatializedContainer` ↔
+ * `TransformVisibilityTaskContainer`) in sync.
+ *
+ * The host is exposed to consumers as `ref.current` — a real `HTMLElement` —
+ * with property descriptors layered on via `Object.defineProperty` (style,
+ * className, removeAttribute, xrClientDepth, xrOffsetBack, extraRefProps).
+ * `style.transform` / `style.visibility` writes are forwarded to the probe
+ * so they reach the platform via `useSpatialTransformVisibility`.
+ *
+ * Several non-trivial invariants must hold for the hidden-host CSS rules to
+ * keep working — `xr-spatial-default` always present as a class token,
+ * `data-xr-host` always present, transform/visibility never written inline
+ * on the host. See `../ARCHITECTURE.md` (Invariants) for the full list and
+ * the reasoning behind each.
+ */
 export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
   private transformVisibilityTaskContainerDom: HTMLElement | null = null
   /** Raw Standard host element (styled root). Used to mirror class onto the transform probe. */

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -71,12 +71,12 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
   private ensureSpatialDefaultClass() {
     const dom = this.standardRawDom
     if (!dom) return
-    const cls = dom.getAttribute('class') ?? ''
-    if (cls.indexOf('xr-spatial-default') !== -1) return
-    dom.setAttribute(
-      'class',
-      cls ? `${cls} xr-spatial-default` : 'xr-spatial-default',
-    )
+    // Token-based check via classList rather than `indexOf('xr-spatial-default')`,
+    // so a class like `foo-xr-spatial-default-theme` does not satisfy the
+    // invariant — the CSS rule is keyed on the real `.xr-spatial-default`
+    // class token, not a substring.
+    if (dom.classList.contains('xr-spatial-default')) return
+    dom.classList.add('xr-spatial-default')
   }
 
   /**
@@ -286,15 +286,17 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
         return dom.getAttribute('class') ?? ''
       },
       set(value) {
-        // Always preserve `xr-spatial-default`. Without it the host loses
-        // both the spatial CSS vars and the `.xr-spatial-default[data-xr-host]`
-        // hidden-placeholder rule, which would un-hide the 2D host. Mirror
-        // the symmetry already provided by removeAttribute('class').
-        let next = String(value)
-        if (next.indexOf('xr-spatial-default') === -1) {
-          next = next ? `${next} xr-spatial-default` : 'xr-spatial-default'
+        // Always preserve the real `xr-spatial-default` class token. Without
+        // it the host loses both the spatial CSS vars and the
+        // `.xr-spatial-default[data-xr-host]` hidden-placeholder rule, which
+        // would un-hide the 2D host. Apply the value first, then re-append
+        // via classList (which uses spec-correct token semantics) so values
+        // like `foo-xr-spatial-default-theme` — substring-matching but not a
+        // real token — still trigger restoration.
+        dom.setAttribute('class', String(value))
+        if (!dom.classList.contains('xr-spatial-default')) {
+          dom.classList.add('xr-spatial-default')
         }
-        dom.setAttribute('class', next)
         self.scheduleSyncTransformClassFromStandard()
       },
     })

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -168,9 +168,16 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
       ensureSpatialDefaultStyleInRoot(root as Document | ShadowRoot)
     }
 
-    this.updateDomProxyToRef()
-
+    // Attach the class observer BEFORE publishing the ref. If a user-supplied
+    // callback ref synchronously mutates the class via a native API that
+    // bypasses the className descriptor (`node.setAttribute('class', …)`,
+    // `node.classList.remove('xr-spatial-default')`, …), the resulting
+    // MutationRecord must reach the self-heal in `attachStandardClassObserver`
+    // — otherwise xr-spatial-default would be lost without restoration and
+    // the host would un-hide. Do not reorder these two calls without a
+    // regression test.
     this.attachStandardClassObserver()
+    this.updateDomProxyToRef()
     this.scheduleSyncTransformClassFromStandard()
   }
 

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -1,6 +1,6 @@
 import { ForwardedRef, useCallback, useEffect, useRef } from 'react'
 import { SpatialCustomStyleVars, SpatializedElementRef } from '../types'
-import { BackgroundMaterialType, supports } from '@webspatial/core-sdk'
+import { supports } from '@webspatial/core-sdk'
 import { extractAndRemoveCustomProperties, joinToCSSText } from '../utils'
 
 export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
@@ -19,9 +19,9 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
   private classSyncMicrotaskQueued = false
   private ref: ForwardedRef<SpatializedElementRef<T>>
   public domProxy?: T | null
-  private styleProxy?: CSSStyleDeclaration
   /** Last value dispatched to `ref` (undefined = none yet); avoids duplicate null/proxy writes. */
   private lastOutgoingToRef: T | null | undefined = undefined
+  private installedProperties: PropertyKey[] = []
 
   // extre ref props, used to add extra props to ref
   private extraRefProps?: ((domProxy: T) => Record<string, unknown>) | undefined
@@ -100,14 +100,12 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
   }
 
   updateStandardSpatializedContainerDom(dom: HTMLElement | null) {
-    const self = this
-
     if (!dom) {
       this.disconnectStandardClassObserver()
+      this.clearInstalledProperties()
       this.standardRawDom = null
       this.lastMirroredClassName = null
       this.domProxy = undefined
-      this.styleProxy = undefined
       this.updateDomProxyToRef()
       return
     }
@@ -117,242 +115,216 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
       return
     }
 
+    this.clearInstalledProperties()
     this.standardRawDom = dom
+    this.domProxy = dom as SpatializedElementRef<T>
+    this.installSpatialRefBehavior(dom as SpatializedElementRef<T>)
 
-    let cacheExtraRefProps: Record<string, unknown> | undefined
-    const domProxy = new Proxy<SpatializedElementRef<T>>(
-      dom as SpatializedElementRef<T>,
-      {
-        get(target, prop) {
-          if (prop === '__raw') {
-            return target
-          }
-          if (prop === 'xrClientDepth') {
-            if (!supports('xrClientDepth')) {
-              return undefined
-            }
-            return target.style.getPropertyValue(SpatialCustomStyleVars.depth)
-          }
-          if (prop === 'xrOffsetBack') {
-            if (!supports('xrOffsetBack')) {
-              return undefined
-            }
-            return target.style.getPropertyValue(SpatialCustomStyleVars.back)
-          }
-          if (prop === 'style') {
-            if (!self.styleProxy) {
-              self.styleProxy = new Proxy<CSSStyleDeclaration>(target.style, {
-                get(target, prop) {
-                  if (prop === 'visibility' || prop === 'transform') {
-                    return self.transformVisibilityTaskContainerDom?.style.getPropertyValue(
-                      prop as string,
-                    )
-                  }
-                  const value = Reflect.get(target, prop)
-                  if (typeof value === 'function') {
-                    if (
-                      prop === 'setProperty' ||
-                      prop === 'removeProperty' ||
-                      prop === 'getPropertyValue'
-                    ) {
-                      return function (this: any, ...args: any[]) {
-                        const validProperties = ['visibility', 'transform']
-                        const [property] = args
-
-                        if (validProperties.includes(property)) {
-                          if (prop === 'setProperty') {
-                            const [, kValue] = args
-                            self.transformVisibilityTaskContainerDom?.style.setProperty(
-                              property,
-                              kValue as string,
-                            )
-                          } else if (prop === 'removeProperty') {
-                            self.transformVisibilityTaskContainerDom?.style.removeProperty(
-                              property,
-                            )
-                          } else if (prop === 'getPropertyValue') {
-                            return self.transformVisibilityTaskContainerDom?.style.getPropertyValue(
-                              property,
-                            )
-                          }
-                        } else {
-                          return value.apply(this, args)
-                        }
-                      }.bind(target)
-                    } else {
-                      return value.bind(target)
-                    }
-                  } else {
-                    return value
-                  }
-                },
-                set(target, prop, value) {
-                  if (prop === 'visibility') {
-                    self.transformVisibilityTaskContainerDom?.style.setProperty(
-                      'visibility',
-                      value,
-                    )
-                    return true
-                  }
-                  if (prop === 'transform') {
-                    self.transformVisibilityTaskContainerDom?.style.setProperty(
-                      'transform',
-                      value,
-                    )
-                    return true
-                  }
-
-                  if (prop === SpatialCustomStyleVars.backgroundMaterial) {
-                    target.setProperty(
-                      SpatialCustomStyleVars.backgroundMaterial,
-                      value as BackgroundMaterialType,
-                    )
-                  } else if (prop === SpatialCustomStyleVars.back) {
-                    target.setProperty(
-                      SpatialCustomStyleVars.back,
-                      value as string,
-                    )
-                  } else if (prop === SpatialCustomStyleVars.xrZIndex) {
-                    target.setProperty(
-                      SpatialCustomStyleVars.xrZIndex,
-                      value as string,
-                    )
-                  } else if (prop === SpatialCustomStyleVars.depth) {
-                    target.setProperty(
-                      SpatialCustomStyleVars.depth,
-                      value as string,
-                    )
-                  } else if (prop === 'cssText') {
-                    // parse cssText, filter out spatialStyle like back/transform/visibility/xrZIndex/backgroundMaterial
-                    const toFilteredCSSProperties = ['transform', 'visibility']
-                    const { extractedValues, filteredCssText } =
-                      extractAndRemoveCustomProperties(
-                        value as string,
-                        toFilteredCSSProperties,
-                      )
-
-                    // update cssText for transformVisibilityTaskContainerDom
-                    toFilteredCSSProperties.forEach(key => {
-                      // update cssText for transformVisibilityTaskContainerDom according to extractedValues
-                      if (extractedValues[key]) {
-                        self.transformVisibilityTaskContainerDom?.style.setProperty(
-                          key,
-                          extractedValues[key],
-                        )
-                      } else {
-                        target.removeProperty(key)
-                      }
-                    })
-
-                    const appendedCSSText = joinToCSSText({
-                      transform: 'none',
-                      visibility: 'hidden',
-                    })
-
-                    // set cssText for spatialDiv
-                    return Reflect.set(
-                      target,
-                      prop,
-                      [appendedCSSText, filteredCssText].join(';'),
-                    )
-                  }
-                  return Reflect.set(target, prop, value)
-                },
-              })
-            }
-
-            return self.styleProxy
-          }
-
-          if (typeof prop === 'string' && self.extraRefProps) {
-            if (!cacheExtraRefProps) {
-              cacheExtraRefProps = self.extraRefProps(domProxy)
-            }
-            const extraProps = cacheExtraRefProps
-            if (extraProps.hasOwnProperty(prop)) {
-              return extraProps[prop]
-            }
-          }
-          const value = Reflect.get(target, prop)
-          if (typeof value === 'function') {
-            if ('removeAttribute' === prop) {
-              return function (this: any, ...args: any[]) {
-                const [property] = args
-                if (property === 'style') {
-                  dom.style.cssText =
-                    'visibility: hidden; transition: none; transform: none;'
-                  if (self.transformVisibilityTaskContainerDom) {
-                    self.transformVisibilityTaskContainerDom.style.visibility =
-                      ''
-                    self.transformVisibilityTaskContainerDom.style.transform =
-                      ''
-                  }
-                  return true
-                }
-                if (property === 'class') {
-                  domProxy.className = 'xr-spatial-default'
-                  return true
-                }
-              }
-            }
-
-            return value.bind(target)
-          }
-          return value
-        },
-        set(target, prop, value) {
-          if (prop === 'className') {
-            if (value && String(value).indexOf('xr-spatial-default') === -1) {
-              value = value + ' xr-spatial-default'
-            }
-          }
-
-          // check extraRefProps setter
-          if (typeof prop === 'string' && self.extraRefProps) {
-            if (!cacheExtraRefProps) {
-              cacheExtraRefProps = self.extraRefProps(domProxy)
-            }
-            cacheExtraRefProps[prop] = value
-          }
-
-          const ok = Reflect.set(target, prop, value)
-          if (ok && prop === 'className') {
-            self.scheduleSyncTransformClassFromStandard()
-          }
-          return ok
-        },
-        has(target, prop) {
-          if (prop === 'xrClientDepth') {
-            return supports('xrClientDepth')
-          }
-          if (prop === 'xrOffsetBack') {
-            return supports('xrOffsetBack')
-          }
-          if (typeof prop === 'string' && self.extraRefProps) {
-            if (!cacheExtraRefProps) {
-              cacheExtraRefProps = self.extraRefProps(domProxy)
-            }
-            if (cacheExtraRefProps.hasOwnProperty(prop)) {
-              return true
-            }
-          }
-          return prop in target
-        },
-      },
-    )
-    this.domProxy = domProxy
-
-    // clear styleProxy
-    this.styleProxy = undefined
     this.updateDomProxyToRef()
-
-    // assign domProxy to dom
-    Object.assign(dom, {
-      __targetProxy: domProxy,
-    })
 
     this.attachStandardClassObserver()
     this.scheduleSyncTransformClassFromStandard()
+  }
+
+  private clearInstalledProperties() {
+    const dom = this.standardRawDom
+    if (!dom) return
+    for (const prop of this.installedProperties) {
+      delete (dom as any)[prop]
+    }
+    this.installedProperties = []
+  }
+
+  private defineDomProperty(
+    dom: HTMLElement,
+    prop: PropertyKey,
+    descriptor: PropertyDescriptor,
+  ) {
+    Object.defineProperty(dom, prop, {
+      configurable: true,
+      ...descriptor,
+    })
+    this.installedProperties.push(prop)
+  }
+
+  private installSpatialRefBehavior(dom: SpatializedElementRef<T>) {
+    const self = this
+
+    const rawStyle = dom.style
+    const rawRemoveProperty = rawStyle.removeProperty.bind(rawStyle)
+    const rawGetPropertyValue = rawStyle.getPropertyValue.bind(rawStyle)
+    const rawRemoveAttribute = dom.removeAttribute.bind(dom)
+    const spatialStyleProperties = ['visibility', 'transform']
+    const styleProxy = new Proxy<CSSStyleDeclaration>(rawStyle, {
+      get(target, prop) {
+        if (prop === 'visibility' || prop === 'transform') {
+          return self.transformVisibilityTaskContainerDom?.style.getPropertyValue(
+            prop as string,
+          )
+        }
+        const value = Reflect.get(target, prop)
+        if (typeof value === 'function') {
+          if (
+            prop === 'setProperty' ||
+            prop === 'removeProperty' ||
+            prop === 'getPropertyValue'
+          ) {
+            return function (this: any, ...args: any[]) {
+              const [property] = args
+
+              if (spatialStyleProperties.includes(property)) {
+                if (prop === 'setProperty') {
+                  const [, kValue, priority] = args
+                  self.transformVisibilityTaskContainerDom?.style.setProperty(
+                    property,
+                    kValue as string,
+                    priority as string | undefined,
+                  )
+                } else if (prop === 'removeProperty') {
+                  return self.transformVisibilityTaskContainerDom?.style.removeProperty(
+                    property,
+                  )
+                } else if (prop === 'getPropertyValue') {
+                  return self.transformVisibilityTaskContainerDom?.style.getPropertyValue(
+                    property,
+                  )
+                }
+                return undefined
+              }
+              return value.apply(this, args)
+            }.bind(target)
+          }
+          return value.bind(target)
+        }
+        return value
+      },
+      set(target, prop, value) {
+        if (prop === 'visibility') {
+          self.transformVisibilityTaskContainerDom?.style.setProperty(
+            'visibility',
+            value,
+          )
+          return true
+        }
+        if (prop === 'transform') {
+          self.transformVisibilityTaskContainerDom?.style.setProperty(
+            'transform',
+            value,
+          )
+          return true
+        }
+
+        if (Object.values(SpatialCustomStyleVars).includes(prop as string)) {
+          target.setProperty(prop as string, value as string)
+          return true
+        }
+        if (prop === 'cssText') {
+          // parse cssText, filter out spatialStyle like transform/visibility
+          const { extractedValues, filteredCssText } =
+            extractAndRemoveCustomProperties(
+              value as string,
+              spatialStyleProperties,
+            )
+
+          // update cssText for transformVisibilityTaskContainerDom
+          spatialStyleProperties.forEach(key => {
+            if (extractedValues[key]) {
+              self.transformVisibilityTaskContainerDom?.style.setProperty(
+                key,
+                extractedValues[key],
+              )
+            } else {
+              rawRemoveProperty(key)
+            }
+          })
+
+          const appendedCSSText = joinToCSSText({
+            transform: 'none',
+            visibility: 'hidden',
+          })
+
+          return Reflect.set(
+            target,
+            prop,
+            [appendedCSSText, filteredCssText].join(';'),
+          )
+        }
+        return Reflect.set(target, prop, value)
+      },
+    })
+
+    this.defineDomProperty(dom, 'style', {
+      get() {
+        return styleProxy
+      },
+      set(value) {
+        styleProxy.cssText = String(value)
+      },
+    })
+
+    this.defineDomProperty(dom, 'className', {
+      get() {
+        return dom.getAttribute('class') ?? ''
+      },
+      set(value) {
+        let next = String(value)
+        if (next && next.indexOf('xr-spatial-default') === -1) {
+          next = `${next} xr-spatial-default`
+        }
+        dom.setAttribute('class', next)
+        self.scheduleSyncTransformClassFromStandard()
+      },
+    })
+
+    this.defineDomProperty(dom, 'removeAttribute', {
+      value(property: string) {
+        if (property === 'style') {
+          rawStyle.cssText =
+            'visibility: hidden; transition: none; transform: none;'
+          self.transformVisibilityTaskContainerDom?.style.removeProperty(
+            'visibility',
+          )
+          self.transformVisibilityTaskContainerDom?.style.removeProperty(
+            'transform',
+          )
+          return
+        }
+        if (property === 'class') {
+          dom.className = 'xr-spatial-default'
+          return
+        }
+        return rawRemoveAttribute(property)
+      },
+    })
+
+    if (supports('xrClientDepth')) {
+      this.defineDomProperty(dom, 'xrClientDepth', {
+        get() {
+          return rawGetPropertyValue(SpatialCustomStyleVars.depth)
+        },
+      })
+    }
+    if (supports('xrOffsetBack')) {
+      this.defineDomProperty(dom, 'xrOffsetBack', {
+        get() {
+          return rawGetPropertyValue(SpatialCustomStyleVars.back)
+        },
+      })
+    }
+
+    if (this.extraRefProps) {
+      const extraProps = this.extraRefProps(dom)
+      for (const prop of Object.keys(extraProps)) {
+        this.defineDomProperty(dom, prop, {
+          get() {
+            return extraProps[prop]
+          },
+          set(value) {
+            extraProps[prop] = value
+          },
+        })
+      }
+    }
   }
 
   updateTransformVisibilityTaskContainerDom(dom: HTMLElement | null) {
@@ -399,19 +371,6 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
     this.ref = ref
     this.lastOutgoingToRef = undefined
     this.updateDomProxyToRef()
-  }
-}
-
-//  hijack getComputedStyle to get raw dom
-export function hijackGetComputedStyle() {
-  const rawFn = window.getComputedStyle.bind(window)
-  window.getComputedStyle = (element, pseudoElt) => {
-    const dom = (element as any).__raw
-
-    if (dom) {
-      return rawFn(dom, pseudoElt)
-    }
-    return rawFn(element, pseudoElt)
   }
 }
 

--- a/packages/react/src/spatialized-container/hooks/useDomProxy.ts
+++ b/packages/react/src/spatialized-container/hooks/useDomProxy.ts
@@ -2,6 +2,7 @@ import { ForwardedRef, useCallback, useEffect, useRef } from 'react'
 import { SpatialCustomStyleVars, SpatializedElementRef } from '../types'
 import { supports } from '@webspatial/core-sdk'
 import { extractAndRemoveCustomProperties, joinToCSSText } from '../utils'
+import { ensureSpatialDefaultStyleInRoot } from '../StandardSpatializedContainer'
 
 /**
  * Owns the spatialized behavior installed on the standard host element and
@@ -155,6 +156,17 @@ export class SpatialContainerRefProxy<T extends SpatializedElementRef> {
     this.standardRawDom = dom
     this.domProxy = dom as SpatializedElementRef<T>
     this.installSpatialRefBehavior(dom as SpatializedElementRef<T>)
+
+    // Make sure the spatial default stylesheet is reachable from this host.
+    // initPolyfill() injects it into `document`, but document-level rules do
+    // not cross shadow boundaries — so a host mounted inside a ShadowRoot
+    // would otherwise miss the `.xr-spatial-default[data-xr-host]` hiding
+    // rule (and the spatial CSS variable defaults). The helper is idempotent
+    // per root.
+    const root = dom.getRootNode()
+    if (root === document || root instanceof ShadowRoot) {
+      ensureSpatialDefaultStyleInRoot(root as Document | ShadowRoot)
+    }
 
     this.updateDomProxyToRef()
 

--- a/packages/react/src/spatialized-container/index.ts
+++ b/packages/react/src/spatialized-container/index.ts
@@ -1,4 +1,3 @@
-import { hijackGetComputedStyle } from './hooks/useDomProxy'
 import { injectSpatialDefaultStyle } from './StandardSpatializedContainer'
 import { initCSSParserDivContainer } from './TransformVisibilityTaskContainer'
 
@@ -36,7 +35,6 @@ export {
 } from './types'
 
 export function initPolyfill() {
-  hijackGetComputedStyle()
   injectSpatialDefaultStyle()
   initCSSParserDivContainer()
 }

--- a/packages/react/src/utils/convertCoordinate.ts
+++ b/packages/react/src/utils/convertCoordinate.ts
@@ -34,8 +34,8 @@ function resolveSpatialObjectId(target: CoordinateConvertible): string | null {
     return maybeEntity.entity?.id ?? null
   }
 
-  // SpatializedElementRef / ModelRef -> DOM proxy to underlying SpatializedElement.id
-  const dom: any = (target as any)?.__raw ?? (target as any)
+  // SpatializedElementRef / ModelRef -> underlying SpatializedElement.id
+  const dom: any = target as any
   if (dom && typeof dom === 'object') {
     const spatializedElement =
       dom.__spatializedElement ?? dom.__innerSpatializedElement?.()


### PR DESCRIPTION
Closes #1067.

## Summary

- Replace the Proxy that wrapped the standard host element in `SpatialContainerRefProxy` with property descriptors installed directly on the underlying DOM. `ref.current` is now a real `HTMLElement` and passes `instanceof Element` / `instanceof Node`, so native APIs that brand-check `Element` (`ResizeObserver.observe`, `IntersectionObserver.observe`, `MutationObserver.observe`, `parent.contains`, `getComputedStyle`, …) accept it directly. This is the underlying cause of #1067.
- Fix `removeAttribute` for non-spatial attribute names: previously the Proxy silently dropped them; now they delegate to the native call. `removeAttribute('style')` also uses `removeProperty` to clear `transform` / `visibility` on the task container.
- Preserve the `priority` argument when forwarding `setProperty` / `removeProperty` / `getPropertyValue` for `transform` / `visibility` to the task container.
- `clearInstalledProperties` removes the installed descriptors when the standard dom is swapped or the component unmounts, restoring the host element to its natural state.

## Cleanup of now-redundant code

- Delete `hijackGetComputedStyle` and its `initPolyfill` hookup — without the Proxy there is no `__raw` to unwrap, so the function was a pure no-op.
- Drop the `__targetProxy` indirection on the host element; `Model`'s load callbacks read `portalInstanceObject.dom` directly.
- Simplify `convertCoordinate` to read the DOM directly (the `?.__raw ?? target` fallback is no longer needed).
- Update the existing `useDomProxy.coverage.test.ts` cases to assert real-node semantics, and adjust the `coverage-boost.test.ts` fixtures that mocked `__targetProxy`.

## Regression test for #1067

`useDomProxy.coverage.test.ts` adds a case that asserts `ref.current instanceof Element` and exercises a `ResizeObserver`-style spec brand check (`if (!(target instanceof Element)) throw new TypeError(...)`) against `ref.current`. This guards any future ref refactor that would re-wrap the element.

## Test plan

- [x] `pnpm --filter @webspatial/react-sdk test` (typecheck + 87 vitest cases incl. the new ResizeObserver regression) — green
- [x] `pnpm --filter @webspatial/react-sdk build` (esbuild + dts) — green
- [x] `pnpm --filter @webspatial/core-sdk test` — green
- [ ] (optional) `npm run ciTest` end-to-end against the AVP simulator
- [ ] Smoke through `apps/test-server` SpatialDiv / styled-components / Model load flows

## Notes

- The pre-existing `@webspatial/builder` (`packages/cli`) `tsc` error about Jimp's import shape is unrelated to this change and reproduces on `origin/main`.
- The internal field name `domProxy` (and the `extraRefProps: (domProxy: T) => …` callback parameter) is left alone in this PR to keep the diff focused; renaming it to something like `domHost` is a fine follow-up.