### PR TITLE
[codex] restrict CI workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - stable
   pull_request:
 
+permissions:
+  contents: read
+  statuses: write
+
 env:
   CI: true
   SKIP_SIMPLE_GIT_HOOKS: 1


### PR DESCRIPTION
## Summary
- add an explicit permissions block to the CI workflow
- grant only contents: read for checkout and statuses: write for the legacy commit status update

## Security impact
This addresses CodeQL alert #4, actions/missing-workflow-permissions, by preventing the CI workflow from inheriting broader repository or organization default GITHUB_TOKEN permissions.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml YAML ok"'
- git diff --check
- inspected the workflow for GITHUB_TOKEN usage; createCommitStatus requires statuses: write