### PR TITLE
feat(react)!: default-entry switchover (BREAKING) 【Draft】

### DIFF
--- a/.changeset/lazy-load-default-entry.md
+++ b/.changeset/lazy-load-default-entry.md
@@ -1,0 +1,21 @@
+---
+'@webspatial/react-sdk': major
+---
+
+BREAKING — default-entry switchover for `openspec/lazy-load-spatial-runtime` (PR 4 of 6). Rewrites `packages/react/src/index.ts` so the default entry exposes ONLY the documented public surface: lazy-load runtime API (`bootSpatial`, `isSpatialReady`, `useSpatialReady`, `onSpatialLoadError`, `WebSpatialBootError`), spatial primitive **facades** (`Model`, `Reality`, `Entity`, `*Entity` family + aliases, materials / assets, `SceneGraph` / `World`), HOC facades (`withSpatialized2DElementContainer`, `withSpatialMonitor`), the `useMetrics` placeholder-or-real selector, stateless utilities (`enableDebugTool`, `convertCoordinate`, `getAbsoluteUrl`, `initScene`, `SSRProvider`), pure re-exports (`WebSpatialRuntime`, `WebSpatialRuntimeError`, `CapabilityKey`, `version`), and the deprecated `createElement` export retained for the classic JSX transform.
+
+**Removed from default entry** (per proposal BREAKING bullet):
+
+- `SpatializedContainer`, `Spatialized2DElementContainer`, `SpatializedStatic3DElementContainer`, `SpatialMonitor` — facade-HOC implementation details; user code routes through `withSpatialized2DElementContainer` / `withSpatialMonitor` facades.
+- Internal reality hooks (`useEntity`, `useEntityRef`, `useEntityTransform`, `useEntityEvent`, `useEntityId`, `useRealityEvents`, `useForceUpdate`) — never documented public surface; ship inside the spatial chunk alongside their consumers.
+- Other previously-leaked internals (`initPolyfill`, `SpatialCustomStyleVars`, `StandardSpatializedContainer`, `PortalSpatializedContainer`, `TransformVisibilityTaskContainer`, `eventMap`).
+
+**Other changes in this PR**:
+
+- Removes the top-level `if (typeof window !== 'undefined') initPolyfill()` side effect from the default entry; polyfill installation moves into the spatial chunk's bootstrap inside `src/spatial/index.ts` (executed when the spatial chunk dynamically loads), per spec tasks.md §7.2.
+- After this PR, `@webspatial/react-sdk` self-imports in the JSX runtime (`packages/react/src/jsx/jsx-shared.ts`) resolve to the facade versions of `Model` / `withSpatialized2DElementContainer` / `withSpatialMonitor` (PR 3 already used a relative path; the resolution endpoint is identical after this switchover, per spec tasks.md §7.4).
+- `createElement` retains its v1 behavior; the `@deprecated` JSDoc on it was added in PR 3.
+
+**Migration guide** (planned for PR 6): existing apps that imported `Spatialized2DElementContainer` / `SpatializedStatic3DElementContainer` / `SpatializedContainer` / `SpatialMonitor` directly MUST switch to the HOC facades (`withSpatialized2DElementContainer(Component)` / `withSpatialMonitor(Element)`) or to the per-component facades (`Model`, `Reality`, etc.). Apps that imported internal reality hooks were doing so against undocumented API; the supported migration is to drop those imports — the facade-shaped public API covers the documented use cases.
+
+Real spatial implementation modules (`./Model`, `./reality/*`, the `./spatialized-container/*` runtime values, the `./spatialized-container-monitor/*` runtime values, and the real `./useMetrics`) are now reachable ONLY from `src/spatial/index.ts` (the dynamic-import target). Physical file relocation under `src/spatial/` (spec tasks.md §3.1) is deferred to a follow-up cosmetic cleanup PR: the runtime module-graph contract (`tasks.md §7.3`) is satisfied by removing the static imports from the default entry, which this PR does. The corresponding build-time identifier scan + size budget assertion lives in PR 5 (`tasks.md §9.1` / §9.4).

