### PR TITLE
ci: publish beta snapshots from main

### DIFF
--- a/.github/workflows/npm-beta-release.yml
+++ b/.github/workflows/npm-beta-release.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   publish-beta:
-    if: github.repository == 'webspatial/webspatial-sdk'
+    if: github.repository == 'webspatial/webspatial-sdk' && github.ref == 'refs/heads/main'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npm-beta-release.yml
+++ b/.github/workflows/npm-beta-release.yml
@@ -1,0 +1,74 @@
+name: NPM beta release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Required for npm trusted publishing / OIDC
+
+concurrency:
+  group: npm-beta-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CI: true
+  SKIP_SIMPLE_GIT_HOOKS: 1
+
+jobs:
+  publish-beta:
+    if: github.repository == 'webspatial/webspatial-sdk'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changesets
+        id: changesets
+        run: |
+          if find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup pnpm
+        if: steps.changesets.outputs.has_changesets == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        if: steps.changesets.outputs.has_changesets == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Update npm
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: npm install -g npm@'>=11.5.1'
+
+      - name: Install dependencies
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Version packages for beta snapshot
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm exec changeset version --snapshot beta --snapshot-prerelease-template "{tag}-{commit}"
+
+      - name: Build packages
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm run buildPackages
+
+      - name: Publish packages to npm beta
+        if: steps.changesets.outputs.has_changesets == 'true'
+        run: pnpm exec changeset publish --tag beta --no-git-tag
+        env:
+          # Use OIDC for npm authentication instead of NPM_TOKEN.
+          NPM_TOKEN: ''


### PR DESCRIPTION
### Motivation

- Automatically publish npm `beta` snapshot releases when `main` is updated and there are unreleased changesets so CI-driven changeset/version lifecycle can produce prerelease artifacts.
- Prevent accidental publishes for docs/CI-only commits by gating the workflow on the presence of `.changeset` entries.

### Description

- Add a new GitHub Actions workflow file at `.github/workflows/npm-beta-release.yml` that triggers on `push` to `main` and `workflow_dispatch` manual runs.
- The workflow checks for unreleased changesets, and when present sets up `pnpm`/Node.js 22, runs `pnpm exec changeset version --snapshot beta --snapshot-prerelease-template "{tag}-{commit}"`, builds via `pnpm run buildPackages`, and publishes with `pnpm exec changeset publish --tag beta --no-git-tag`.
- The job requires `id-token: write` to support npm trusted publishing (OIDC) and is scoped to run only for the `webspatial/webspatial-sdk` repository.
- The workflow uses a concurrency group to avoid overlap and avoids creating git tags when publishing snapshots.

### Testing

- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-beta-release.yml')"` which succeeded.
- Ran `git diff --check` to ensure no whitespace or diff errors, which passed.
- Verified the changeset gating by running `find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' | grep -q .` which reported `has_changesets=true` in this workspace.
- Executed `pnpm exec changeset version --snapshot beta --snapshot-prerelease-template "{tag}-{commit}"` in a dry/run-and-restore flow to confirm snapshot versioning behavior, which completed successfully (note: a separate Python YAML parse attempt failed due to missing `PyYAML` but the Ruby validation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0148af0520832c85e69db9f789f288)