### PR TITLE
feat(react): lazy-load facades + useMetrics placeholder 【Draft】

### DIFF
--- a/.changeset/lazy-load-facades.md
+++ b/.changeset/lazy-load-facades.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Internal lazy-load facades + hook placeholders (PR 2 of 6 for `openspec/lazy-load-spatial-runtime`). Adds the default-entry facade components for every public spatial primitive (`Model`, `Reality`, `Entity` / `*Entity` family, materials, assets, `SceneGraph` / `World`) and the HOC facades (`withSpatialized2DElementContainer`, `withSpatialMonitor`) under `packages/react/src/facades/`, together with the `useMetrics` placeholder + selector under `packages/react/src/hooks-web/`. Facades subscribe to bridge readiness via `useSpatialReady` (added in PR 1) and render the spec-pinned per-component fallback when the spatial chunk is not ready, delegating to the real implementation after `bootSpatial()` resolves. The new modules are not yet wired into `src/index.ts` (that switchover is PR 4); no public API surface changes in this release.

--- a/packages/react/src/facades/Model.tsx
+++ b/packages/react/src/facades/Model.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { ForwardedRef, createElement, forwardRef } from 'react'
+import type { ModelProps, ModelRef } from '../Model'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+export type { ModelProps, ModelRef }
+
+/**
+ * Default-entry facade for `Model`. Renders the spec-pinned degraded
+ * native `<model>` element when the spatial chunk is not ready, and
+ * delegates to the real `Model` implementation once `bootSpatial()`
+ * resolves in a WebSpatial runtime.
+ *
+ * Per spatial-lazy-load spec "Component facades" + "Model fallback
+ * renders degraded `<model>` tag" Scenarios. Not wrapped in
+ * `React.memo` (per facade conventions).
+ */
+function ModelFacadeImpl(props: ModelProps, ref: ForwardedRef<ModelRef>) {
+  const ready = useSpatialReady()
+  if (!ready) {
+    warnBootForgotten('Model')
+    return renderModelFallback(props, ref)
+  }
+  const RealModel = getSpatialImpl()!.Model
+  return <RealModel {...props} ref={ref} />
+}
+
+export const Model = forwardRef<ModelRef, ModelProps>(ModelFacadeImpl)
+Model.displayName = 'Model'
+
+function renderModelFallback(
+  props: ModelProps,
+  ref: ForwardedRef<ModelRef>,
+): JSX.Element {
+  // Strip spatial-only event props + spatialEventOptions before reaching the
+  // native <model> element (per spec "Model fallback renders degraded
+  // <model> tag" Scenario).
+  const {
+    onSpatialTap: _onSpatialTap,
+    onSpatialDragStart: _onSpatialDragStart,
+    onSpatialDrag: _onSpatialDrag,
+    onSpatialDragEnd: _onSpatialDragEnd,
+    onSpatialRotate: _onSpatialRotate,
+    onSpatialRotateEnd: _onSpatialRotateEnd,
+    onSpatialMagnify: _onSpatialMagnify,
+    onSpatialMagnifyEnd: _onSpatialMagnifyEnd,
+    spatialEventOptions: _spatialEventOptions,
+    'enable-xr': _enableXR,
+    ...modelProps
+  } = props
+  // Native <model> is a non-React intrinsic; createElement bypasses the
+  // JSX intrinsic-type check while still preserving ref forwarding.
+  return createElement('model', { ...modelProps, ref })
+}

--- a/packages/react/src/facades/Reality.tsx
+++ b/packages/react/src/facades/Reality.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { ForwardedRef, forwardRef } from 'react'
+import type { RealityProps } from '../reality/components/Reality'
+import type { SpatializedElementRef } from '../spatialized-container/types'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+export type { RealityProps }
+
+/**
+ * Default-entry facade for `Reality`. Renders a single
+ * `<div aria-hidden="true">` placeholder when the spatial chunk is not
+ * ready (preserving the layout box and excluding the React children
+ * subtree, per spec) and delegates to the real `Reality` once boot
+ * resolves in a WebSpatial runtime.
+ */
+function RealityFacadeImpl(
+  props: RealityProps,
+  ref: ForwardedRef<SpatializedElementRef>,
+) {
+  const ready = useSpatialReady()
+  if (!ready) {
+    warnBootForgotten('Reality')
+    return renderRealityFallback(props, ref)
+  }
+  const RealReality = getSpatialImpl()!.Reality
+  return <RealReality {...props} ref={ref} />
+}
+
+export const Reality = forwardRef<SpatializedElementRef, RealityProps>(
+  RealityFacadeImpl,
+)
+Reality.displayName = 'Reality'
+
+function renderRealityFallback(
+  props: RealityProps,
+  ref: ForwardedRef<SpatializedElementRef>,
+): JSX.Element {
+  // Strip spatial-only event handlers + spatialEventOptions + children before
+  // reaching the host <div>; per spec the child subtree MUST NOT mount and
+  // the placeholder MUST be excluded from focus + a11y tree.
+  const {
+    children: _children,
+    onSpatialTap: _onSpatialTap,
+    onSpatialDragStart: _onSpatialDragStart,
+    onSpatialDrag: _onSpatialDrag,
+    onSpatialDragEnd: _onSpatialDragEnd,
+    onSpatialRotate: _onSpatialRotate,
+    onSpatialRotateEnd: _onSpatialRotateEnd,
+    onSpatialMagnify: _onSpatialMagnify,
+    onSpatialMagnifyEnd: _onSpatialMagnifyEnd,
+    spatialEventOptions: _spatialEventOptions,
+    ...divProps
+  } = props as RealityProps & { spatialEventOptions?: unknown }
+  return (
+    <div {...divProps} ref={ref as ForwardedRef<HTMLDivElement>} aria-hidden />
+  )
+}

--- a/packages/react/src/facades/SceneGraph.tsx
+++ b/packages/react/src/facades/SceneGraph.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+export type SceneGraphProps = {
+  children?: ReactNode
+}
+
+/**
+ * Default-entry facade for `SceneGraph`. The fallback is a transparent
+ * `<>{children}</>` Fragment so users can still author scene-graph trees
+ * in plain browsers / before boot, with each individual entity / asset
+ * falling back via its own facade. Per spec per-component fallback
+ * table ("`SceneGraph` / `World` → `<>{children}</>` (transparent
+ * container)").
+ */
+export function SceneGraph({ children }: SceneGraphProps) {
+  const ready = useSpatialReady()
+  if (!ready) {
+    warnBootForgotten('SceneGraph')
+    return <>{children}</>
+  }
+  const RealSceneGraph = getSpatialImpl()!.SceneGraph
+  return <RealSceneGraph>{children}</RealSceneGraph>
+}
+SceneGraph.displayName = 'SceneGraph'
+
+// Public alias matches src/reality/components/index.tsx (`export {
+// SceneGraph as World } from './SceneGraph'`).
+export { SceneGraph as World }

