### PR TITLE
chore: drop dead XR_ENV env var (post-PR-5 cleanup) [Draft]

### DIFF
--- a/apps/test-server/esbuild.mjs
+++ b/apps/test-server/esbuild.mjs
@@ -46,7 +46,6 @@ const buildOptions = {
   sourcemap: !isBuild,
   plugins,
   define: {
-    'process.env.XR_ENV': JSON.stringify(process.env.XR_ENV ?? ''),
     __WEBSPATIAL_CORE_SDK_VERSION__: JSON.stringify(corePkg.version),
     __WEBSPATIAL_REACT_SDK_VERSION__: JSON.stringify(reactPkg.version),
   },

--- a/apps/test-server/package.json
+++ b/apps/test-server/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "tsc -p ./tsconfig.json",
     "build": "node esbuild.mjs --build",
-    "dev": "XR_ENV=avp node esbuild.mjs",
-    "dev:web": "node esbuild.mjs",
+    "dev": "node esbuild.mjs",
     "start": "npm run dev",
     "deployAppCode": "cp -r dist/ ../visionOSApp/web-spatial/static-web/dist/ && cp -r src/ ../visionOSApp/web-spatial/static-web/src/ && cp -r public/ ../visionOSApp/web-spatial/static-web/public/",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/packages/autoTest/package.json
+++ b/packages/autoTest/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "devAVP": "XR_ENV=avp vite",
+    "devAVP": "vite",
     "build": "tsc -b && vite build",
-    "build:avp": "vite build && XR_ENV=avp vite build",
+    "build:avp": "vite build",
     "build-test": "tsc -p tsconfig.json --outDir dist",
     "test": "npm run build-test && mocha --exit --require source-map-support/register --reporter mochawesome --reporter-options reportDir=reports,reportFilename=autotest,overwrite=true,html=true,json=true dist/tests/**/*.test.js",
     "devTest": "npm run build-test && mocha --require source-map-support/register --reporter mochawesome --reporter-options reportDir=reports,reportFilename=autotest,overwrite=true,html=true,json=true dist/tests/**/*.test.js",


### PR DESCRIPTION
## Summary

Removes the `XR_ENV=avp` prefix from `apps/test-server` and `packages/autoTest` dev/build scripts, plus the now-unused `process.env.XR_ENV` define in test-server's esbuild config.

## Why

The SDK used to write `window.__webspatialsdk__['XR_ENV']` in its tsup banner, and consumers branched on this value. Lazy-load PR 5 (`tasks.md §8.2`) deleted that banner write — the runtime detection moved into `core-sdk`'s user-agent snapshot path (`computeRuntimeFromUserAgent`).

Repo-wide grep confirms nothing reads `XR_ENV` anywhere in the SDK or the consumer apps anymore. The only remaining mentions are dead-type declarations in `packages/{core,react}/src/types/global.{ts,d.ts}` (left alone in this PR — they're harmless but a follow-up could remove them).

## Changes

- **`apps/test-server/package.json`**: `dev` had `XR_ENV=avp` prefix that esbuild then defined in `process.env.XR_ENV` for the bundle. Both the prefix and the define are gone. `dev:web` was the no-XR_ENV variant — now redundant with `dev`, dropped (no external references found).
- **`apps/test-server/esbuild.mjs`**: removed the `'process.env.XR_ENV': JSON.stringify(process.env.XR_ENV ?? '')` define. The other two defines (`__WEBSPATIAL_CORE_SDK_VERSION__` / `__WEBSPATIAL_REACT_SDK_VERSION__`) remain — they ARE consumed.
- **`packages/autoTest/package.json`**: `devAVP` (invoked by the Puppeteer test harness in `tests/*.test.ts`) lost its `XR_ENV=avp` prefix; the script body is now identical to `dev` but the script name is preserved so the test harness keeps working without changes. `build:avp` was `vite build && XR_ENV=avp vite build` — the duplicate run only made sense if XR_ENV produced a different bundle, which it never did (the local `vite.config.js` has zero XR_ENV references). Reduced to a single `vite build`.

Diff: 3 files, +3 / −5.

## Verification

- [x] `apps/test-server`: `npm run test` (tsc) clean; `npm run build` clean (zero warnings, zero errors).
- [x] No lint errors on the three modified files.
- [x] Repo-wide grep confirms no surviving `process.env.XR_ENV` or `window.__webspatialsdk__.XR_ENV` runtime reads, only the type-only declarations.

## Test plan

- [ ] CI green on `version (22) / version (24) / version (latest)`.
- [ ] Quick manual smoke that `npm run dev` in `apps/test-server` and `npm run devAVP` in `packages/autoTest` still start vite/esbuild correctly.

## Out of scope

- `packages/{core,react}/src/types/global.{ts,d.ts}`'s `XR_ENV?: string` type-only field — harmless dead type, removable in a future cleanup PR if needed.

## Merge dependency

Functionally independent of the lazy-load stack (does not import any new SDK API). The PR base is set to `feat/extract-core-sdk-polyfills` so the diff stays focused; this PR can technically be rebased onto `main` and merged independently if priorities shift.
