### PR TITLE
[codex] Fix Jimp imports in builder

### DIFF
--- a/.changeset/gentle-jimp-build.md
+++ b/.changeset/gentle-jimp-build.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/builder': patch
+---
+
+Fix the builder TypeScript compile failure with Jimp 1.x by reading the Jimp class from the module namespace under Node16/CommonJS resolution.

--- a/packages/cli/src/lib/resource/imageHelper.ts
+++ b/packages/cli/src/lib/resource/imageHelper.ts
@@ -1,10 +1,14 @@
-import { Jimp } from 'jimp'
+import * as JimpModule from 'jimp'
 import sharp = require('sharp')
 import { Resvg, ResvgRenderOptions } from '@resvg/resvg-js'
 
 export class ImageHelper {
   public static createImg(size: number): any {
-    return new Jimp({ width: size, height: size, color: 0x00000000 })
+    return new JimpModule.Jimp({
+      width: size,
+      height: size,
+      color: 0x00000000,
+    })
   }
   public static async webp2PngBuffer(buffer: Buffer): Promise<Buffer> {
     return await sharp(buffer).toFormat('png').toBuffer()

--- a/packages/cli/src/lib/resource/load.ts
+++ b/packages/cli/src/lib/resource/load.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { fetchUtils } from '../utils/FetchUtils-1'
 import { CustomError } from '../utils/CustomError'
-import { Jimp } from 'jimp'
+import * as JimpModule from 'jimp'
 import { ImageHelper } from './imageHelper'
 
 export async function loadJsonFromNet(
@@ -120,11 +120,11 @@ export async function loadImageFromNet(src: string): Promise<any> {
   if (contentType.startsWith('image/webp')) {
     body = await ImageHelper.webp2PngBuffer(body)
   }
-  return await Jimp.read(Buffer.from(body))
+  return await JimpModule.Jimp.read(Buffer.from(body))
 }
 
 export async function loadImageFromDisk(src: string): Promise<any> {
-  return await Jimp.read(src)
+  return await JimpModule.Jimp.read(src)
 }
 
 export async function loadFileString(url: String): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes the builder package TypeScript failure caused by importing `Jimp` as a named export under the package's Node16/CommonJS compiler settings.

The Jimp 1.6.1 CommonJS declaration exposes the constructable class/static API as `Jimp` on the module namespace, so the CLI resource helpers now import the module namespace and call `JimpModule.Jimp` for image creation and reads.

## Impact

`@webspatial/builder` can compile again while keeping the existing image loading behavior unchanged.

## Validation

- `pnpm run test`
- core: 110 tests passed
- react: 94 tests passed
- builder CLI: `tsc` passed
- test-server: `tsc -p apps/test-server/tsconfig.json` passed