--- a/packages/react/src/facades/entities.tsx
+++ b/packages/react/src/facades/entities.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { ComponentType, ForwardedRef, forwardRef } from 'react'
+import type {
+  SpatialBoxGeometryOptions,
+  SpatialConeGeometryOptions,
+  SpatialCylinderGeometryOptions,
+  SpatialPlaneGeometryOptions,
+  SpatialSphereGeometryOptions,
+} from '@webspatial/core-sdk'
+import type { EntityRefShape } from '../reality/hooks/useEntityRef'
+import type { EntityEventHandler, EntityProps } from '../reality/type'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+export type { EntityRefShape }
+
+type SpatialImpl = NonNullable<ReturnType<typeof getSpatialImpl>>
+
+/**
+ * Factory for entity-class facades whose documented fallback is `null`.
+ * The facade subscribes to bridge readiness via `useSpatialReady()` and
+ * renders the real implementation only after `bootSpatial()` resolves in
+ * a WebSpatial runtime. Per spec "Component facades" Requirement +
+ * per-component fallback table.
+ */
+function createEntityRefFacade<P>(
+  componentName: string,
+  pickReal: (impl: SpatialImpl) => unknown,
+) {
+  function Impl(props: P, ref: ForwardedRef<EntityRefShape>) {
+    const ready = useSpatialReady()
+    if (!ready) {
+      warnBootForgotten(componentName)
+      return null
+    }
+    const RealComponent = pickReal(getSpatialImpl()!) as ComponentType<
+      P & { ref?: unknown }
+    >
+    return <RealComponent {...(props as P)} ref={ref as any} />
+  }
+  const Facade = forwardRef<EntityRefShape, P>(Impl as any)
+  Facade.displayName = componentName
+  return Facade
+}
+
+/** Factory for facades whose real impl is a plain function component (no ref). */
+function createNullFacade<P>(
+  componentName: string,
+  pickReal: (impl: SpatialImpl) => unknown,
+) {
+  function Facade(props: P) {
+    const ready = useSpatialReady()
+    if (!ready) {
+      warnBootForgotten(componentName)
+      return null
+    }
+    const RealComponent = pickReal(getSpatialImpl()!) as ComponentType<any>
+    return <RealComponent {...(props as any)} />
+  }
+  Facade.displayName = componentName
+  return Facade
+}
+
+// Prop shapes mirror src/reality/components/*Entity.tsx so consumers get the
+// same TypeScript signatures from the default-entry facade as they would
+// from the real spatial implementation.
+
+type WithChildren<T> = T & { children?: React.ReactNode }
+export type EntityFacadeProps = WithChildren<EntityProps>
+export type BoxEntityProps = WithChildren<
+  EntityProps & { materials?: string[] } & SpatialBoxGeometryOptions
+>
+export type SphereEntityProps = WithChildren<
+  EntityProps & { materials?: string[] } & SpatialSphereGeometryOptions
+>
+export type ConeEntityProps = WithChildren<
+  EntityProps & { materials?: string[] } & SpatialConeGeometryOptions
+>
+export type CylinderEntityProps = WithChildren<
+  EntityProps & { materials?: string[] } & SpatialCylinderGeometryOptions
+>
+export type PlaneEntityProps = WithChildren<
+  EntityProps & { materials?: string[] } & SpatialPlaneGeometryOptions
+>
+export type ModelEntityProps = WithChildren<
+  EntityProps & EntityEventHandler & { model: string; materials?: string[] }
+>
+export type AttachmentEntityProps = {
+  attachment: string
+  position?: [number, number, number]
+  size: { width: number; height: number }
+}
+
+export const Entity = createEntityRefFacade<EntityFacadeProps>(
+  'Entity',
+  impl => impl.Entity,
+)
+export const BoxEntity = createEntityRefFacade<BoxEntityProps>(
+  'BoxEntity',
+  impl => impl.BoxEntity,
+)
+export const SphereEntity = createEntityRefFacade<SphereEntityProps>(
+  'SphereEntity',
+  impl => impl.SphereEntity,
+)
+export const ConeEntity = createEntityRefFacade<ConeEntityProps>(
+  'ConeEntity',
+  impl => impl.ConeEntity,
+)
+export const CylinderEntity = createEntityRefFacade<CylinderEntityProps>(
+  'CylinderEntity',
+  impl => impl.CylinderEntity,
+)
+export const PlaneEntity = createEntityRefFacade<PlaneEntityProps>(
+  'PlaneEntity',
+  impl => impl.PlaneEntity,
+)
+export const ModelEntity = createEntityRefFacade<ModelEntityProps>(
+  'ModelEntity',
+  impl => impl.ModelEntity,
+)
+
+export const AttachmentEntity = createNullFacade<AttachmentEntityProps>(
+  'AttachmentEntity',
+  impl => impl.AttachmentEntity,
+)
+
+// Public aliases mirror src/reality/components/index.tsx.
+export {
+  BoxEntity as Box,
+  ConeEntity as Cone,
+  CylinderEntity as Cylinder,
+  PlaneEntity as Plane,
+  SphereEntity as Sphere,
+}

--- a/packages/react/src/facades/index.ts
+++ b/packages/react/src/facades/index.ts
@@ -1,0 +1,53 @@
+export { Model } from './Model'
+export type { ModelProps, ModelRef } from './Model'
+
+export { Reality } from './Reality'
+export type { RealityProps } from './Reality'
+
+export {
+  AttachmentEntity,
+  Box,
+  BoxEntity,
+  Cone,
+  ConeEntity,
+  Cylinder,
+  CylinderEntity,
+  Entity,
+  ModelEntity,
+  Plane,
+  PlaneEntity,
+  Sphere,
+  SphereEntity,
+} from './entities'
+export type {
+  AttachmentEntityProps,
+  BoxEntityProps,
+  ConeEntityProps,
+  CylinderEntityProps,
+  EntityFacadeProps,
+  EntityRefShape,
+  ModelEntityProps,
+  PlaneEntityProps,
+  SphereEntityProps,
+} from './entities'
+
+export {
+  AttachmentAsset,
+  Material,
+  ModelAsset,
+  Texture,
+  UnlitMaterial,
+} from './resources'
+export type {
+  AttachmentAssetProps,
+  MaterialProps,
+  ModelAssetProps,
+  TextureProps,
+  UnlitMaterialProps,
+} from './resources'
+
+export { SceneGraph, World } from './SceneGraph'
+export type { SceneGraphProps } from './SceneGraph'
+
+export { withSpatialized2DElementContainer } from './withSpatialized2DElementContainer'
+export { withSpatialMonitor } from './withSpatialMonitor'