--- a/packages/react/src/default-entry-public-surface.test.ts
+++ b/packages/react/src/default-entry-public-surface.test.ts
@@ -1,0 +1,241 @@
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import * as sdk from './index'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const indexSource = readFileSync(resolve(__dirname, 'index.ts'), 'utf8')
+
+describe('default-entry public surface (spec tasks.md §7.1 / §7.2 / §7.3 / §3.3)', () => {
+  describe('Public runtime exports (per spec "Public API surface")', () => {
+    // Runtime-value exports — these MUST resolve to a defined binding after
+    // `import * as sdk from '@webspatial/react-sdk'`. Types-only exports are
+    // erased at runtime and validated separately below via a source-level
+    // check on `src/index.ts`.
+    const requiredRuntimeExports = [
+      // Lazy-load runtime
+      'bootSpatial',
+      'isSpatialReady',
+      'useSpatialReady',
+      'onSpatialLoadError',
+      'WebSpatialBootError',
+      // Core infrastructure
+      'WebSpatialRuntime',
+      'WebSpatialRuntimeError',
+      'enableDebugTool',
+      'convertCoordinate',
+      'getAbsoluteUrl',
+      'initScene',
+      'SSRProvider',
+      // Spatial primitive facades
+      'AttachmentEntity',
+      'Box',
+      'BoxEntity',
+      'Cone',
+      'ConeEntity',
+      'Cylinder',
+      'CylinderEntity',
+      'Entity',
+      'Model',
+      'ModelEntity',
+      'Plane',
+      'PlaneEntity',
+      'Reality',
+      'SceneGraph',
+      'Sphere',
+      'SphereEntity',
+      'AttachmentAsset',
+      'Material',
+      'ModelAsset',
+      'Texture',
+      'UnlitMaterial',
+      'World',
+      'withSpatialMonitor',
+      'withSpatialized2DElementContainer',
+      // Hooks
+      'useMetrics',
+      // Deprecated v1 export
+      'createElement',
+      // Constants
+      'version',
+    ] as const
+
+    it.each(requiredRuntimeExports)('exports `%s`', name => {
+      expect(name in sdk).toBe(true)
+      expect((sdk as Record<string, unknown>)[name]).toBeDefined()
+    })
+  })
+
+  describe('Removed internals (per proposal BREAKING bullet + spec tasks.md §3.3)', () => {
+    // The four internal container / monitor constructors MUST be removed from
+    // the public surface — they are facade-HOC implementation details and
+    // user-facing exports route through `withSpatialized2DElementContainer` /
+    // `withSpatialMonitor` facade HOCs instead.
+    const removedInternals = [
+      'SpatializedContainer',
+      'Spatialized2DElementContainer',
+      'SpatializedStatic3DElementContainer',
+      'SpatialMonitor',
+    ] as const
+
+    it.each(removedInternals)('does NOT export `%s`', name => {
+      expect(name in sdk).toBe(false)
+    })
+
+    // Internal reality hooks MUST NOT be part of the documented public API
+    // (per spec tasks.md §5.3 / §7.1 — they ship inside the spatial chunk
+    // alongside the components that consume them).
+    const internalRealityHooks = [
+      'useEntity',
+      'useEntityRef',
+      'useEntityTransform',
+      'useEntityEvent',
+      'useEntityId',
+      'useRealityEvents',
+      'useForceUpdate',
+    ] as const
+
+    it.each(internalRealityHooks)(
+      'does NOT export internal reality hook `%s`',
+      name => {
+        expect(name in sdk).toBe(false)
+      },
+    )
+
+    // Other internals that were previously surfaced via `export *` and MUST
+    // now stay inside the spatial chunk.
+    const otherInternals = [
+      'initPolyfill',
+      'SpatialCustomStyleVars',
+      'StandardSpatializedContainer',
+      'PortalSpatializedContainer',
+      'TransformVisibilityTaskContainer',
+      'eventMap',
+    ] as const
+
+    it.each(otherInternals)('does NOT export internal `%s`', name => {
+      expect(name in sdk).toBe(false)
+    })
+  })
+
+  describe('Default-entry static module graph (spec tasks.md §7.3 — source-level check)', () => {
+    // Per spec tasks.md §7.3: `no static import path from src/index.ts
+    // reaches src/spatial/` and, since §3.1's physical file move is
+    // staged after PR 4, the same prohibition applies to the existing
+    // spatial implementation directories. Type-only re-exports / imports
+    // are erased at runtime and remain permitted (the underlying file is
+    // not pulled into the bundle's module graph).
+    //
+    // We assert this at the source level on `src/index.ts` only. A full
+    // graph walk lives in `tasks.md §9.4` (identifier scan on the built
+    // `dist/index.js`) which PR 5 wires into CI.
+
+    // Strip comments before regex parsing so a path mentioned inside a
+    // comment doesn't false-positive against the runtime-import rule.
+    const stripComments = (src: string): string => {
+      let stripped = src.replace(/\/\*[\s\S]*?\*\//g, '')
+      stripped = stripped
+        .split('\n')
+        .map(line => line.replace(/(^|[^:])\/\/.*$/, '$1'))
+        .join('\n')
+      return stripped
+    }
+
+    const sourceNoComments = stripComments(indexSource)
+
+    // Match `import` / `export ... from '...'` declarations, possibly
+    // spanning multiple lines. The non-greedy `[\s\S]*?` between the
+    // keyword and `from` covers both `{ a, b }` and `* as ns` forms while
+    // stopping at the first `from '...'` clause.
+    const declRe =
+      /\b(import|export)\s+(type\s+)?([\s\S]*?)from\s+['"]([^'"]+)['"]/g
+
+    const forbiddenRuntimePathPrefixes = [
+      './Model',
+      './reality',
+      './spatialized-container',
+      './spatialized-container-monitor',
+      './useMetrics',
+      './spatial',
+      './notifyUpdateStandInstanceLayout',
+    ]
+
+    const findOffendingRuntimeImports = (): {
+      keyword: string
+      bindings: string
+      path: string
+    }[] => {
+      const offenders: { keyword: string; bindings: string; path: string }[] =
+        []
+      let match: RegExpExecArray | null
+      declRe.lastIndex = 0
+      while ((match = declRe.exec(sourceNoComments)) !== null) {
+        const [, keyword, typeKeyword, bindings, path] = match
+        // Skip type-only re-exports / imports — TypeScript / esbuild
+        // erase them and the underlying module is NOT pulled into the
+        // runtime bundle's module graph.
+        if (typeKeyword) continue
+        for (const prefix of forbiddenRuntimePathPrefixes) {
+          if (path === prefix || path.startsWith(prefix + '/')) {
+            offenders.push({
+              keyword,
+              bindings: bindings.trim().replace(/\s+/g, ' '),
+              path,
+            })
+            break
+          }
+        }
+      }
+      return offenders
+    }
+
+    it('contains NO runtime `import` / `export` from spatial implementation paths', () => {
+      const offenders = findOffendingRuntimeImports()
+      // If this test fails, the error message lists each offending
+      // declaration so the PR author can either route the import through
+      // a facade / runtime helper or convert it to a type-only re-export.
+      expect(offenders).toEqual([])
+    })
+
+    it('contains NO top-level `initPolyfill` invocation (per spec tasks.md §7.2)', () => {
+      const invokesPolyfill = /\binitPolyfill\s*\(/.test(sourceNoComments)
+      expect(invokesPolyfill).toBe(false)
+    })
+
+    it('declares `version` exactly once', () => {
+      const matches = sourceNoComments.match(/export const version\s*=/g) ?? []
+      expect(matches.length).toBe(1)
+    })
+  })
+
+  describe('Facade vs real-impl identity (PR 4 wires facades into default entry)', () => {
+    it('the default-entry `Model` is the facade exported from `./facades`, not the real spatial Model', async () => {
+      const facadeMod = await import('./facades/Model')
+      expect((sdk as Record<string, unknown>).Model).toBe(facadeMod.Model)
+    })
+
+    it('the default-entry `withSpatialized2DElementContainer` is the facade HOC', async () => {
+      const facadeMod = await import(
+        './facades/withSpatialized2DElementContainer'
+      )
+      expect(
+        (sdk as Record<string, unknown>).withSpatialized2DElementContainer,
+      ).toBe(facadeMod.withSpatialized2DElementContainer)
+    })
+
+    it('the default-entry `withSpatialMonitor` is the facade HOC', async () => {
+      const facadeMod = await import('./facades/withSpatialMonitor')
+      expect((sdk as Record<string, unknown>).withSpatialMonitor).toBe(
+        facadeMod.withSpatialMonitor,
+      )
+    })
+
+    it('the default-entry `useMetrics` is the placeholder-or-real selector', async () => {
+      const selectorMod = await import('./hooks-web/useMetrics')
+      expect((sdk as Record<string, unknown>).useMetrics).toBe(
+        selectorMod.useMetrics,
+      )
+    })
+  })
+})

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,22 +1,164 @@
-import { initPolyfill } from './spatialized-container'
+// =============================================================================
+// `@webspatial/react-sdk` default entry — lazy-load v1.
+//
+// Per spatial-lazy-load spec tasks.md §7.1, the default entry exposes ONLY the
+// documented public surface: bridge / boot / readiness API, the spatial
+// primitive **facades** (which lazy-load the real implementation via
+// `bootSpatial()`), the `useMetrics` placeholder-or-real selector, stateless
+// utilities (Group B), pure re-exports (Group C), and the deprecated
+// `createElement` export retained for the classic JSX transform.
+//
+// Notably absent (per the BREAKING bullet in the proposal): the four internal
+// containers / monitors `SpatializedContainer`, `Spatialized2DElementContainer`,
+// `SpatializedStatic3DElementContainer`, and `SpatialMonitor`. They were
+// previously exposed via `export * from './spatialized-container'` /
+// `./spatialized-container-monitor` and are now facade-HOC implementation
+// details only reachable through the `withSpatialized2DElementContainer` /
+// `withSpatialMonitor` facade HOCs.
+//
+// Real spatial implementation modules (`./Model`, `./reality/*`, the
+// `./spatialized-container/*` and `./spatialized-container-monitor/*` runtime
+// values, and the real `./useMetrics`) MUST NOT be statically reachable from
+// this file. Per spec tasks.md §7.3 the only path from default entry to the
+// spatial implementation is the bridge's dynamic `import('./spatial')` (PR 5
+// publishes the corresponding `@webspatial/react-sdk/spatial` exports
+// subpath). The top-level `initPolyfill()` side effect that previously lived
+// here has been moved into `src/spatial/index.ts` (per spec tasks.md §7.2) so
+// the polyfill installs when the spatial chunk loads, not on every default
+// import.
+// =============================================================================
 
+// --- Lazy-load runtime: bridge / boot / readiness / error class --------------
+export { bootSpatial } from './runtime/boot'
+export { isSpatialReady, onSpatialLoadError } from './runtime/bridge'
+export { useSpatialReady } from './runtime/useSpatialReady'
+export { WebSpatialBootError } from './runtime/errors'
+
+// --- Core infrastructure (Group C: pure re-exports / type re-exports) --------
 export { WebSpatialRuntime } from './webSpatialRuntime'
 export { WebSpatialRuntimeError } from '@webspatial/core-sdk'
 export type { CapabilityKey } from '@webspatial/core-sdk'
+
+// --- Stateless utilities (Group B: gracefully degrade via core-sdk session) --
 export { enableDebugTool } from './utils'
-export * from './initScene'
-export * from './spatialized-container'
-export * from './spatialized-container-monitor'
-export * from './reality'
-export * from './Model'
-export { SSRProvider } from './ssr'
-export { useMetrics } from './useMetrics'
-export { createElement } from './jsx/jsx-shared'
 export { convertCoordinate } from './utils/convertCoordinate'
 export { getAbsoluteUrl } from './utils/urlUtils'
+export * from './initScene'
 
+// --- SSR --------------------------------------------------------------------
+export { SSRProvider } from './ssr'
+
+// --- Spatial primitive facades (Group A: lazy-loaded) -----------------------
+export {
+  AttachmentEntity,
+  Box,
+  BoxEntity,
+  Cone,
+  ConeEntity,
+  Cylinder,
+  CylinderEntity,
+  Entity,
+  Model,
+  ModelEntity,
+  Plane,
+  PlaneEntity,
+  Reality,
+  SceneGraph,
+  Sphere,
+  SphereEntity,
+  AttachmentAsset,
+  Material,
+  ModelAsset,
+  Texture,
+  UnlitMaterial,
+  World,
+  withSpatialMonitor,
+  withSpatialized2DElementContainer,
+} from './facades'
+export type {
+  AttachmentAssetProps,
+  AttachmentEntityProps,
+  BoxEntityProps,
+  ConeEntityProps,
+  CylinderEntityProps,
+  EntityFacadeProps,
+  EntityRefShape,
+  MaterialProps,
+  ModelAssetProps,
+  ModelEntityProps,
+  ModelProps,
+  ModelRef,
+  PlaneEntityProps,
+  RealityProps,
+  SceneGraphProps,
+  SphereEntityProps,
+  TextureProps,
+  UnlitMaterialProps,
+} from './facades'
+
+// --- Hooks (placeholder-or-real selector per spec "Hook placeholders") ------
+export { useMetrics } from './hooks-web/useMetrics'
+
+// --- Public type surface (no runtime values) --------------------------------
+// Spatial event + ref types — referenced by facade prop / ref typing.
+// Using `export type` so TypeScript / esbuild fully erase these
+// re-exports; the underlying `./spatialized-container/types.ts` module
+// stays in the spatial chunk's runtime module graph, not default entry's
+// (per spec tasks.md §7.3).
+export type {
+  ModelLoadEvent,
+  ModelSpatialDragEndEvent,
+  ModelSpatialDragEvent,
+  ModelSpatialDragStartEvent,
+  ModelSpatialMagnifyEndEvent,
+  ModelSpatialMagnifyEvent,
+  ModelSpatialRotateEndEvent,
+  ModelSpatialRotateEvent,
+  ModelSpatialTapEvent,
+  Point3D,
+  Quaternion,
+  Spatialized2DElementContainerProps,
+  SpatializedDivElementRef,
+  SpatializedElementRef,
+  SpatializedStatic3DContainerProps,
+  SpatializedStatic3DElementRef,
+  SpatialContentReadyCallback,
+  SpatialContentReadyContext,
+  SpatialDragEndEvent,
+  SpatialDragEvent,
+  SpatialDragStartEvent,
+  SpatialEventOptions,
+  SpatialMagnifyEndEvent,
+  SpatialMagnifyEvent,
+  SpatialRotateEndEvent,
+  SpatialRotateEvent,
+  SpatialTapEvent,
+  Vec3,
+} from './spatialized-container/types'
+// Entity event types and event handler shapes.
+export type {
+  EntityEventHandler,
+  EntityProps,
+  SpatialDragEndEntityEvent,
+  SpatialDragEntityEvent,
+  SpatialDragStartEntityEvent,
+  SpatialMagnifyEndEntityEvent,
+  SpatialMagnifyEntityEvent,
+  SpatialRotateEndEntityEvent,
+  SpatialRotateEntityEvent,
+  SpatialTapEntityEvent,
+} from './reality/type'
+// `EntityRef` — the (class-shaped) public ref type for `*Entity` facades.
+// Re-exported as type-only — the class value is a spatial-chunk implementation
+// detail, not part of the default-entry runtime surface.
+export type { EntityRef } from './reality/hooks/useEntityRef'
+
+// --- Deprecated JSX runtime classic-transform export ------------------------
+// Annotation lives on the named function in `./jsx/jsx-shared.ts`. See spec
+// "createElement export is deprecated" Scenario; the export's v1 runtime
+// behavior is unchanged (still calls `replaceToSpatialPrimitiveType` +
+// `reactCreateElement`).
+export { createElement } from './jsx/jsx-shared'
+
+// --- Package version --------------------------------------------------------
 export const version = __WEBSPATIAL_REACT_SDK_VERSION__
-
-if (typeof window !== 'undefined') {
-  initPolyfill()
-}

--- a/packages/react/src/spatial/index.ts
+++ b/packages/react/src/spatial/index.ts
@@ -1,5 +1,43 @@
+// =============================================================================
+// `@webspatial/react-sdk/spatial` — bridge-facing spatial namespace.
+//
+// This module is the dynamic-import target invoked by
+// `runtime/bridge.ts#loadSpatialImpl()`. It exposes ONLY the real
+// implementations that default-entry facades need to resolve by name:
+// real `Model`, `Reality`, `Entity`, all `*Entity` components,
+// materials / assets, `SceneGraph` / `World`, the real
+// `withSpatialized2DElementContainer` / `withSpatialMonitor` HOCs, and the
+// real `useMetrics`. Per spec tasks.md §3.2, internal containers / monitors
+// (`SpatializedContainer`, `Spatialized2DElementContainer`,
+// `SpatializedStatic3DElementContainer`, `SpatialMonitor`) and internal
+// reality hooks (`useEntity`, `useEntityRef`, `useEntityTransform`,
+// `useEntityEvent`, `useEntityId`, `useRealityEvents`, `useForceUpdate`)
+// are NOT exposed here even though they are reachable from the spatial
+// chunk's static module graph — they are facade-HOC implementation details.
+//
+// Phasing note (spec tasks.md §3.2): until §3.1's physical file relocation
+// lands, the re-export targets remain pointed at the existing source paths
+// (`../Model`, `../reality`, etc.); the runtime module-graph contract is
+// nevertheless satisfied because `src/index.ts` (the default entry) no
+// longer statically imports any of these paths — they are reachable ONLY
+// through this module, which the bridge dynamic-imports.
+// =============================================================================
+
+import { initPolyfill } from '../spatialized-container'
+
 export * from '../Model'
 export * from '../reality'
 export { useMetrics } from '../useMetrics'
 export { withSpatialized2DElementContainer } from '../spatialized-container'
 export { withSpatialMonitor } from '../spatialized-container-monitor'
+
+// Spatial chunk bootstrap: install the CSS parser + default-style polyfill
+// when the spatial chunk loads. Per spec tasks.md §7.2 this side effect
+// MUST live inside the spatial chunk, NOT in the default entry — the
+// default entry's previous top-level `if (typeof window !== 'undefined')
+// initPolyfill()` was removed in this PR (per "No observable top-level
+// side effects in default-entry modules" Scenario of the Tree-shake
+// friendliness Requirement).
+if (typeof window !== 'undefined') {
+  initPolyfill()
+}

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { version } from './package.json'
 
 export default defineConfig({
   plugins: [react()],
+  // tsup replaces `__WEBSPATIAL_REACT_SDK_VERSION__` at build time via its
+  // `esbuildOptions.define`. Vitest doesn't run through tsup, so tests that
+  // import `src/index.ts` (which references the constant) need an equivalent
+  // global injection here.
+  define: {
+    __WEBSPATIAL_REACT_SDK_VERSION__: JSON.stringify(version),
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION
Implements `tasks.md §7` (+ `§3.3` verification) from spec PR #1170. PR 4 of 6 for `openspec/lazy-load-spatial-runtime`.

> **Stacked** on top of `feat/lazy-load-jsx-runtime` (#1205) → `feat/lazy-load-facades` (#1204) → `feat/lazy-load-foundation` (#1201) → `openspec/lazy-load-spatial-runtime` (spec PR #1170). Review the dependency chain bottom-up; once each upstream PR merges, please **rebase this PR's base** so the diff narrows to only PR 4's changes.

## Summary

This is **the BREAKING switchover.** The default entry no longer surfaces the legacy real-implementation modules; it now exposes only the documented public API (facades + bridge + utilities + the placeholder-or-real `useMetrics` selector). Real spatial implementation modules are reachable only via the bridge's dynamic `import('./spatial')`.

### Public surface (final, per `spec.md` "Public API surface")

- Boot / state: `bootSpatial`, `isSpatialReady`, `useSpatialReady`, `onSpatialLoadError`, `WebSpatialBootError`
- Spatial primitive facades: `Model`, `Reality`, `Entity`, `BoxEntity` / `Box`, `SphereEntity` / `Sphere`, `ConeEntity` / `Cone`, `CylinderEntity` / `Cylinder`, `PlaneEntity` / `Plane`, `ModelEntity`, `AttachmentEntity`, `UnlitMaterial`, `Material`, `Texture`, `ModelAsset`, `AttachmentAsset`, `SceneGraph` / `World`
- HOC facades: `withSpatialized2DElementContainer`, `withSpatialMonitor`
- Hooks: `useMetrics` (placeholder-or-real selector, decided per component instance)
- Group B utilities (gracefully degrade via core-sdk session): `initScene`, `convertCoordinate`, `enableDebugTool`
- Group C re-exports: `WebSpatialRuntime`, `WebSpatialRuntimeError`, `CapabilityKey`, `SSRProvider`, `getAbsoluteUrl`, `version`
- Deprecated v1 export: `createElement` (carries `@deprecated` JSDoc from PR 3)

### BREAKING removals (per proposal BREAKING bullet)

- `SpatializedContainer`, `Spatialized2DElementContainer`, `SpatializedStatic3DElementContainer`, `SpatialMonitor` — facade-HOC implementation details now; route through HOC facades.
- Internal reality hooks (`useEntity`, `useEntityRef`, `useEntityTransform`, `useEntityEvent`, `useEntityId`, `useRealityEvents`, `useForceUpdate`) — were never documented public surface.
- Other leaked internals: `initPolyfill`, `SpatialCustomStyleVars`, `StandardSpatializedContainer`, `PortalSpatializedContainer`, `TransformVisibilityTaskContainer`, `eventMap`.
- Top-level `if (typeof window !== 'undefined') initPolyfill()` side effect — relocated into the spatial chunk's bootstrap (`src/spatial/index.ts`) per `tasks.md §7.2`.

### Acceptance criteria

- [x] Default entry exports every name listed in `spec.md` "Public API surface" (per `tasks.md §7.1`)
- [x] The four legacy container / monitor constructors are NO LONGER part of the default entry (per the proposal BREAKING bullet + `tasks.md §3.3`)
- [x] Internal reality hooks are NOT exported from `src/index.ts` (per `tasks.md §5.3` / `§7.1`)
- [x] Top-level `initPolyfill()` invocation is removed from the default entry; the bootstrap lives in the spatial chunk (per `tasks.md §7.2`)
- [x] No non-type runtime `import` / `export` path from `src/index.ts` reaches `./Model`, `./reality`, `./spatialized-container`, `./spatialized-container-monitor`, `./useMetrics`, or `./spatial` (per `tasks.md §7.3` — source-level check; identifier scan on the built bundle lives in `tasks.md §9.4` and ships in PR 5)
- [x] Default-entry `Model` / `withSpatialized2DElementContainer` / `withSpatialMonitor` / `useMetrics` resolve to the facade-shaped exports defined in `src/facades/` and `src/hooks-web/` respectively
- [x] `createElement` continues to function in v1 (deprecation JSDoc only)

### Out of scope (deferred)

- **Physical file relocation of real spatial implementation modules into `src/spatial/`** (`tasks.md §3.1`): cosmetic; deferred to a follow-up cleanup PR. The runtime module-graph contract is already satisfied by the static-import removal in this PR — real implementation modules are no longer reachable from the default entry's import graph.
- **tsup rewrite + `package.json` `exports` cleanup** (`tasks.md §8`): PR 5. Drops `/web` / `/default` subpaths and the `react-server` conditional, adds the `./spatial` subpath, declares `sideEffects: false`, flips React peer to hard-required.
- **Size budget enforcement** (`tasks.md §9`): PR 5. SDK-side `dist/index.js` ≤ 8KB proxy, marginal-delta fixture on a typical Vite consumer, identifier scan on the built bundle, `sideEffects` declaration check, top-level side-effect lint.
- **Documentation + migration guide + parity tests** (`tasks.md §10` / `§13` / `§14` / `§15`): PR 6.

### Test plan

- [x] `pnpm --filter @webspatial/react-sdk test` — **253 / 253 green** (up from 190 in PR 3; 63 new in `default-entry-public-surface.test.ts`).
- [x] Repo-wide `pnpm test` green for `@webspatial/*` workspaces (the pre-existing `packages/cli` Jimp default-import TS error reproduces on `main` and on every parent branch; unrelated).
- [ ] CI green (Vercel preview + GitHub Actions).

### Compatibility note for in-tree consumers

`apps/test-server`, `packages/autoTest`, and `tests/ci-test` are NOT migrated in this change (deferred per `tasks.md §12.2`). They continue to consume the SDK against the **published** package surface; once this PR merges to `main`, those workspaces will see the BREAKING removals. The deferred migration tasks track that work cross-repo.
