### PR TITLE
chore(test-server): boot spatial runtime before mount (lazy-load §12.1, partial) [draft]

### DIFF
--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react'
-import ReactDOM from 'react-dom/client'
 import { HashRouter as Router, Routes, Route } from 'react-router-dom'
+import { bootEntry } from './src/lib/bootEntry'
 import Sidebar from './src/components/Sidebar'
 import Home from './src/pages/Home'
 // Static route registry: add your test component here to expose it in the SPA
@@ -257,22 +257,8 @@ function App() {
   )
 }
 
-const init = () => {
-  const rootElement = document.getElementById('root')
-  if (!rootElement) {
-    console.error('Root element not found')
-    return
-  }
-
-  ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  )
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init)
-} else {
-  init()
-}
+// `bootEntry` awaits `bootSpatial()` before mounting so the lazy-loaded
+// spatial chunk lands before the first React commit in WebSpatial runtimes.
+// In plain web browsers `bootSpatial()` resolves on the next microtask and
+// the user sees no perceptible delay.
+bootEntry(<App />)

--- a/apps/test-server/src/lib/bootEntry.tsx
+++ b/apps/test-server/src/lib/bootEntry.tsx
@@ -1,0 +1,102 @@
+// =============================================================================
+// `bootEntry` — shared `bootSpatial() → ReactDOM.createRoot().render()` wrapper
+// for every test-server entry point (SPA + standalone test pages).
+//
+// Background: post-lazy-load (`openspec/changes/lazy-load-spatial-runtime/`),
+// `@webspatial/react-sdk` no longer eagerly initializes the spatial runtime.
+// Apps MUST call `await bootSpatial()` before mounting their first React tree
+// in WebSpatial-capable runtimes; otherwise every spatial primitive renders
+// its documented web fallback (poster `<model>`, `<div aria-hidden>` Reality,
+// no-op entities/materials, identity `useMetrics` constants). In plain web
+// browsers `bootSpatial()` resolves immediately without scheduling any
+// dynamic import — the wait is one microtask, not a network round trip.
+//
+// This helper consolidates the two ergonomic concerns each entry was
+// otherwise re-solving by hand:
+//
+//   1. The `document.readyState === 'loading'` → `DOMContentLoaded` dance
+//      that the legacy `mount()` pattern in `pages/scene/{hook,loading,
+//      volumeHook}.tsx` open-coded.
+//   2. Boot failure isolation: `bootSpatial()` rejects with
+//      `WebSpatialBootError` when the spatial chunk fetch fails (network
+//      error, chunk-not-found, etc.). The page MUST still render — the
+//      facades' web fallback IS the user's degraded display path — so we
+//      log + continue, never throw.
+//
+// Plain `await bootSpatial()` would also work, but this helper keeps the
+// intent ("boot spatial runtime, then render") in one obvious place that
+// future maintainers can find when they add a new entry.
+// =============================================================================
+
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { bootSpatial, WebSpatialBootError } from '@webspatial/react-sdk'
+
+export interface BootEntryOptions {
+  /** Root element id; default `'root'`. */
+  rootId?: string
+  /** If true (default), creates `<div id="root">` when missing — matches the
+   * legacy `mount()` pattern several standalone pages relied on. */
+  createRootIfMissing?: boolean
+  /** Wrap `tree` in `<React.StrictMode>`; default `true`. */
+  strictMode?: boolean
+}
+
+export function bootEntry(
+  tree: React.ReactElement,
+  options: BootEntryOptions = {},
+): void {
+  const {
+    rootId = 'root',
+    createRootIfMissing = true,
+    strictMode = true,
+  } = options
+
+  const start = async (): Promise<void> => {
+    try {
+      await bootSpatial()
+    } catch (err) {
+      // Per spec, facades render documented web fallback when the bridge is
+      // unready for any reason — including a rejected boot. Surface the
+      // failure for diagnostics and let the React tree mount in fallback
+      // mode instead of leaving the page blank.
+      if (err instanceof WebSpatialBootError) {
+        console.error(
+          '[test-server] bootSpatial() rejected; rendering with web fallback',
+          err,
+        )
+      } else {
+        // Unexpected non-WebSpatialBootError: re-throw so it shows up in
+        // the browser's error overlay during development.
+        throw err
+      }
+    }
+
+    let root = document.getElementById(rootId)
+    if (!root && createRootIfMissing) {
+      root = document.createElement('div')
+      root.id = rootId
+      document.body.appendChild(root)
+    }
+    if (!root) {
+      console.error(`[test-server] bootEntry: #${rootId} not found`)
+      return
+    }
+
+    const wrapped = strictMode ? (
+      <React.StrictMode>{tree}</React.StrictMode>
+    ) : (
+      tree
+    )
+
+    ReactDOM.createRoot(root).render(wrapped)
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      void start()
+    })
+  } else {
+    void start()
+  }
+}

--- a/apps/test-server/src/pages/reality-sample/sample1/src/main.tsx
+++ b/apps/test-server/src/pages/reality-sample/sample1/src/main.tsx
@@ -1,5 +1,5 @@
-import { createRoot } from 'react-dom/client'
+import { bootEntry } from '../../../../lib/bootEntry'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(<App />)
+bootEntry(<App />, { strictMode: false })

--- a/apps/test-server/src/pages/scene/hook.tsx
+++ b/apps/test-server/src/pages/scene/hook.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import ReactDOM from 'react-dom/client'
 import { initScene } from '@webspatial/react-sdk'