--- a/packages/react/src/facades/lazy-load-facades.test.tsx
+++ b/packages/react/src/facades/lazy-load-facades.test.tsx
@@ -1,0 +1,538 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import React, { createRef, forwardRef } from 'react'
+import { __resetBootStateForTests, bootSpatial } from '../runtime/boot'
+import {
+  __resetSpatialBridgeForTests,
+  __setSpatialImplLoaderForTests,
+  type SpatialImplementation,
+} from '../runtime/bridge'
+import * as reality from '../reality'
+import { Model } from './Model'
+import { Reality } from './Reality'
+import {
+  AttachmentEntity,
+  Box,
+  BoxEntity,
+  Cone,
+  ConeEntity,
+  Cylinder,
+  CylinderEntity,
+  Entity,
+  ModelEntity,
+  Plane,
+  PlaneEntity,
+  Sphere,
+  SphereEntity,
+} from './entities'
+import {
+  AttachmentAsset,
+  Material,
+  ModelAsset,
+  Texture,
+  UnlitMaterial,
+} from './resources'
+import { SceneGraph, World } from './SceneGraph'
+import {
+  __resetWithSpatialized2DElementContainerCacheForTests,
+  withSpatialized2DElementContainer,
+} from './withSpatialized2DElementContainer'
+import {
+  __resetWithSpatialMonitorCacheForTests,
+  withSpatialMonitor,
+} from './withSpatialMonitor'
+import { __resetBootForgottenWarningForTests } from './shared/warnBootForgotten'
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  })
+}
+
+function setPlainWebUserAgent(): void {
+  setUserAgent('Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36')
+}
+
+function setPuppeteerUserAgent(): void {
+  setUserAgent('Mozilla/5.0 Chrome/120.0.0.0 Puppeteer Safari/537.36')
+}
+
+function makeSentinelSpatialImpl(): SpatialImplementation {
+  const SentinelModel = forwardRef<HTMLDivElement>((_, ref) => (
+    <div data-sentinel="Model" ref={ref} />
+  ))
+  const SentinelReality = forwardRef<
+    HTMLDivElement,
+    { children?: React.ReactNode }
+  >(({ children }, ref) => (
+    <div data-sentinel="Reality" ref={ref}>
+      {children}
+    </div>
+  ))
+  const makeSentinelEntity = (name: string) =>
+    forwardRef<HTMLElement, { children?: React.ReactNode }>(
+      ({ children }, _ref) => <div data-sentinel={name}>{children}</div>,
+    )
+  const makeSentinelResource = (name: string) =>
+    function SentinelResource(props: { children?: React.ReactNode }) {
+      return <div data-sentinel={name}>{props.children}</div>
+    }
+  const SentinelSceneGraph = ({ children }: { children?: React.ReactNode }) => (
+    <div data-sentinel="SceneGraph">{children}</div>
+  )
+
+  const sentinelHOC2D = vi.fn(<P extends React.ElementType>(_Component: P) => {
+    return forwardRef<HTMLElement, Record<string, unknown>>(
+      function HOC2DReal(_props, ref) {
+        return <span data-sentinel="HOC2D" ref={ref as any} />
+      },
+    ) as unknown as P
+  })
+  const sentinelHOCMonitor = vi.fn((_El: React.ElementType) =>
+    forwardRef<HTMLElement, Record<string, unknown>>(
+      function HOCMonitorReal(_props, ref) {
+        return <span data-sentinel="HOCMonitor" ref={ref as any} />
+      },
+    ),
+  )
+
+  const sentinelUseMetrics = () => ({
+    pointToPhysical: (pt: number) => pt * 999,
+    physicalToPoint: (m: number) => m * 999,
+  })
+
+  return {
+    Model: SentinelModel,
+    Reality: SentinelReality,
+    Entity: makeSentinelEntity('Entity'),
+    BoxEntity: makeSentinelEntity('BoxEntity'),
+    SphereEntity: makeSentinelEntity('SphereEntity'),
+    ConeEntity: makeSentinelEntity('ConeEntity'),
+    CylinderEntity: makeSentinelEntity('CylinderEntity'),
+    PlaneEntity: makeSentinelEntity('PlaneEntity'),
+    ModelEntity: makeSentinelEntity('ModelEntity'),
+    AttachmentEntity: makeSentinelResource('AttachmentEntity'),
+    UnlitMaterial: makeSentinelResource('UnlitMaterial'),
+    Material: makeSentinelResource('Material'),
+    Texture: makeSentinelResource('Texture'),
+    ModelAsset: makeSentinelResource('ModelAsset'),
+    AttachmentAsset: makeSentinelResource('AttachmentAsset'),
+    SceneGraph: SentinelSceneGraph,
+    World: SentinelSceneGraph,
+    withSpatialized2DElementContainer: sentinelHOC2D,
+    withSpatialMonitor: sentinelHOCMonitor,
+    useMetrics: sentinelUseMetrics,
+    // Aliases
+    Box: makeSentinelEntity('BoxEntity'),
+    Sphere: makeSentinelEntity('SphereEntity'),
+    Cone: makeSentinelEntity('ConeEntity'),
+    Cylinder: makeSentinelEntity('CylinderEntity'),
+    Plane: makeSentinelEntity('PlaneEntity'),
+  } as unknown as SpatialImplementation
+}
+
+describe('lazy-load facades', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+    __resetBootForgottenWarningForTests()
+    __resetWithSpatialized2DElementContainerCacheForTests()
+    __resetWithSpatialMonitorCacheForTests()
+    setPlainWebUserAgent()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // The native HTML <model> element is part of a future spec and not
+    // recognized by jsdom / React's intrinsic table; React logs an "unknown
+    // tag" error every time the Model facade renders fallback. The DOM
+    // output is correct and the warning is unavoidable without changing
+    // public Model behavior, so we suppress it for this suite.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    cleanup()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+    __resetBootForgottenWarningForTests()
+    __resetWithSpatialized2DElementContainerCacheForTests()
+    __resetWithSpatialMonitorCacheForTests()
+  })
+
+  describe('Model facade — plain web fallback (per "Model fallback renders degraded <model> tag" Scenario)', () => {
+    it('renders a native <model> element and forwards ref to it', () => {
+      const ref = createRef<HTMLElement>()
+      const { container } = render(<Model ref={ref as any} src="x.usdz" />)
+
+      const modelEl = container.querySelector('model')
+      expect(modelEl).not.toBeNull()
+      expect(ref.current).toBe(modelEl)
+      expect(modelEl?.getAttribute('src')).toBe('x.usdz')
+    })
+
+    it('strips spatial-only event handlers + spatialEventOptions before reaching the <model> element', () => {
+      const onSpatialTap = vi.fn()
+      const onSpatialDrag = vi.fn()
+      const { container } = render(
+        <Model
+          onSpatialTap={onSpatialTap}
+          onSpatialDragStart={onSpatialDrag}
+          onSpatialDrag={onSpatialDrag}
+          onSpatialDragEnd={onSpatialDrag}
+          onSpatialRotate={onSpatialDrag}
+          onSpatialRotateEnd={onSpatialDrag}
+          onSpatialMagnify={onSpatialDrag}
+          onSpatialMagnifyEnd={onSpatialDrag}
+          spatialEventOptions={{ constrainedToAxis: [0, 1, 0] }}
+          src="x.usdz"
+        />,
+      )
+
+      const modelEl = container.querySelector('model')!
+      for (const attr of [
+        'onspatialtap',
+        'onspatialdragstart',
+        'onspatialdrag',
+        'onspatialdragend',
+        'onspatialrotate',
+        'onspatialrotateend',
+        'onspatialmagnify',
+        'onspatialmagnifyend',
+        'spatialeventoptions',
+      ]) {
+        expect(modelEl.hasAttribute(attr)).toBe(false)
+      }
+    })
+
+    it('displayName is "Model"', () => {
+      expect(Model.displayName).toBe('Model')
+    })
+  })
+
+  describe('Reality facade — plain web fallback (per "Reality fallback preserves layout" Scenario)', () => {
+    it('renders a single <div aria-hidden> placeholder with the layout box', () => {
+      const ref = createRef<HTMLDivElement>()
+      const { container } = render(
+        <Reality
+          ref={ref as any}
+          className="foo"
+          style={{ width: 100 }}
+          data-testid="reality-placeholder"
+        >
+          <span data-testid="reality-child" />
+        </Reality>,
+      )
+
+      const placeholder = container.querySelector(
+        '[data-testid="reality-placeholder"]',
+      ) as HTMLDivElement
+      expect(placeholder).not.toBeNull()
+      expect(placeholder.tagName).toBe('DIV')
+      expect(placeholder.getAttribute('aria-hidden')).toBe('true')
+      expect(placeholder.classList.contains('foo')).toBe(true)
+      expect(placeholder.style.width).toBe('100px')
+      expect(ref.current).toBe(placeholder)
+    })
+
+    it('does NOT mount the React children subtree in fallback mode', () => {
+      const { queryByTestId } = render(
+        <Reality>
+          <span data-testid="reality-child" />
+        </Reality>,
+      )
+      expect(queryByTestId('reality-child')).toBeNull()
+    })
+
+    it('displayName is "Reality"', () => {
+      expect(Reality.displayName).toBe('Reality')
+    })
+  })
+
+  describe('Entity-class facades — plain web fallback returns null', () => {
+    const entityRefCases: Array<{ name: string; Component: any }> = [
+      { name: 'Entity', Component: Entity },
+      { name: 'BoxEntity', Component: BoxEntity },
+      { name: 'SphereEntity', Component: SphereEntity },
+      { name: 'ConeEntity', Component: ConeEntity },
+      { name: 'CylinderEntity', Component: CylinderEntity },
+      { name: 'PlaneEntity', Component: PlaneEntity },
+      { name: 'ModelEntity', Component: ModelEntity },
+    ]
+    const nullCases: Array<{ name: string; Component: any }> = [
+      { name: 'AttachmentEntity', Component: AttachmentEntity },
+      { name: 'UnlitMaterial', Component: UnlitMaterial },
+      { name: 'Material', Component: Material },
+      { name: 'Texture', Component: Texture },
+      { name: 'ModelAsset', Component: ModelAsset },
+      { name: 'AttachmentAsset', Component: AttachmentAsset },
+    ]
+
+    for (const { name, Component } of entityRefCases) {
+      it(`${name} renders null in fallback (children NOT mounted) and forwards ref (ref.current === null per "Facade ref is null when fallback renders no host element" Scenario)`, () => {
+        const ref = createRef<unknown>()
+        const { container } = render(
+          <Component ref={ref as any} id="x" name="n" model="m">
+            <span data-testid={`${name}-child`} />
+          </Component>,
+        )
+        expect(container.children.length).toBe(0)
+        expect(ref.current).toBeNull()
+      })
+
+      it(`${name} displayName is "${name}"`, () => {
+        expect(Component.displayName).toBe(name)
+      })
+    }
+
+    for (const { name, Component } of nullCases) {
+      it(`${name} renders null in fallback (children NOT mounted) and has no ref-forwarding contract`, () => {
+        const { container } = render(
+          <Component
+            id="x"
+            url="u"
+            src="s"
+            name="n"
+            attachment="a"
+            size={{ width: 0, height: 0 }}
+          >
+            <span data-testid={`${name}-child`} />
+          </Component>,
+        )
+        expect(container.children.length).toBe(0)
+      })
+
+      it(`${name} displayName is "${name}"`, () => {
+        expect(Component.displayName).toBe(name)
+      })
+    }
+
+    it('Box / Sphere / Cone / Cylinder / Plane aliases reference the same facade as their *Entity counterpart', () => {
+      expect(Box).toBe(BoxEntity)
+      expect(Sphere).toBe(SphereEntity)
+      expect(Cone).toBe(ConeEntity)
+      expect(Cylinder).toBe(CylinderEntity)
+      expect(Plane).toBe(PlaneEntity)
+    })
+  })
+
+  describe('SceneGraph / World facade — transparent <>{children}</> in fallback', () => {
+    it('passes children through unchanged', () => {
+      const { container } = render(
+        <SceneGraph>
+          <span data-testid="scenegraph-child">hello</span>
+        </SceneGraph>,
+      )
+      const child = container.querySelector('[data-testid="scenegraph-child"]')
+      expect(child).not.toBeNull()
+      expect(child?.textContent).toBe('hello')
+    })
+
+    it('World alias references the same facade as SceneGraph', () => {
+      expect(World).toBe(SceneGraph)
+    })
+
+    it('displayName is "SceneGraph"', () => {
+      expect(SceneGraph.displayName).toBe('SceneGraph')
+    })
+  })
+
+  describe('HOC facades — wrapper-cache identity contract', () => {
+    it('withSpatialized2DElementContainer returns the same wrapper for the same Component reference', () => {
+      const A = withSpatialized2DElementContainer('section')
+      const B = withSpatialized2DElementContainer('section')
+      const C = withSpatialized2DElementContainer('article')
+      expect(A).toBe(B)
+      expect(A).not.toBe(C)
+    })
+
+    it('withSpatialMonitor returns the same wrapper for the same El reference', () => {
+      const A = withSpatialMonitor('section')
+      const B = withSpatialMonitor('section')
+      const C = withSpatialMonitor('article')
+      expect(A).toBe(B)
+      expect(A).not.toBe(C)
+    })
+
+    it('withSpatialized2DElementContainer fallback renders the raw component transparently and strips spatial-only event handlers', () => {
+      // Cast the wrapper to a permissive React component shape — its public
+      // surface is `Spatialized2DElementContainerProps<'section'>` (which
+      // includes spatial-event handlers + `spatialEventOptions`), but the
+      // type-parameter `P = 'section'` exposed by the real HOC's existing
+      // signature loses that information at the call site.
+      const Wrapped = withSpatialized2DElementContainer(
+        'section',
+      ) as unknown as React.ComponentType<Record<string, unknown>>
+      const ref = createRef<HTMLElement>()
+      const onSpatialTap = vi.fn()
+      const { container } = render(
+        <Wrapped
+          ref={ref as any}
+          onSpatialTap={onSpatialTap}
+          spatialEventOptions={{ constrainedToAxis: [0, 0, 1] }}
+          className="hoc-fallback"
+        >
+          <span data-testid="hoc2d-child" />
+        </Wrapped>,
+      )
+      const section = container.querySelector('section.hoc-fallback')!
+      expect(section).not.toBeNull()
+      expect(section.hasAttribute('onspatialtap')).toBe(false)
+      expect(section.hasAttribute('spatialeventoptions')).toBe(false)
+      expect(ref.current).toBe(section)
+    })
+
+    it('withSpatialMonitor fallback renders the raw El transparently', () => {
+      const Monitor = withSpatialMonitor(
+        'div',
+      ) as unknown as React.ComponentType<{
+        ref?: any
+        children?: React.ReactNode
+      }>
+      const ref = createRef<HTMLDivElement>()
+      const { getByTestId } = render(
+        <Monitor ref={ref}>
+          <span data-testid="monitor-child" />
+        </Monitor>,
+      )
+      const child = getByTestId('monitor-child')
+      expect(child.parentElement?.tagName).toBe('DIV')
+      expect(ref.current).toBe(child.parentElement)
+    })
+
+    it('HOC displayName follows the WithSpatialized2DElementContainer(<inner>) / WithSpatialMonitor(<inner>) convention', () => {
+      const W2D = withSpatialized2DElementContainer(
+        'section',
+      ) as unknown as React.ComponentType & { displayName?: string }
+      const WM = withSpatialMonitor(
+        'section',
+      ) as unknown as React.ComponentType & {
+        displayName?: string
+      }
+      expect(W2D.displayName).toBe('WithSpatialized2DElementContainer(section)')
+      expect(WM.displayName).toBe('WithSpatialMonitor(section)')
+    })
+  })
+
+  describe('Dev-mode warning policy (per "Dev-mode warning when boot is forgotten" / "No dev-mode warning in non-WebSpatial browsers")', () => {
+    it('does NOT warn in a plain web browser regardless of how many facades render', () => {
+      render(
+        <>
+          <Model src="x" />
+          <Reality />
+          <Entity />
+          <SceneGraph>
+            <span />
+          </SceneGraph>
+        </>,
+      )
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('warns exactly once in a WebSpatial runtime when a facade renders before bootSpatial() is called', () => {
+      setPuppeteerUserAgent()
+      render(
+        <>
+          <Model src="x" />
+          <Model src="y" />
+          <Reality />
+          <Entity />
+        </>,
+      )
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toMatch(/bootSpatial\(\)/)
+    })
+
+    it('does NOT warn in a WebSpatial runtime once bootSpatial() has been called', async () => {
+      setPuppeteerUserAgent()
+      __setSpatialImplLoaderForTests(() => new Promise(() => {})) // hang
+      await act(async () => {
+        bootSpatial()
+      })
+      render(<Model src="x" />)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Facade -> real implementation switch after bootSpatial() resolves', () => {
+    it('Model renders the spatial-chunk real implementation once boot resolves', async () => {
+      setPuppeteerUserAgent()
+      const sentinel = makeSentinelSpatialImpl()
+      __setSpatialImplLoaderForTests(() => Promise.resolve(sentinel))
+
+      const { container, rerender } = render(<Model src="x" />)
+      expect(container.querySelector('model')).not.toBeNull()
+
+      await act(async () => {
+        await bootSpatial()
+      })
+      rerender(<Model src="x" />)
+      expect(container.querySelector('[data-sentinel="Model"]')).not.toBeNull()
+      expect(container.querySelector('model')).toBeNull()
+    })
+
+    it('Reality mounts children only after the real implementation is in scope', async () => {
+      setPuppeteerUserAgent()
+      const sentinel = makeSentinelSpatialImpl()
+      __setSpatialImplLoaderForTests(() => Promise.resolve(sentinel))
+
+      const { container, rerender, queryByTestId } = render(
+        <Reality>
+          <span data-testid="reality-child" />
+        </Reality>,
+      )
+      expect(queryByTestId('reality-child')).toBeNull()
+
+      await act(async () => {
+        await bootSpatial()
+      })
+      rerender(
+        <Reality>
+          <span data-testid="reality-child" />
+        </Reality>,
+      )
+      expect(
+        container.querySelector('[data-sentinel="Reality"]'),
+      ).not.toBeNull()
+      expect(queryByTestId('reality-child')).not.toBeNull()
+    })
+
+    it('Entity mounts the spatial-chunk real implementation once boot resolves', async () => {
+      setPuppeteerUserAgent()
+      const sentinel = makeSentinelSpatialImpl()
+      __setSpatialImplLoaderForTests(() => Promise.resolve(sentinel))
+
+      const { container, rerender } = render(<Entity />)
+      expect(container.children.length).toBe(0)
+
+      await act(async () => {
+        await bootSpatial()
+      })
+      rerender(<Entity />)
+      expect(container.querySelector('[data-sentinel="Entity"]')).not.toBeNull()
+    })
+  })
+
+  describe('Internal reality hooks are NOT publicly exported (per tasks §5.3)', () => {
+    const internalNames = [
+      'useEntity',
+      'useEntityRef',
+      'useEntityTransform',
+      'useEntityEvent',
+      'useEntityId',
+      'useRealityEvents',
+      'useForceUpdate',
+    ] as const
+
+    for (const name of internalNames) {
+      it(`reality barrel does not expose ${name} at runtime`, () => {
+        expect((reality as Record<string, unknown>)[name]).toBeUndefined()
+      })
+    }
+  })
+})

--- a/packages/react/src/facades/resources.tsx
+++ b/packages/react/src/facades/resources.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { ComponentType, ReactNode } from 'react'
+import type { SpatialUnlitMaterialOptions } from '@webspatial/core-sdk'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+type SpatialImpl = NonNullable<ReturnType<typeof getSpatialImpl>>
+
+/**
+ * Factory for material / texture / asset facades. Fallback is `null` per
+ * spec's per-component fallback table ("Unsupported HTML component
+ * rendering" Scenario in runtime-capabilities + facade table).
+ */
+function createNullFacade<P>(
+  componentName: string,
+  pickReal: (impl: SpatialImpl) => unknown,
+) {
+  function Facade(props: P) {
+    const ready = useSpatialReady()
+    if (!ready) {
+      warnBootForgotten(componentName)
+      return null
+    }
+    const RealComponent = pickReal(getSpatialImpl()!) as ComponentType<any>
+    return <RealComponent {...(props as any)} />
+  }
+  Facade.displayName = componentName
+  return Facade
+}
+
+export type UnlitMaterialProps = {
+  children?: ReactNode
+  id: string
+} & SpatialUnlitMaterialOptions
+
+export type MaterialProps = { type: 'unlit' } & UnlitMaterialProps
+
+export type TextureProps = {
+  children?: ReactNode
+  id: string
+  url: string
+  onLoad?: () => void
+  onError?: (error: unknown) => void
+}
+
+export type ModelAssetProps = {
+  children?: ReactNode
+  id: string
+  src: string
+  onLoad?: () => void
+  onError?: (error: unknown) => void
+}
+
+export type AttachmentAssetProps = {
+  name: string
+  children?: ReactNode
+}
+
+export const UnlitMaterial = createNullFacade<UnlitMaterialProps>(
+  'UnlitMaterial',
+  impl => impl.UnlitMaterial,
+)
+
+export const Material = createNullFacade<MaterialProps>(
+  'Material',
+  impl => impl.Material,
+)
+
+export const Texture = createNullFacade<TextureProps>(
+  'Texture',
+  impl => impl.Texture,
+)
+
+export const ModelAsset = createNullFacade<ModelAssetProps>(
+  'ModelAsset',
+  impl => impl.ModelAsset,
+)
+
+export const AttachmentAsset = createNullFacade<AttachmentAssetProps>(
+  'AttachmentAsset',
+  impl => impl.AttachmentAsset,
+)

--- a/packages/react/src/facades/shared/warnBootForgotten.ts
+++ b/packages/react/src/facades/shared/warnBootForgotten.ts
@@ -1,0 +1,41 @@
+import { hasBootSpatialBeenCalled } from '../../runtime/boot'
+import { isSpatialReady } from '../../runtime/bridge'
+import { detectSpatialRuntime } from '../../runtime/detect'
+
+let hasWarned = false
+
+/**
+ * One-shot dev-mode console warning when a facade renders fallback in a
+ * WebSpatial runtime because `bootSpatial()` was never called.
+ *
+ * Per spatial-lazy-load spec Scenarios "Dev-mode warning when boot is forgotten
+ * in a WebSpatial runtime" + "No dev-mode warning in non-WebSpatial browsers":
+ *   - Plain web (`detectSpatialRuntime() === null`): silent — fallback IS the
+ *     final intended display.
+ *   - `bootSpatial()` already called (pending / rejected / succeeded): silent —
+ *     the developer wired the boot path; this warning would be misleading.
+ *   - Bridge ready (`isSpatialReady()` is true): silent — facade is about to
+ *     render the real implementation anyway.
+ *   - WebSpatial runtime + boot not yet called + bridge not ready: warn once.
+ *
+ * Stripped from production builds via `process.env.NODE_ENV` guard
+ * (consumer bundlers / tsup minify dead-code).
+ */
+export function warnBootForgotten(componentName: string): void {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
+    return
+  }
+  if (hasWarned) return
+  if (detectSpatialRuntime() === null) return
+  if (isSpatialReady()) return
+  if (hasBootSpatialBeenCalled()) return
+
+  hasWarned = true
+  console.warn(
+    `[WebSpatial] ${componentName} rendered fallback in a WebSpatial runtime because bootSpatial() may not have been awaited. Call \`await bootSpatial()\` from @webspatial/react-sdk before initial render.`,
+  )
+}
+
+export function __resetBootForgottenWarningForTests(): void {
+  hasWarned = false
+}

--- a/packages/react/src/facades/withSpatialMonitor.tsx
+++ b/packages/react/src/facades/withSpatialMonitor.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { ComponentType, ElementType, Ref, forwardRef } from 'react'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+const facadeCache = new Map<ElementType, ComponentType<any>>()
+
+/**
+ * Default-entry facade for the `withSpatialMonitor(El)` HOC.
+ *
+ * Per spec "HOC facade preserves wrapper-cache identity contract" Scenario:
+ * same `El` reference → same wrapper reference. Cache key is the raw `El`.
+ *
+ * Fallback renders `<El {...passthrough} ref={ref} />` (transparent
+ * passthrough). After boot the wrapper delegates to the real
+ * `withSpatialMonitor(El)` HOC, which has its own internal cache so
+ * repeated calls return a stable reference.
+ */
+export function withSpatialMonitor(El: ElementType): ElementType {
+  const cached = facadeCache.get(El)
+  if (cached) return cached
+
+  const FacadeWrapper = forwardRef(function FacadeWrapper(
+    givenProps: Record<string, unknown>,
+    ref: Ref<HTMLElement>,
+  ) {
+    const ready = useSpatialReady()
+    if (!ready) {
+      warnBootForgotten('withSpatialMonitor')
+      const { El: _ignoredEl, ...passthrough } = givenProps
+      const Element = El
+      return <Element {...(passthrough as any)} ref={ref as any} />
+    }
+    const RealHOC = getSpatialImpl()!
+      .withSpatialMonitor as typeof withSpatialMonitor
+    const RealWrapper = RealHOC(El) as unknown as ComponentType<
+      Record<string, unknown> & { ref?: unknown }
+    >
+    return <RealWrapper {...givenProps} ref={ref as any} />
+  })
+
+  FacadeWrapper.displayName = `WithSpatialMonitor(${componentDisplayName(El)})`
+
+  facadeCache.set(El, FacadeWrapper)
+  return FacadeWrapper
+}
+
+export function __resetWithSpatialMonitorCacheForTests(): void {
+  facadeCache.clear()
+}
+
+function componentDisplayName(El: ElementType): string {
+  if (typeof El === 'string') return El
+  const c = El as { displayName?: string; name?: string }
+  return c.displayName || c.name || 'Component'
+}

--- a/packages/react/src/facades/withSpatialized2DElementContainer.tsx
+++ b/packages/react/src/facades/withSpatialized2DElementContainer.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { ComponentType, ElementType, ForwardedRef, forwardRef } from 'react'
+import type {
+  Spatialized2DElementContainerProps,
+  SpatializedElementRef,
+} from '../spatialized-container/types'
+import { getSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+
+const SPATIAL_EVENT_PROPS = [
+  'onSpatialTap',
+  'onSpatialDragStart',
+  'onSpatialDrag',
+  'onSpatialDragEnd',
+  'onSpatialRotate',
+  'onSpatialRotateEnd',
+  'onSpatialMagnify',
+  'onSpatialMagnifyEnd',
+  'spatialEventOptions',
+  'onSpatialContentReady',
+] as const
+
+const facadeCache = new Map<ElementType, ComponentType<any>>()
+
+/**
+ * Default-entry facade for the `withSpatialized2DElementContainer(Comp)` HOC.
+ *
+ * Per spec "HOC facade preserves wrapper-cache identity contract" Scenario:
+ * passing the same `Component` reference more than once returns the same
+ * wrapper facade reference. Cache key is the raw `Component` reference; no
+ * normalization.
+ *
+ * In fallback mode the wrapper is a transparent passthrough — `<Component
+ * {...passthroughProps} ref={ref} />` after stripping spatial-only event
+ * handlers / spatial-only options. Once `bootSpatial()` resolves, the
+ * wrapper renders the real spatialized container by delegating to the real
+ * HOC produced via `getSpatialImpl()!.withSpatialized2DElementContainer`
+ * (the real HOC has its own internal cache, so `RealHOC(Component)`
+ * returns a stable reference across renders).
+ */
+export function withSpatialized2DElementContainer<P extends ElementType>(
+  Component: P,
+): P {
+  const cached = facadeCache.get(Component)
+  if (cached) {
+    return cached as unknown as P
+  }
+
+  const FacadeWrapper = forwardRef(function FacadeWrapper(
+    givenProps: Spatialized2DElementContainerProps<P>,
+    ref: ForwardedRef<SpatializedElementRef>,
+  ) {
+    const ready = useSpatialReady()
+    if (!ready) {
+      warnBootForgotten('withSpatialized2DElementContainer')
+      const { component: _component, ...rest } = givenProps as Record<
+        string,
+        unknown
+      > & { component?: unknown }
+      const passthrough = stripSpatialOnlyProps(rest)
+      const Element = Component as ElementType
+      return <Element {...(passthrough as any)} ref={ref as any} />
+    }
+    const RealHOC = getSpatialImpl()!
+      .withSpatialized2DElementContainer as typeof withSpatialized2DElementContainer
+    const RealWrapper = RealHOC(Component)
+    const RealComponent = RealWrapper as unknown as ComponentType<
+      Spatialized2DElementContainerProps<P> & { ref?: unknown }
+    >
+    return <RealComponent {...givenProps} ref={ref as any} />
+  })
+
+  FacadeWrapper.displayName = `WithSpatialized2DElementContainer(${componentDisplayName(Component)})`
+
+  facadeCache.set(Component, FacadeWrapper)
+  return FacadeWrapper as unknown as P
+}
+
+export function __resetWithSpatialized2DElementContainerCacheForTests(): void {
+  facadeCache.clear()
+}
+
+function stripSpatialOnlyProps(props: Record<string, unknown>) {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(props)) {
+    if ((SPATIAL_EVENT_PROPS as readonly string[]).includes(key)) continue
+    out[key] = props[key]
+  }
+  return out
+}
+
+function componentDisplayName(Component: ElementType): string {
+  if (typeof Component === 'string') return Component
+  const c = Component as { displayName?: string; name?: string }
+  return c.displayName || c.name || 'Component'
+}

--- a/packages/react/src/hooks-web/useMetrics-placeholder.ts
+++ b/packages/react/src/hooks-web/useMetrics-placeholder.ts
@@ -1,0 +1,44 @@
+/**
+ * `useMetrics` placeholder constants (web-mode fallback).
+ *
+ * Module-level frozen singleton with module-level constant function
+ * references for `pointToPhysical` / `physicalToPoint`. The 1/1360 ratio
+ * matches today's `noRuntime.ts` web fallback so consumers see no behavior
+ * change after the lazy-load architecture lands.
+ *
+ * Per spatial-lazy-load spec "Hook placeholders" Requirement (the
+ * `useMetrics` row in the public-hook table) + "useMetrics placeholder
+ * returns the documented fallback values" / "useMetrics function identities
+ * are stable across renders" / "useMetrics is SSR-safe" Scenarios.
+ *
+ * Pure constants module — no React imports, no `'use client'` directive,
+ * no `window` access. Safe to call during SSR and to import from
+ * server-only modules.
+ */
+
+const POINT_TO_PHYSICAL_RATIO = 1 / 1360
+const PHYSICAL_TO_POINT_RATIO = 1360
+
+function pointToPhysical(point: number, _options?: object): number {
+  return point * POINT_TO_PHYSICAL_RATIO
+}
+
+function physicalToPoint(physical: number, _options?: object): number {
+  return physical * PHYSICAL_TO_POINT_RATIO
+}
+
+const METRICS_PLACEHOLDER = Object.freeze({
+  pointToPhysical,
+  physicalToPoint,
+})
+
+export type MetricsPlaceholder = typeof METRICS_PLACEHOLDER
+
+/**
+ * Returns the frozen module-level metrics singleton. The two function
+ * references are stable across the page lifetime (consumers using them in
+ * `useEffect` dependency arrays get no re-runs).
+ */
+export function useMetricsPlaceholder(): MetricsPlaceholder {
+  return METRICS_PLACEHOLDER
+}

--- a/packages/react/src/hooks-web/useMetrics.test.tsx
+++ b/packages/react/src/hooks-web/useMetrics.test.tsx
@@ -1,0 +1,149 @@
+import { act, cleanup, render, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import { __resetBootStateForTests, bootSpatial } from '../runtime/boot'
+import {
+  __resetSpatialBridgeForTests,
+  __setSpatialImplLoaderForTests,
+  type SpatialImplementation,
+} from '../runtime/bridge'
+import { useMetrics } from './useMetrics'
+import { useMetricsPlaceholder } from './useMetrics-placeholder'
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  })
+}
+
+function setPlainWebUserAgent(): void {
+  setUserAgent('Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36')
+}
+
+function setPuppeteerUserAgent(): void {
+  setUserAgent('Mozilla/5.0 Chrome/120.0.0.0 Puppeteer Safari/537.36')
+}
+
+describe('useMetrics placeholder', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+    setPlainWebUserAgent()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+  })
+
+  it('returns the documented 1/1360 ratio constants (per "useMetrics placeholder returns the documented fallback values" Scenario)', () => {
+    const m = useMetricsPlaceholder()
+    expect(m.pointToPhysical(0)).toBe(0)
+    expect(m.pointToPhysical(1360)).toBe(1)
+    expect(m.physicalToPoint(1)).toBe(1360)
+  })
+
+  it('exposes stable function identities across calls (per "useMetrics function identities are stable across renders" Scenario)', () => {
+    const a = useMetricsPlaceholder()
+    const b = useMetricsPlaceholder()
+    expect(a).toBe(b)
+    expect(a.pointToPhysical).toBe(b.pointToPhysical)
+    expect(a.physicalToPoint).toBe(b.physicalToPoint)
+  })
+
+  it('placeholder singleton is frozen', () => {
+    const m = useMetricsPlaceholder()
+    expect(Object.isFrozen(m)).toBe(true)
+  })
+})
+
+describe('useMetrics public hook (placeholder-vs-real selector)', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+    setPlainWebUserAgent()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
+  })
+
+  it('returns the placeholder when isSpatialReady() is false', () => {
+    const { result } = renderHook(() => useMetrics())
+    expect(result.current.pointToPhysical(1360)).toBe(1)
+    expect(result.current.physicalToPoint(1)).toBe(1360)
+  })
+
+  it('keeps function identities stable across renders inside the same component instance', () => {
+    const { result, rerender } = renderHook(() => useMetrics())
+    const first = result.current
+    rerender()
+    rerender()
+    rerender()
+    expect(result.current).toBe(first)
+    expect(result.current.pointToPhysical).toBe(first.pointToPhysical)
+    expect(result.current.physicalToPoint).toBe(first.physicalToPoint)
+  })
+
+  it('renderToString returns the placeholder constants without touching window (per "useMetrics is SSR-safe" Scenario)', () => {
+    function Probe() {
+      const m = useMetrics()
+      return <span>{m.pointToPhysical(1360)}</span>
+    }
+    const html = renderToString(<Probe />)
+    expect(html).toContain('>1<')
+  })
+
+  it('does NOT switch implementations mid-life: a component that first invoked the placeholder keeps invoking the placeholder even after bootSpatial() resolves (per "Hook implementation does not switch mid-life" Scenario)', async () => {
+    setPuppeteerUserAgent()
+    // Sentinel "real" useMetrics that returns different (and detectable) values.
+    const sentinelImpl = {
+      useMetrics: () => ({
+        pointToPhysical: (n: number) => n * 7,
+        physicalToPoint: (n: number) => n * 11,
+      }),
+    } as unknown as SpatialImplementation
+    __setSpatialImplLoaderForTests(() => Promise.resolve(sentinelImpl))
+
+    const { result, rerender } = renderHook(() => useMetrics())
+    // First render mounted while spatial was not ready ⇒ placeholder pinned for life.
+    expect(result.current.pointToPhysical(1360)).toBe(1)
+
+    await act(async () => {
+      await bootSpatial()
+    })
+    rerender()
+
+    // Despite isSpatialReady === true now, this instance keeps the placeholder.
+    expect(result.current.pointToPhysical(1360)).toBe(1)
+    expect(result.current.physicalToPoint(1)).toBe(1360)
+  })
+
+  it('a fresh instance after remount picks up the real implementation once boot has resolved (per "Remount picks up the real hook implementation" Scenario)', async () => {
+    setPuppeteerUserAgent()
+    const sentinelImpl = {
+      useMetrics: () => ({
+        pointToPhysical: (n: number) => n * 7,
+        physicalToPoint: (n: number) => n * 11,
+      }),
+    } as unknown as SpatialImplementation
+    __setSpatialImplLoaderForTests(() => Promise.resolve(sentinelImpl))
+
+    await act(async () => {
+      await bootSpatial()
+    })
+
+    const { result } = renderHook(() => useMetrics())
+    expect(result.current.pointToPhysical(3)).toBe(21)
+    expect(result.current.physicalToPoint(3)).toBe(33)
+  })
+})

