### PR TITLE
Clean up texture material refresh

### DIFF
--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import {
   BoxEntity,
   ConeEntity,
@@ -52,7 +52,7 @@ export default function TexturedUnlitBox() {
   const [coreNote, setCoreNote] = useState('')
   const [coreLoads, setCoreLoads] = useState(0)
 
-  // Lab: one Texture id; only `url` changes. Plane + box share one material (surfaceSyncRev = load count).
+  // Lab: one Texture id; only `url` changes. Plane + box share one material.
   const [labUrl, setLabUrl] = useState(carUrl)
   const [labColor, setLabColor] = useState('#ffffff')
   const [labLoads, setLabLoads] = useState(0)
@@ -65,13 +65,6 @@ export default function TexturedUnlitBox() {
   >('switchTextureCar')
   const [bindColor, setBindColor] = useState('#ffffff')
   const bindMatId = bindTex === '' ? 'bindMat_none' : `bindMat_${bindTex}`
-  // Bumps on tint changes and when bind-scene textures finish loading so UnlitMaterial runs
-  // updateProperties after pixels exist (same idea as lab `surfaceSyncRev={labLoads}`).
-  const [bindSurfaceRev, setBindSurfaceRev] = useState(0)
-  useEffect(() => {
-    setBindSurfaceRev(v => v + 1)
-  }, [bindColor])
-
   return (
     <div
       style={{ padding: 16, color: '#eee', fontFamily: 'system-ui,sans-serif' }}
@@ -179,8 +172,8 @@ export default function TexturedUnlitBox() {
       <p style={hint}>
         <code>runtimePlaneTexture</code> keeps the same id; only{' '}
         <code>url</code> changes. Plane <code>runtimeTextureBox</code> and the
-        small box both use <code>labMat</code>. Each successful load bumps the
-        counter so the material can sync to the new pixels.
+        small box both use <code>labMat</code>; the material refreshes through
+        the resource registry when the texture settles.
       </p>
       <p
         style={{ fontSize: 11, color: '#666', marginTop: -4, marginBottom: 8 }}
@@ -266,7 +259,6 @@ export default function TexturedUnlitBox() {
           />
           <UnlitMaterial
             id="labMat"
-            surfaceSyncRev={labLoads}
             color={labColor}
             textureId="runtimePlaneTexture"
             transparent={false}
@@ -340,19 +332,10 @@ export default function TexturedUnlitBox() {
       </div>
       <div style={view}>
         <Reality id="realityBind" style={rv}>
-          <Texture
-            id="switchTextureCar"
-            url={buildPublicUrl(IMG_CAR)}
-            onLoad={() => setBindSurfaceRev(v => v + 1)}
-          />
-          <Texture
-            id="switchTextureBadge"
-            url={TEX_BADGE}
-            onLoad={() => setBindSurfaceRev(v => v + 1)}
-          />
+          <Texture id="switchTextureCar" url={buildPublicUrl(IMG_CAR)} />
+          <Texture id="switchTextureBadge" url={TEX_BADGE} />
           <UnlitMaterial
             id={bindMatId}
-            surfaceSyncRev={bindSurfaceRev}
             color={bindColor}
             textureId={bindTex}
             transparent

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -301,6 +301,37 @@ describe('reality/utils/ResourceRegistry', () => {
     expect(destroy1).toHaveBeenCalledTimes(1)
     expect(destroy2).toHaveBeenCalledTimes(1)
   })
+
+  it('notifies subscribers when resource attempts settle or are removed', async () => {
+    const registry = new ResourceRegistry()
+    const listener = vi.fn()
+    const unsubscribe = registry.subscribe('texture', listener)
+
+    registry.add('texture', Promise.resolve({ destroy: vi.fn() }) as any)
+    await Promise.resolve()
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    registry.notify('texture')
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    registry.remove('texture')
+    expect(listener).toHaveBeenCalledTimes(3)
+
+    unsubscribe()
+    registry.notify('texture')
+    expect(listener).toHaveBeenCalledTimes(3)
+  })
+
+  it('notifies subscribers when a resource attempt fails', async () => {
+    const registry = new ResourceRegistry()
+    const listener = vi.fn()
+    registry.subscribe('texture', listener)
+
+    registry.add('texture', Promise.reject(new Error('nope')) as any)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('notifyUpdateStandInstanceLayout', () => {

--- a/packages/react/src/reality/components/Texture.tsx
+++ b/packages/react/src/reality/components/Texture.tsx
@@ -44,6 +44,7 @@ export const Texture: React.FC<TextureProps> = ({
       try {
         if (textureRef.current) {
           await textureRef.current.updateProperties({ url: resolvedUrl })
+          resourceRegistry.notify(id)
         } else {
           const texturePromise = session.createTexture({ url: resolvedUrl })
           resourceRegistry.add(id, texturePromise)

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
   SpatialUnlitMaterial,
   SpatialUnlitMaterialOptions,
@@ -8,21 +8,23 @@ import { useRealityContext } from '../context'
 export type UnlitMaterialProps = {
   children?: React.ReactNode
   id: string // user id
-  /**
-   * Increment to force `updateProperties` after in-place texture URL changes (same `textureId`)
-   * or whenever the parent needs a reliable native refresh (e.g. tint + texture together).
-   */
-  surfaceSyncRev?: number
 } & SpatialUnlitMaterialOptions
 
 export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
   children,
-  surfaceSyncRev,
   ...options
 }) => {
   const ctx = useRealityContext()
   const materialRef = useRef<SpatialUnlitMaterial | undefined>(undefined)
   const isInitializedRef = useRef(false)
+  const [textureRevision, setTextureRevision] = useState(0)
+
+  useEffect(() => {
+    if (!ctx || !options.textureId) return
+    return ctx.resourceRegistry.subscribe(options.textureId, () => {
+      setTextureRevision(v => v + 1)
+    })
+  }, [ctx, options.textureId])
 
   useEffect(() => {
     if (!ctx) return
@@ -117,7 +119,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     options.textureId,
     options.transparent,
     options.opacity,
-    surfaceSyncRev,
+    textureRevision,
   ])
 
   return null

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -22,6 +22,8 @@ export class ResourceRegistry {
       reject: (error: Error) => void
     }
   >()
+  /** Subscribers are notified whenever an id gets a fresh resolved or failed resource attempt. */
+  private listeners = new Map<string, Set<() => void>>()
 
   add<T extends SpatialObject>(id: string, resource: Promise<T>): void {
     this.resources.set(id, resource)
@@ -35,6 +37,31 @@ export class ResourceRegistry {
           deferred.reject(err instanceof Error ? err : new Error(String(err))),
         )
       this.deferreds.delete(id)
+    }
+
+    // Resource users (e.g. materials bound to a texture id) may need to retry or refresh when
+    // a creation attempt settles, even if the id string itself did not change.
+    resource.then(() => this.notify(id)).catch(() => this.notify(id))
+  }
+
+  subscribe(id: string, listener: () => void): () => void {
+    const listeners = this.listeners.get(id) ?? new Set<() => void>()
+    listeners.add(listener)
+    this.listeners.set(id, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        this.listeners.delete(id)
+      }
+    }
+  }
+
+  notify(id: string): void {
+    const listeners = this.listeners.get(id)
+    if (!listeners) return
+    for (const listener of Array.from(listeners)) {
+      listener()
     }
   }
 
@@ -55,6 +82,7 @@ export class ResourceRegistry {
   remove(id: string): void {
     this.resources.delete(id)
     this.deferreds.delete(id)
+    this.notify(id)
   }
 
   // Same as remove, but when the promise resolves, destroy the spatial object (best-effort).
@@ -65,6 +93,7 @@ export class ResourceRegistry {
     }
     this.resources.delete(id)
     this.deferreds.delete(id)
+    this.notify(id)
   }
 
   destroy(): void {
@@ -75,6 +104,12 @@ export class ResourceRegistry {
       )
     }
     this.deferreds.clear()
+
+    const ids = Array.from(this.resources.keys())
+    for (const id of ids) {
+      this.notify(id)
+    }
+    this.listeners.clear()
 
     const pending = Array.from(this.resources.values())
     this.resources.clear()


### PR DESCRIPTION
### Motivation

- Provide a cleaner upstream mechanism so textures that change their `url` in-place refresh bound materials without requiring manual revision props. 
- Avoid changing texture ids to trigger native material updates and reduce race/fallback complexity when a texture load succeeds, fails, or is replaced. 
- Simplify the demo and developer surface by moving refresh orchestration into the resource registry and React components.

### Description

- Add subscribe/notify support to `ResourceRegistry` so callers can `subscribe(id, listener)` and be notified when a resource promise settles, fails, or is removed. 
- Have `Texture` call `resourceRegistry.notify(id)` after an in-place `updateProperties({ url })` so same-id updates propagate to consumers. 
- Update `UnlitMaterial` to subscribe to its `textureId` internally and re-run `updateProperties` when the registry notifies, removing the external `surfaceSyncRev` prop. 
- Update the textured demo `apps/test-server/src/pages/reality/texturedUnlitBox.tsx` and add tests in `packages/react/src/coverage-boost.test.ts` to cover registry notifications and failure paths.

### Testing

- Ran formatting with `prettier` on the changed files; the command completed successfully. 
- Built core with `pnpm --filter @webspatial/core-sdk build` then ran component tests with `pnpm --filter @webspatial/react-sdk test`, and the test suite passed (all tests in `packages/react` completed successfully). 
- An initial run of `pnpm --filter @webspatial/react-sdk test` failed until the core package was built (expected local package build-order issue), after which tests passed. 
- Running `tsc -p apps/test-server/tsconfig.json` revealed unrelated missing CSS/SCSS side-effect module declarations in the test-server pages and therefore failed; this failure is orthogonal to the texture/material changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05217723208323ac344213d3b47e84)