+import { bootEntry } from '../../lib/bootEntry'
 
 window.xrCurrentSceneType = 'window'
 window.xrCurrentSceneDefaults = async () => {
@@ -249,22 +249,4 @@ function App() {
 
 export default App
 
-function mount() {
-  let root = document.getElementById('root')
-  if (!root) {
-    root = document.createElement('div')
-    root.id = 'root'
-    document.body.appendChild(root)
-  }
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  )
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', mount)
-} else {
-  mount()
-}
+bootEntry(<App />)

--- a/apps/test-server/src/pages/scene/loading.tsx
+++ b/apps/test-server/src/pages/scene/loading.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import ReactDOM from 'react-dom/client'
 import { initScene } from '@webspatial/react-sdk'
+import { bootEntry } from '../../lib/bootEntry'
 window.xrCurrentSceneDefaults = async () => {
   await new Promise<void>((resolve, _) => {
     setTimeout(resolve, 2000)
@@ -245,22 +245,4 @@ function App() {
 
 export default App
 
-function mount() {
-  let root = document.getElementById('root')
-  if (!root) {
-    root = document.createElement('div')
-    root.id = 'root'
-    document.body.appendChild(root)
-  }
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  )
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', mount)
-} else {
-  mount()
-}
+bootEntry(<App />)

--- a/apps/test-server/src/pages/scene/volumeHook.tsx
+++ b/apps/test-server/src/pages/scene/volumeHook.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import ReactDOM from 'react-dom/client'
 import { initScene } from '@webspatial/react-sdk'
+import { bootEntry } from '../../lib/bootEntry'
 
 window.xrCurrentSceneType = 'volume'
 window.xrCurrentSceneDefaults = async () => {
@@ -265,22 +265,4 @@ function App() {
 
 export default App
 
-function mount() {
-  let root = document.getElementById('root')
-  if (!root) {
-    root = document.createElement('div')
-    root.id = 'root'
-    document.body.appendChild(root)
-  }
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  )
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', mount)
-} else {
-  mount()
-}
+bootEntry(<App />)


### PR DESCRIPTION
## Summary

Implements the `bootSpatial()` half of `openspec/changes/lazy-load-spatial-runtime/tasks.md §12.1` ("Migrate apps/test-server to ... call bootSpatial()"). The other halves (consume `dist`, switch to splitting-capable pipeline) are deferred to follow-up PRs.

After the lazy-load v1 architecture, `@webspatial/react-sdk` no longer eagerly initializes the spatial runtime — every facade renders its documented web fallback (poster `<model>`, `<div aria-hidden>` Reality, no-op entities/materials, identity `useMetrics` constants) until `bootSpatial()` resolves the spatial chunk. test-server's SPA was rendering fallback for every spatial primitive in the AVP simulator because no entry called boot. This PR fixes that.

## Changes

- **New** `apps/test-server/src/lib/bootEntry.tsx`: shared `bootSpatial() → ReactDOM.createRoot().render()` wrapper. Handles the `document.readyState === 'loading'` → `DOMContentLoaded` dance that several entries open-coded, plus boot-failure isolation: a rejected `WebSpatialBootError` is logged and the React tree mounts in fallback mode (per spec, the facade fallback IS the user's degraded display path) instead of leaving a blank page.
- `apps/test-server/index.tsx`: SPA root replaces the inline init+mount block with `bootEntry(<App />)`.
- `apps/test-server/src/pages/scene/{hook,loading,volumeHook}.tsx`: each replaces its open-coded `mount()` + DOMContentLoaded block with the helper.
- `apps/test-server/src/pages/reality-sample/sample1/src/main.tsx`: preserves the existing no-StrictMode behavior via `bootEntry(<App />, { strictMode: false })`.

Diff: 6 files, +116 / −82.

## Verification

- [x] `npm run test` (tsc) clean.
- [x] `npm run build` clean — zero warnings, zero errors. The previous `[ignored-bare-import]` esbuild warning that surfaced after the PR 6 calibration is gone (the warning was fixed in the calibration commit's `sideEffects` allowlist; this PR only verifies the dev loop end-to-end).
- [x] `npm run dev` starts cleanly.
- [x] `bootSpatial` symbol present in both `dist/index.js` (5 occurrences) and standalone `dist/src/pages/scene/hook.js` (4 occurrences).
- [x] HTTP probes against the live dev server: SPA `/` → 200, standalone `/pages/scene/hook.html` → 200.

## Test plan

- [ ] Manual smoke in plain Chrome: open the SPA at `http://localhost:5173/`, navigate to `/reality`, `/model-test`, `/scene`, confirm no console errors and pages render their documented web fallback.
- [ ] Manual smoke in AVP simulator: same pages render real spatial primitives after `bootSpatial()` resolves the spatial chunk.
- [ ] CI green on `version (22) / version (24) / version (latest)`.

## Out of scope

Deferred follow-ups under the same `tasks.md §12.1`:

- Switching the `esbuild.mjs` alias from `packages/react/src` to `packages/react/dist` (validates the published-bundle shape under the SPA's actual import graph).
- Switching from bare esbuild to a splitting-capable pipeline so the spatial chunk lands as a separate fetch instead of being inlined into the main bundle. `tasks.md §12.1` explicitly allows the inlined-chunk fallback for v1.
- The dead `XR_ENV=avp` env var prefix on the `dev` script is handled in the sibling [`chore/drop-dead-xr-env`](https://github.com/webspatial/webspatial-sdk/tree/chore/drop-dead-xr-env) PR.

## Merge dependency

This PR uses `bootSpatial` from `@webspatial/react-sdk`, which is introduced by the lazy-load stack (`feat/extract-core-sdk-polyfills`). The PR base is set to `feat/extract-core-sdk-polyfills`; once the stack merges to `main`, GitHub will auto-rebase the PR base to `main`.