--- a/packages/react/src/hooks-web/useMetrics.ts
+++ b/packages/react/src/hooks-web/useMetrics.ts
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+import { getSpatialImpl, isSpatialReady } from '../runtime/bridge'
+import {
+  type MetricsPlaceholder,
+  useMetricsPlaceholder,
+} from './useMetrics-placeholder'
+
+type MetricsImpl = () => MetricsPlaceholder
+
+/**
+ * Public `useMetrics` hook.
+ *
+ * Per spatial-lazy-load spec "Hook placeholders" Requirement: the
+ * placeholder-vs-real selection is decided ONCE per component instance via
+ * a `useState` initializer. The hook never switches mid-life: a component
+ * that first invoked the placeholder keeps invoking the placeholder for
+ * its entire lifetime, even after `bootSpatial()` resolves. To get the
+ * real hook implementation, the component MUST be unmounted and remounted
+ * (e.g. via a `key` change, parent unmount, or page reload).
+ *
+ * This decision lives in `useState`'s initializer (called once per
+ * instance) — that is what allows the placeholder and the real hook to
+ * differ in their internal React Hook call sequences without violating
+ * the Rules of Hooks.
+ */
+export function useMetrics(): MetricsPlaceholder {
+  const [impl] = useState<MetricsImpl>(() => {
+    if (!isSpatialReady()) return useMetricsPlaceholder
+    const real = getSpatialImpl()?.useMetrics
+    return (real ?? useMetricsPlaceholder) as MetricsImpl
+  })
+  return impl()
+}

