### PR TITLE
[codex] fix beta release npm support

### DIFF
--- a/.github/workflows/npm-beta-release.yml
+++ b/.github/workflows/npm-beta-release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   CI: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   SKIP_SIMPLE_GIT_HOOKS: 1
 
 jobs:
@@ -46,14 +47,13 @@ jobs:
         if: steps.changesets.outputs.has_changesets == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Install npm with trusted publishing support
+      - name: Verify npm trusted publishing support
         if: steps.changesets.outputs.has_changesets == 'true'
         run: |
-          pnpm add --global npm@11.5.1
           hash -r
           node --version
           npm --version

--- a/tools/scripts/check-release-workflows.js
+++ b/tools/scripts/check-release-workflows.js
@@ -29,13 +29,28 @@ assertIncludes(
 )
 assertIncludes(
   betaWorkflow,
-  'pnpm add --global npm@11.5.1',
-  'npm beta release workflow must install the trusted-publishing npm CLI via pnpm.',
+  'node-version: 24',
+  'npm beta release workflow must use Node 24 so the active npm CLI supports trusted publishing.',
+)
+assertIncludes(
+  betaWorkflow,
+  "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'",
+  'npm beta release workflow must opt into the Node 24 JavaScript action runtime.',
+)
+assertExcludes(
+  betaWorkflow,
+  'pnpm add --global npm',
+  'npm beta release workflow must not install npm into pnpm global storage.',
 )
 assertExcludes(
   betaWorkflow,
   'npm install -g npm',
-  'npm beta release workflow must not use npm to upgrade npm.',
+  'npm beta release workflow must not self-upgrade the runner-provided npm CLI.',
+)
+assertIncludes(
+  betaWorkflow,
+  "execFileSync('npm', ['--version']",
+  'npm beta release workflow must verify the active npm CLI version after upgrade.',
 )
 assertIncludes(
   betaWorkflow,


### PR DESCRIPTION
## Summary
- run the beta release workflow on Node 24 so the active npm CLI already supports trusted publishing
- opt the workflow into GitHub's Node 24 JavaScript action runtime before the June 2026 default switch
- keep an explicit npm version check before publish
- update the workflow guard script to reject both pnpm-global npm installs and runner self-upgrades

## Root cause
The previous fixes tried to upgrade npm inside the Node 22 runner. Scratch GitHub Actions verification showed both approaches are brittle: pnpm global installs did not affect the active npm binary, and npm self-upgrade failed on the hosted Node 22.22.2 image with a missing npm dependency.

## Validation
- pnpm run test:workflows
- GitHub Actions scratch verification: https://github.com/webspatial/webspatial-sdk/actions/runs/25721909871
  - JavaScript actions were forced onto Node 24 runtime
  - setup-node selected Node v24.14.1 with npm 11.11.0
  - the trusted-publishing npm version check passed
  - install/version/build/publish were intentionally skipped on the scratch branch