--- a/packages/react/src/runtime/boot.ts
+++ b/packages/react/src/runtime/boot.ts
@@ -1,10 +1,29 @@
 import { loadSpatialImpl } from './bridge'
 import { detectSpatialRuntime } from './detect'
 
+let hasBeenCalled = false
+
 export async function bootSpatial(): Promise<void> {
+  hasBeenCalled = true
+
   if (detectSpatialRuntime() === null) {
     return
   }
 
   await loadSpatialImpl()
+}
+
+/**
+ * Returns `true` once `bootSpatial()` has been invoked at least once on this
+ * page (independent of resolution / rejection / runtime gating). Consumed by
+ * the facades' dev-mode "boot was forgotten" warning per spatial-lazy-load
+ * spec's "Dev-mode warning when boot is forgotten in a WebSpatial runtime"
+ * Scenario. NOT part of the documented public API.
+ */
+export function hasBootSpatialBeenCalled(): boolean {
+  return hasBeenCalled
+}
+
+export function __resetBootStateForTests(): void {
+  hasBeenCalled = false
 }

--- a/packages/react/src/runtime/index.ts
+++ b/packages/react/src/runtime/index.ts
@@ -1,4 +1,4 @@
-export { bootSpatial } from './boot'
+export { bootSpatial, hasBootSpatialBeenCalled } from './boot'
 export {
   getSpatialImpl,
   isSpatialReady,

--- a/packages/react/src/runtime/lazy-load-foundation.test.tsx
+++ b/packages/react/src/runtime/lazy-load-foundation.test.tsx
@@ -9,7 +9,7 @@ import {
   onSpatialLoadError,
   type SpatialImplementation,
 } from './bridge'
-import { bootSpatial } from './boot'
+import { __resetBootStateForTests, bootSpatial } from './boot'
 import { detectSpatialRuntime } from './detect'
 import { WebSpatialBootError } from './errors'
 import { useSpatialReady } from './useSpatialReady'
@@ -35,12 +35,14 @@ describe('lazy-load runtime foundation', () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
     __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
     setPlainWebUserAgent()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     __resetSpatialBridgeForTests()
+    __resetBootStateForTests()
   })
 
   it('detectSpatialRuntime is SSR safe and returns null without window', () => {


### PR DESCRIPTION
Implements `tasks.md §4 + §5` from spec PR #1170 (`openspec/lazy-load-spatial-runtime`), stacked on top of PR #1201 (`feat/lazy-load-foundation`).

> ⚠️ **Stacked PR — depends on #1201 → which depends on #1170.**
> Base branch is `feat/lazy-load-foundation` so the diff here is purely the facade + hook-placeholder source code. **Do not merge before #1201 is merged.** Once #1201 lands, this PR can be retargeted to its new base (`openspec/lazy-load-spatial-runtime`, or `main` if the spec PR has also landed).

## Summary

- New `packages/react/src/facades/` directory containing the default-entry facade for every public spatial component / HOC. Each facade subscribes to bridge readiness via `useSpatialReady()` (from PR 1) and renders the spec-pinned per-component fallback when the spatial chunk is not yet loaded; once `bootSpatial()` resolves in a WebSpatial runtime, the facade delegates to the real implementation resolved via `getSpatialImpl()`.
- New `packages/react/src/hooks-web/` directory with `useMetrics-placeholder.ts` (no React imports / no `'use client'`; frozen 1/1360 ratio singleton) and `useMetrics.ts` (the public hook that uses a `useState` initializer to pin placeholder vs real **once per component instance** — per spec's "Hook implementation does not switch mid-life" Scenario).
- Single additive touch on PR 1's surface: `runtime/boot.ts` exposes `hasBootSpatialBeenCalled()` (consumed by the dev-mode "boot was forgotten" warning) plus a test-only `__resetBootStateForTests()`. Re-exported from `runtime/index.ts`.
- 62 new vitest cases (54 facades + 8 useMetrics). Total suite now **169/169 green** (up from 107 in #1201).
- `src/index.ts` is **not** touched in this PR. The new modules exist as dead-code paths until #1170's PR 4 (default-entry switchover) wires them in.

## Acceptance criteria (Scenarios covered by tests in this PR)

**`spatial-lazy-load` — Component facades**

- [x] Per-component default fallback table reproduced literally:
  - [x] `Model` → degraded native `<model>` with spatial-event props + `spatialEventOptions` stripped, ref attached to the `<model>` element ("Model fallback renders degraded `<model>` tag")
  - [x] `Reality` → single `<div aria-hidden="true" ref>` preserving className/style, children NOT mounted ("Reality fallback preserves layout")
  - [x] `Entity` / `BoxEntity` / `SphereEntity` / `ConeEntity` / `CylinderEntity` / `PlaneEntity` / `ModelEntity` / `AttachmentEntity` → `null`; ref forwarded but `ref.current === null` for the forwardRef variants ("Facade ref is null when fallback renders no host element")
  - [x] `UnlitMaterial` / `Material` / `Texture` / `ModelAsset` / `AttachmentAsset` → `null`
  - [x] `SceneGraph` / `World` → `<>{children}</>` (transparent)
  - [x] HOC wrappers → `<Comp/El {...passthrough} ref/>` after stripping spatial-only handlers
- [x] `displayName` matches public name for every facade (`Model`, `Reality`, `BoxEntity`, …)
- [x] HOC wrapper-cache identity contract: same `Comp` / `El` reference → same wrapper reference ("HOC facade preserves wrapper-cache identity contract")
- [x] No facade is wrapped in `React.memo`
- [x] Every facade source file begins with the `'use client'` directive (the build-output assertion in `dist/` is PR 5)
- [x] Facade → real implementation switch on `false → true` readiness flip ("Mounted facade switches to real implementation when bridge becomes ready") — verified for `Model`, `Reality`, and one entity facade against a mocked spatial-chunk namespace

**`spatial-lazy-load` — `bootSpatial` dev-mode warning differential**

- [x] No warning in a plain web browser regardless of how many facades render ("No dev-mode warning in non-WebSpatial browsers")
- [x] Exactly one warning in a WebSpatial runtime when a facade renders fallback and `bootSpatial()` has never been called ("Dev-mode warning when boot is forgotten in a WebSpatial runtime")
- [x] No warning in a WebSpatial runtime once `bootSpatial()` has been called (even if the boot is still pending) — the warning is gated on `hasBootSpatialBeenCalled()` so successful, pending, and rejected boot all silence it

**`spatial-lazy-load` — Hook placeholders**

- [x] `useMetrics()` placeholder returns `pointToPhysical(pt) === pt / 1360` and `physicalToPoint(m) === m * 1360` with assertion-grade values `(0 → 0`, `1360 → 1`, `1 → 1360)` ("useMetrics placeholder returns the documented fallback values")
- [x] Function identities (`pointToPhysical` / `physicalToPoint`) and the returned object itself are stable across renders within the same component instance ("useMetrics function identities are stable across renders")
- [x] `renderToString` produces the placeholder output without touching `window` or throwing ("useMetrics is SSR-safe")
- [x] Component instance that first invoked the placeholder keeps invoking the placeholder for its entire lifetime even after `bootSpatial()` resolves and the bridge real `useMetrics` becomes available ("Hook implementation does not switch mid-life")
- [x] A fresh instance after remount picks up the real implementation once boot has resolved ("Remount picks up the real hook implementation")

**Tasks §5.3 — Internal reality hooks are not publicly exported**

- [x] `useEntity` / `useEntityRef` / `useEntityTransform` / `useEntityEvent` / `useEntityId` / `useRealityEvents` / `useForceUpdate` are NOT runtime-exported from `src/reality/index.tsx` (regression-pinned by unit test). `src/reality/index.tsx` only re-exports the `EntityRef` **type** (`export type { EntityRef } from './hooks'`) so the hook functions never leak to the default entry.

## Out of scope (deferred to later PRs)

- Unified JSX runtime that strips markers + wraps with these facade HOCs — PR 3
- Default entry rewrite (`src/index.ts`) to actually expose these facades + remove the four internal container exports + `@deprecate` `createElement` + delete the top-level `initPolyfill()` side effect → PR 4
- Physical relocation of real spatial source files into `src/spatial/` → PR 4
- Build-output audit that scans `dist/index.js` for spatial-only identifiers + size budget enforcement → PR 5
- SSR / hydration integration tests, parity validation, README + migration guide → PR 6

## Test plan

- [x] `pnpm test` in `packages/react` is green (`tsc -p ./tsconfig.json && vitest run` → **169/169**, including 54 in `lazy-load-facades.test.tsx` and 8 in `useMetrics.test.tsx`)
- [x] No edits to any tracked file outside the new `facades/` and `hooks-web/` directories, the three additive runtime changes (`runtime/boot.ts` exposes `hasBootSpatialBeenCalled`; `runtime/index.ts` re-exports it; `runtime/lazy-load-foundation.test.tsx` resets the new boot flag in its `beforeEach`/`afterEach`), and the new changeset
- [ ] CI checks pass
- [ ] After #1201 lands, retarget this PR's base from `feat/lazy-load-foundation` to its new parent (`openspec/lazy-load-spatial-runtime` or `main` depending on where #1201 lands)
