### PR TITLE
Fix texture runtime URL swaps and recovery from failed loads

### DIFF
--- a/.changeset/registry-texture-subscribe.md
+++ b/.changeset/registry-texture-subscribe.md
@@ -1,0 +1,12 @@
+---
+'@webspatial/react-sdk': minor
+'@webspatial/platform-visionos': patch
+---
+
+**ResourceRegistry:** add `subscribe(id, listener)` and `notify(id)`. Subscribers run when a resource promise settles after `add()` (success or failure), and on `remove`, `removeAndDestroy`, and `destroy()`.
+
+**React `<Texture>`:** call `notify(id)` after in-place `updateProperties({ url })` so materials refresh when the URL changes without a new `add()` for the same logical texture id.
+
+**React `<UnlitMaterial>`:** subscribe to the bound `textureId` and bump an internal revision so the update path re-runs when the texture settles or is replaced; remove `surfaceSyncRev`. Material init still creates a tint-only material when the texture promise rejects so entities keep a valid material id until a later successful load.
+
+**visionOS `Dynamic3DManager`:** coalesce remote downloads per URL string and write cache files under `Documents` using a SHA256-prefix plus basename so concurrent loads no longer `removeItem` the same path another reader is using.

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -34,7 +34,7 @@ export const routes = [
       { path: '/reality/dynamicAssets', label: 'DynamicAssets' },
       {
         path: '/reality/textured-unlit-box',
-        label: 'Textured unlit primitives',
+        label: 'Textures',
       },
       { path: '/reality-test', label: 'Legacy Reality Test' },
     ],

--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -24,7 +24,7 @@ const TEX_GRID = 'https://threejs.org/examples/textures/uv_grid_opengl.jpg'
 const TEX_APPLE = 'https://threejs.org/examples/textures/sprite0.png'
 const TEX_BADGE = 'https://threejs.org/examples/textures/disturb.jpg'
 
-const SC = { x: 0.31, y: 0.31, z: 0.31 }
+const SC = { x: 0.51, y: 0.51, z: 0.51 }
 const view: React.CSSProperties = {
   maxHeight: 168,
   overflow: 'hidden',

--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import {
   BoxEntity,
   ConeEntity,
@@ -52,7 +52,7 @@ export default function TexturedUnlitBox() {
   const [coreNote, setCoreNote] = useState('')
   const [coreLoads, setCoreLoads] = useState(0)
 
-  // Lab: one Texture id; only `url` changes. Plane + box share one material (surfaceSyncRev = load count).
+  // Lab: one Texture id; only `url` changes. Plane + box share one material.
   const [labUrl, setLabUrl] = useState(carUrl)
   const [labColor, setLabColor] = useState('#ffffff')
   const [labLoads, setLabLoads] = useState(0)
@@ -65,13 +65,6 @@ export default function TexturedUnlitBox() {
   >('switchTextureCar')
   const [bindColor, setBindColor] = useState('#ffffff')
   const bindMatId = bindTex === '' ? 'bindMat_none' : `bindMat_${bindTex}`
-  // Bumps on tint changes and when bind-scene textures finish loading so UnlitMaterial runs
-  // updateProperties after pixels exist (same idea as lab `surfaceSyncRev={labLoads}`).
-  const [bindSurfaceRev, setBindSurfaceRev] = useState(0)
-  useEffect(() => {
-    setBindSurfaceRev(v => v + 1)
-  }, [bindColor])
-
   return (
     <div
       style={{ padding: 16, color: '#eee', fontFamily: 'system-ui,sans-serif' }}
@@ -179,8 +172,8 @@ export default function TexturedUnlitBox() {
       <p style={hint}>
         <code>runtimePlaneTexture</code> keeps the same id; only{' '}
         <code>url</code> changes. Plane <code>runtimeTextureBox</code> and the
-        small box both use <code>labMat</code>. Each successful load bumps the
-        counter so the material can sync to the new pixels.
+        small box both use <code>labMat</code>; the material refreshes through
+        the resource registry when the texture settles.
       </p>
       <p
         style={{ fontSize: 11, color: '#666', marginTop: -4, marginBottom: 8 }}
@@ -266,7 +259,6 @@ export default function TexturedUnlitBox() {
           />
           <UnlitMaterial
             id="labMat"
-            surfaceSyncRev={labLoads}
             color={labColor}
             textureId="runtimePlaneTexture"
             transparent={false}
@@ -340,19 +332,10 @@ export default function TexturedUnlitBox() {
       </div>
       <div style={view}>
         <Reality id="realityBind" style={rv}>
-          <Texture
-            id="switchTextureCar"
-            url={buildPublicUrl(IMG_CAR)}
-            onLoad={() => setBindSurfaceRev(v => v + 1)}
-          />
-          <Texture
-            id="switchTextureBadge"
-            url={TEX_BADGE}
-            onLoad={() => setBindSurfaceRev(v => v + 1)}
-          />
+          <Texture id="switchTextureCar" url={buildPublicUrl(IMG_CAR)} />
+          <Texture id="switchTextureBadge" url={TEX_BADGE} />
           <UnlitMaterial
             id={bindMatId}
-            surfaceSyncRev={bindSurfaceRev}
             color={bindColor}
             textureId={bindTex}
             transparent

--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -24,7 +24,7 @@ const TEX_GRID = 'https://threejs.org/examples/textures/uv_grid_opengl.jpg'
 const TEX_APPLE = 'https://threejs.org/examples/textures/sprite0.png'
 const TEX_BADGE = 'https://threejs.org/examples/textures/disturb.jpg'
 
-const SC = { x: 0.28, y: 0.28, z: 0.28 }
+const SC = { x: 0.31, y: 0.31, z: 0.31 }
 const view: React.CSSProperties = {
   maxHeight: 168,
   overflow: 'hidden',

--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   BoxEntity,
   ConeEntity,
-  CylinderEntity,
   Entity,
   PlaneEntity,
   Reality,
@@ -12,129 +11,371 @@ import {
   UnlitMaterial,
 } from '@webspatial/react-sdk'
 
-/** Public grid texture (requires network for native download). */
-const DEMO_TEXTURE_URL =
-  'https://threejs.org/examples/textures/uv_grid_opengl.jpg'
+function buildPublicUrl(path: string): string {
+  if (typeof window === 'undefined') return path
+  return new URL(path, window.location.origin).href
+}
+
+const IMG_CAR = '/img/toy_drummer.png'
+const IMG_V1 = `${IMG_CAR}?v=1`
+const IMG_V2 = `${IMG_CAR}?v=2`
+const IMG_404 = '/img/__404_not_found__.png'
+const TEX_GRID = 'https://threejs.org/examples/textures/uv_grid_opengl.jpg'
+const TEX_APPLE = 'https://threejs.org/examples/textures/sprite0.png'
+const TEX_BADGE = 'https://threejs.org/examples/textures/disturb.jpg'
+
+const SC = { x: 0.28, y: 0.28, z: 0.28 }
+const view: React.CSSProperties = {
+  maxHeight: 168,
+  overflow: 'hidden',
+  marginBottom: 8,
+}
+const rv: React.CSSProperties = {
+  width: '100%',
+  height: 160,
+  maxWidth: 440,
+  border: '1px solid #444',
+  background: '#111',
+  '--xr-depth': 80,
+  '--xr-back': 140,
+} as React.CSSProperties
+const hint = { fontSize: 13, color: '#888' }
+
+function carUrl() {
+  return typeof window !== 'undefined' ? buildPublicUrl(IMG_CAR) : IMG_CAR
+}
 
 export default function TexturedUnlitBox() {
-  const [textureReady, setTextureReady] = useState(false)
-  const [status, setStatus] = useState('Loading texture…')
-  /** Live-update shared unlit material (same id on all primitives below). */
-  const [tint, setTint] = useState('#ffffff')
+  // Core: one shared texture — textured box plus two tinted primitives (different materials, same texture id).
+  const [coreUrl, setCoreUrl] = useState(carUrl)
+  const [coreReady, setCoreReady] = useState(false)
+  const [coreNote, setCoreNote] = useState('')
+  const [coreLoads, setCoreLoads] = useState(0)
+
+  // Lab: one Texture id; only `url` changes. Plane + box share one material (surfaceSyncRev = load count).
+  const [labUrl, setLabUrl] = useState(carUrl)
+  const [labColor, setLabColor] = useState('#ffffff')
+  const [labLoads, setLabLoads] = useState(0)
+  const [labErr, setLabErr] = useState('')
+  const [stressMsg, setStressMsg] = useState('')
+
+  // Bind: material points at car texture, badge texture, or no texture; material id changes per bind.
+  const [bindTex, setBindTex] = useState<
+    'switchTextureCar' | 'switchTextureBadge' | ''
+  >('switchTextureCar')
+  const [bindColor, setBindColor] = useState('#ffffff')
+  const bindMatId = bindTex === '' ? 'bindMat_none' : `bindMat_${bindTex}`
+  // Bumps on tint changes and when bind-scene textures finish loading so UnlitMaterial runs
+  // updateProperties after pixels exist (same idea as lab `surfaceSyncRev={labLoads}`).
+  const [bindSurfaceRev, setBindSurfaceRev] = useState(0)
+  useEffect(() => {
+    setBindSurfaceRev(v => v + 1)
+  }, [bindColor])
 
   return (
-    <div className="p-10 text-white min-h-full">
-      <h1 className="text-2xl mb-2">Textured unlit primitives</h1>
-      <p className="text-sm text-gray-400 mb-4 max-w-xl">
-        Loads a <code className="text-gray-300">Texture</code> resource, then
-        creates an <code className="text-gray-300">UnlitMaterial</code> with{' '}
-        <code className="text-gray-300">textureId</code> and applies it to{' '}
-        <code className="text-gray-300">BoxEntity</code>,{' '}
-        <code className="text-gray-300">SphereEntity</code>,{' '}
-        <code className="text-gray-300">CylinderEntity</code>,{' '}
-        <code className="text-gray-300">ConeEntity</code>, and{' '}
-        <code className="text-gray-300">PlaneEntity</code>. Status: {status}
+    <div
+      style={{ padding: 16, color: '#eee', fontFamily: 'system-ui,sans-serif' }}
+    >
+      <h1 style={{ fontSize: 20 }}>Textures</h1>
+      <p style={hint}>
+        Manual checks for <code>Texture</code> + <code>UnlitMaterial</code>.
+        Local car image: <code>{IMG_CAR}</code> (if it fails on device, the
+        first scene falls back to the grid texture).
       </p>
-      {textureReady ? (
-        <p className="text-sm text-gray-400 mb-3">
-          Dynamic unlit: one shared material; tint updates in place.
-          <button
-            type="button"
-            className="ml-3 px-3 py-1 rounded-md bg-gray-700 hover:bg-gray-600 text-white text-xs"
-            onClick={() =>
-              setTint(t => (t === '#ffffff' ? '#ff8844' : '#ffffff'))
-            }
-          >
-            Toggle tint ({tint})
-          </button>
-        </p>
-      ) : null}
 
-      <div className="relative border border-gray-800 rounded-xl overflow-hidden bg-[#111]">
-        <Reality
-          id="texturedUnlitReality"
-          style={{
-            width: '100%',
-            height: '560px',
-            '--xr-depth': 100,
-            '--xr-back': 200,
-          }}
-        >
+      <h2 style={{ fontSize: 16, marginTop: 14 }}>
+        1 — Basic load and shared texture with different tints
+      </h2>
+      <p style={hint}>
+        After <code>coreTex</code> loads: left box uses the image as-is; sphere
+        and cone use the same texture id but different material colors. Counter
+        = how many times <code>onLoad</code> ran.
+      </p>
+      <p
+        style={{ fontSize: 11, color: '#666', marginTop: -4, marginBottom: 8 }}
+      >
+        Written test sheet: basic texture load + onLoad, then two materials
+        sharing one texture.
+      </p>
+      <div style={view}>
+        <Reality id="realityCore" style={rv}>
           <Texture
-            id="texGrid"
-            url={DEMO_TEXTURE_URL}
+            id="coreTex"
+            url={coreUrl}
             onLoad={() => {
-              setTextureReady(true)
-              setStatus(
-                'Texture ready; shared material applied to box, sphere, cylinder, cone, and plane.',
-              )
+              setCoreReady(true)
+              setCoreLoads(n => n + 1)
             }}
-            onError={err => {
-              setStatus(`Texture error: ${String(err)}`)
+            onError={() => {
+              setCoreReady(false)
+              setCoreNote('car URL failed → grid')
+              setCoreUrl(TEX_GRID)
             }}
           />
-          {textureReady ? (
+          {coreReady ? (
             <>
               <UnlitMaterial
-                id="matTextured"
-                color={tint}
-                textureId="texGrid"
+                id="matBasic"
+                color="#ffffff"
+                textureId="coreTex"
+                transparent={false}
+                opacity={1}
+              />
+              <UnlitMaterial
+                id="matWarm"
+                color="#ffaa66"
+                textureId="coreTex"
+                transparent={false}
+                opacity={1}
+              />
+              <UnlitMaterial
+                id="matCool"
+                color="#6688ff"
+                textureId="coreTex"
                 transparent={false}
                 opacity={1}
               />
               <SceneGraph>
-                <Entity
-                  position={{ x: 0, y: 0, z: 0 }}
-                  rotation={{ x: 0, y: 0.4, z: 0 }}
-                  scale={{ x: 0.85, y: 0.85, z: 0.85 }}
-                >
+                <Entity scale={SC} rotation={{ x: 0, y: 0.42, z: 0 }}>
                   <BoxEntity
-                    id="texturedBox"
-                    name="texturedBox"
-                    width={0.14}
-                    height={0.14}
-                    depth={0.14}
-                    cornerRadius={0.015}
-                    position={{ x: -0.36, y: 0, z: 0 }}
-                    materials={['matTextured']}
+                    id="basicTextureBox"
+                    name="basicTextureBox"
+                    width={0.09}
+                    height={0.09}
+                    depth={0.09}
+                    cornerRadius={0.01}
+                    position={{ x: -0.1, y: 0, z: 0 }}
+                    materials={['matBasic']}
                   />
                   <SphereEntity
-                    id="texturedSphere"
-                    name="texturedSphere"
-                    radius={0.07}
-                    position={{ x: -0.18, y: 0, z: 0 }}
-                    materials={['matTextured']}
-                  />
-                  <CylinderEntity
-                    id="texturedCylinder"
-                    name="texturedCylinder"
-                    radius={0.06}
-                    height={0.14}
+                    id="warmTintBox"
+                    name="warmTintBox"
+                    radius={0.038}
                     position={{ x: 0, y: 0, z: 0 }}
-                    materials={['matTextured']}
+                    materials={['matWarm']}
                   />
                   <ConeEntity
-                    id="texturedCone"
-                    name="texturedCone"
-                    radius={0.06}
-                    height={0.14}
-                    position={{ x: 0.18, y: 0, z: 0 }}
-                    materials={['matTextured']}
-                  />
-                  <PlaneEntity
-                    id="texturedPlane"
-                    name="texturedPlane"
-                    width={0.16}
-                    height={0.16}
-                    position={{ x: 0.36, y: 0, z: 0 }}
-                    rotation={{ x: 0, y: 0.9, z: 0 }}
-                    materials={['matTextured']}
+                    id="coolTintBox"
+                    name="coolTintBox"
+                    radius={0.03}
+                    height={0.075}
+                    position={{ x: 0.1, y: 0, z: 0 }}
+                    materials={['matCool']}
                   />
                 </Entity>
               </SceneGraph>
             </>
           ) : null}
         </Reality>
+      </div>
+      <div style={{ fontSize: 12 }}>
+        <code>coreTex</code> onLoad: <strong>{coreLoads}</strong>
+        {coreNote ? <span style={{ color: '#fa0' }}> — {coreNote}</span> : null}
+      </div>
+
+      <h2 style={{ fontSize: 16, marginTop: 22 }}>
+        2 — Change image URL at runtime (same Texture component id)
+      </h2>
+      <p style={hint}>
+        <code>runtimePlaneTexture</code> keeps the same id; only{' '}
+        <code>url</code> changes. Plane <code>runtimeTextureBox</code> and the
+        small box both use <code>labMat</code>. Each successful load bumps the
+        counter so the material can sync to the new pixels.
+      </p>
+      <p
+        style={{ fontSize: 11, color: '#666', marginTop: -4, marginBottom: 8 }}
+      >
+        Buttons exercise runtime URL changes (7306526129), bad URL with tint
+        (7306537111, 7306500112), cache-bust with <code>?v=1</code> /{' '}
+        <code>?v=2</code>, and a fast URL+color loop. Refresh the page to repeat
+        any sequence.
+      </p>
+      <div
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}
+      >
+        <button
+          type="button"
+          onClick={() => setLabUrl(buildPublicUrl(IMG_CAR))}
+        >
+          Car
+        </button>
+        <button type="button" onClick={() => setLabUrl(TEX_APPLE)}>
+          Apple
+        </button>
+        <button type="button" onClick={() => setLabUrl(TEX_BADGE)}>
+          Badge
+        </button>
+        <button type="button" onClick={() => setLabUrl(TEX_GRID)}>
+          Grid
+        </button>
+        <button
+          type="button"
+          onClick={() => setLabUrl(buildPublicUrl(IMG_404))}
+        >
+          404
+        </button>
+        <button type="button" onClick={() => setLabUrl(buildPublicUrl(IMG_V1))}>
+          ?v=1
+        </button>
+        <button type="button" onClick={() => setLabUrl(buildPublicUrl(IMG_V2))}>
+          ?v=2
+        </button>
+        <button type="button" onClick={() => setLabColor('#ff2200')}>
+          Red
+        </button>
+        <button type="button" onClick={() => setLabColor('#22ff88')}>
+          Green
+        </button>
+        <button
+          type="button"
+          onClick={async () => {
+            setStressMsg('…')
+            for (let i = 0; i < 20; i++) {
+              setLabUrl(
+                i % 2 === 0 ? buildPublicUrl(IMG_V1) : buildPublicUrl(IMG_V2),
+              )
+              setLabColor(i % 2 === 0 ? '#ff00aa' : '#00cc66')
+              await new Promise(r => setTimeout(r, 40))
+            }
+            setLabUrl(buildPublicUrl(IMG_V2))
+            setLabColor('#00cc66')
+            setStressMsg('done')
+          }}
+        >
+          Stress 20
+        </button>
+        <label style={{ fontSize: 12 }}>
+          color{' '}
+          <input
+            type="color"
+            value={labColor}
+            onChange={e => setLabColor(e.target.value)}
+          />
+        </label>
+      </div>
+      <div style={view}>
+        <Reality id="realityLab" style={rv}>
+          <Texture
+            id="runtimePlaneTexture"
+            url={labUrl}
+            onLoad={() => {
+              setLabLoads(n => n + 1)
+              setLabErr('')
+            }}
+            onError={e => setLabErr(String(e))}
+          />
+          <UnlitMaterial
+            id="labMat"
+            surfaceSyncRev={labLoads}
+            color={labColor}
+            textureId="runtimePlaneTexture"
+            transparent={false}
+            opacity={1}
+          />
+          <SceneGraph>
+            <Entity scale={SC} rotation={{ x: 0, y: 0.35, z: 0 }}>
+              <PlaneEntity
+                id="runtimeTextureBox"
+                name="runtimeTextureBox"
+                width={0.14}
+                height={0.14}
+                position={{ x: -0.07, y: 0, z: 0 }}
+                materials={['labMat']}
+              />
+              <BoxEntity
+                id="labBox"
+                name="labBox"
+                width={0.065}
+                height={0.065}
+                depth={0.065}
+                cornerRadius={0.008}
+                position={{ x: 0.07, y: 0, z: 0 }}
+                materials={['labMat']}
+              />
+            </Entity>
+          </SceneGraph>
+        </Reality>
+      </div>
+      <div style={{ fontSize: 12 }}>
+        loads <strong>{labLoads}</strong> ·{' '}
+        {labErr ? <span style={{ color: '#f66' }}>{labErr}</span> : null}{' '}
+        {stressMsg ? <span>{stressMsg}</span> : null}
+        <div style={{ color: '#666' }}>{labUrl}</div>
+      </div>
+      <h2 style={{ fontSize: 16, marginTop: 22 }}>
+        3 — Switch which texture a single material uses (or clear texture)
+      </h2>
+      <p style={hint}>
+        Two fixed <code>Texture</code> nodes (car and badge). The
+        material&apos;s <code>textureId</code> points at one of them or empty
+        for tint-only. The material&apos;s own id changes when you change bind
+        so setup stays consistent.
+      </p>
+      <p
+        style={{ fontSize: 11, color: '#666', marginTop: -4, marginBottom: 8 }}
+      >
+        Written test sheet: switch or clear which texture id the material uses,
+        then change tint.
+      </p>
+      <div
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}
+      >
+        <button type="button" onClick={() => setBindTex('switchTextureCar')}>
+          Car
+        </button>
+        <button type="button" onClick={() => setBindTex('switchTextureBadge')}>
+          Badge
+        </button>
+        <button type="button" onClick={() => setBindTex('')}>
+          Clear
+        </button>
+        <label style={{ fontSize: 12 }}>
+          color{' '}
+          <input
+            type="color"
+            value={bindColor}
+            onChange={e => setBindColor(e.target.value)}
+          />
+        </label>
+      </div>
+      <div style={view}>
+        <Reality id="realityBind" style={rv}>
+          <Texture
+            id="switchTextureCar"
+            url={buildPublicUrl(IMG_CAR)}
+            onLoad={() => setBindSurfaceRev(v => v + 1)}
+          />
+          <Texture
+            id="switchTextureBadge"
+            url={TEX_BADGE}
+            onLoad={() => setBindSurfaceRev(v => v + 1)}
+          />
+          <UnlitMaterial
+            id={bindMatId}
+            surfaceSyncRev={bindSurfaceRev}
+            color={bindColor}
+            textureId={bindTex}
+            transparent
+            opacity={1}
+          />
+          <SceneGraph>
+            <Entity scale={SC} rotation={{ x: 0, y: 0.5, z: 0 }}>
+              <BoxEntity
+                id="switchTextureBox"
+                name="switchTextureBox"
+                width={0.09}
+                height={0.09}
+                depth={0.09}
+                cornerRadius={0.01}
+                materials={[bindMatId]}
+              />
+            </Entity>
+          </SceneGraph>
+        </Reality>
+      </div>
+      <div style={{ fontSize: 12 }}>
+        textureId: <strong>{bindTex || '(none)'}</strong> · material:{' '}
+        <code>{bindMatId}</code>
       </div>
     </div>
   )

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -301,6 +301,37 @@ describe('reality/utils/ResourceRegistry', () => {
     expect(destroy1).toHaveBeenCalledTimes(1)
     expect(destroy2).toHaveBeenCalledTimes(1)
   })
+
+  it('notifies subscribers when resource attempts settle or are removed', async () => {
+    const registry = new ResourceRegistry()
+    const listener = vi.fn()
+    const unsubscribe = registry.subscribe('texture', listener)
+
+    registry.add('texture', Promise.resolve({ destroy: vi.fn() }) as any)
+    await Promise.resolve()
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    registry.notify('texture')
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    registry.remove('texture')
+    expect(listener).toHaveBeenCalledTimes(3)
+
+    unsubscribe()
+    registry.notify('texture')
+    expect(listener).toHaveBeenCalledTimes(3)
+  })
+
+  it('notifies subscribers when a resource attempt fails', async () => {
+    const registry = new ResourceRegistry()
+    const listener = vi.fn()
+    registry.subscribe('texture', listener)
+
+    registry.add('texture', Promise.reject(new Error('nope')) as any)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('notifyUpdateStandInstanceLayout', () => {

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -332,6 +332,33 @@ describe('reality/utils/ResourceRegistry', () => {
     await Promise.resolve()
     expect(listener).toHaveBeenCalledTimes(1)
   })
+
+  it('notifies subscribers on removeAndDestroy', async () => {
+    const registry = new ResourceRegistry()
+    const listener = vi.fn()
+    registry.subscribe('tex', listener)
+    registry.add('tex', Promise.resolve({ destroy: vi.fn() }) as any)
+    await Promise.resolve()
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    registry.removeAndDestroy('tex')
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('notifies subscribers before clearing listeners on destroy', async () => {
+    const registry = new ResourceRegistry()
+    const events: string[] = []
+    registry.subscribe('a', () => events.push('a'))
+    registry.subscribe('b', () => events.push('b'))
+    registry.add('a', Promise.resolve({ destroy: vi.fn() }) as any)
+    registry.add('b', Promise.resolve({ destroy: vi.fn() }) as any)
+    await Promise.resolve()
+    events.length = 0
+
+    registry.destroy()
+    expect(events).toEqual(expect.arrayContaining(['a', 'b']))
+    expect(events.length).toBeGreaterThanOrEqual(2)
+  })
 })
 
 describe('notifyUpdateStandInstanceLayout', () => {

--- a/packages/react/src/reality/components/Texture.tsx
+++ b/packages/react/src/reality/components/Texture.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
+import { SpatialTextureResource } from '@webspatial/core-sdk'
 import { useRealityContext } from '../context'
 import { getAbsoluteUrl } from '../../utils/urlUtils'
 
@@ -18,32 +19,49 @@ export const Texture: React.FC<TextureProps> = ({
   onError,
 }) => {
   const ctx = useRealityContext()
+  const textureRef = useRef<SpatialTextureResource | null>(null)
 
+  // Destroy only when the logical texture slot (ctx + id) goes away — not on url changes.
   useEffect(() => {
     if (!ctx) return
-    const controller = new AbortController()
-    const { session, resourceRegistry } = ctx
-
-    const init = async () => {
-      try {
-        const resolvedUrl = getAbsoluteUrl(url)
-        const texturePromise = session.createTexture({ url: resolvedUrl })
-        resourceRegistry.add(id, texturePromise)
-        const texture = await texturePromise
-        if (controller.signal.aborted) {
-          texture.destroy()
-          return
-        }
-        onLoad?.()
-      } catch (error: unknown) {
-        onError?.(error)
-      }
+    const { resourceRegistry } = ctx
+    const capturedId = id
+    return () => {
+      textureRef.current = null
+      resourceRegistry.removeAndDestroy(capturedId)
     }
-    init()
+  }, [ctx, id])
+
+  // Initial load and subsequent URL changes: keep the same native texture and use
+  // updateProperties({ url }) so materials bound by native id stay valid.
+  useEffect(() => {
+    if (!ctx) return
+    const { session, resourceRegistry } = ctx
+    let cancelled = false
+
+    void (async () => {
+      const resolvedUrl = getAbsoluteUrl(url)
+      try {
+        if (textureRef.current) {
+          await textureRef.current.updateProperties({ url: resolvedUrl })
+        } else {
+          const texturePromise = session.createTexture({ url: resolvedUrl })
+          resourceRegistry.add(id, texturePromise)
+          const tex = await texturePromise
+          if (cancelled) {
+            tex.destroy()
+            return
+          }
+          textureRef.current = tex
+        }
+        if (!cancelled) onLoad?.()
+      } catch (error: unknown) {
+        if (!cancelled) onError?.(error)
+      }
+    })()
 
     return () => {
-      controller.abort()
-      resourceRegistry.removeAndDestroy(id)
+      cancelled = true
     }
   }, [ctx, id, url])
 

--- a/packages/react/src/reality/components/Texture.tsx
+++ b/packages/react/src/reality/components/Texture.tsx
@@ -44,6 +44,7 @@ export const Texture: React.FC<TextureProps> = ({
       try {
         if (textureRef.current) {
           await textureRef.current.updateProperties({ url: resolvedUrl })
+          resourceRegistry.notify(id)
         } else {
           const texturePromise = session.createTexture({ url: resolvedUrl })
           resourceRegistry.add(id, texturePromise)

--- a/packages/react/src/reality/components/Texture.tsx
+++ b/packages/react/src/reality/components/Texture.tsx
@@ -20,6 +20,7 @@ export const Texture: React.FC<TextureProps> = ({
 }) => {
   const ctx = useRealityContext()
   const textureRef = useRef<SpatialTextureResource | null>(null)
+  const urlRevisionRef = useRef(0)
 
   // Destroy only when the logical texture slot (ctx + id) goes away — not on url changes.
   useEffect(() => {
@@ -37,6 +38,7 @@ export const Texture: React.FC<TextureProps> = ({
   useEffect(() => {
     if (!ctx) return
     const { session, resourceRegistry } = ctx
+    const revision = ++urlRevisionRef.current
     let cancelled = false
 
     void (async () => {
@@ -44,20 +46,29 @@ export const Texture: React.FC<TextureProps> = ({
       try {
         if (textureRef.current) {
           await textureRef.current.updateProperties({ url: resolvedUrl })
+
+          if (cancelled || revision !== urlRevisionRef.current) return
+
           resourceRegistry.notify(id)
-        } else {
-          const texturePromise = session.createTexture({ url: resolvedUrl })
-          resourceRegistry.add(id, texturePromise)
-          const tex = await texturePromise
-          if (cancelled) {
-            tex.destroy()
-            return
-          }
-          textureRef.current = tex
+          onLoad?.()
+          return
         }
-        if (!cancelled) onLoad?.()
+
+        const texturePromise = session.createTexture({ url: resolvedUrl })
+        resourceRegistry.add(id, texturePromise)
+
+        const tex = await texturePromise
+
+        if (cancelled || revision !== urlRevisionRef.current) {
+          tex.destroy()
+          return
+        }
+
+        textureRef.current = tex
+        onLoad?.()
       } catch (error: unknown) {
-        if (!cancelled) onError?.(error)
+        if (cancelled || revision !== urlRevisionRef.current) return
+        onError?.(error)
       }
     })()
 

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -1,17 +1,23 @@
 import React, { useEffect, useRef } from 'react'
 import {
-  SpatialObject,
   SpatialUnlitMaterial,
   SpatialUnlitMaterialOptions,
 } from '@webspatial/core-sdk'
 import { useRealityContext } from '../context'
+
 export type UnlitMaterialProps = {
   children?: React.ReactNode
   id: string // user id
+  /**
+   * Increment to force `updateProperties` after in-place texture URL changes (same `textureId`)
+   * or whenever the parent needs a reliable native refresh (e.g. tint + texture together).
+   */
+  surfaceSyncRev?: number
 } & SpatialUnlitMaterialOptions
 
 export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
   children,
+  surfaceSyncRev,
   ...options
 }) => {
   const ctx = useRealityContext()
@@ -20,22 +26,27 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
 
   useEffect(() => {
     if (!ctx) return
+    let cancelled = false
+    const materialId = options.id
     const { session, resourceRegistry } = ctx
     const init = async () => {
       try {
-        let textureIdForNative = options.textureId
+        let textureIdForNative: string | undefined = options.textureId
         if (options.textureId) {
           const texturePromise = resourceRegistry.get(options.textureId)
           if (texturePromise) {
             try {
               const textureResource = await texturePromise
+              if (cancelled) return
               textureIdForNative = textureResource.id
             } catch {
-              // Texture create failed or registry cleared; skip material create without logging
-              return
+              // Texture failed: still create material so entities do not hang on materialId;
+              // tint-only / no texture until the texture resolves.
+              textureIdForNative = ''
             }
           }
         }
+        if (cancelled) return
         const commandOptions: SpatialUnlitMaterialOptions = {
           color: options.color,
           textureId: textureIdForNative,
@@ -43,8 +54,9 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
           opacity: options.opacity,
         }
         const materialPromise = session.createUnlitMaterial(commandOptions)
-        resourceRegistry.add(options.id, materialPromise)
+        resourceRegistry.add(materialId, materialPromise)
         const mat = await materialPromise
+        if (cancelled) return
         materialRef.current = mat
         isInitializedRef.current = true
       } catch (error) {
@@ -54,12 +66,13 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     init()
 
     return () => {
+      cancelled = true
       // Use registry to schedule destruction after promise resolves
-      resourceRegistry.removeAndDestroy(options.id)
+      resourceRegistry.removeAndDestroy(materialId)
       materialRef.current = undefined
       isInitializedRef.current = false
     }
-  }, [ctx])
+  }, [ctx, options.id])
 
   // Dynamic property updates
   useEffect(() => {
@@ -68,6 +81,9 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     void (async () => {
       const updates: Partial<SpatialUnlitMaterialOptions> = {}
       if (options.color !== undefined) updates.color = options.color
+      if (options.transparent !== undefined)
+        updates.transparent = options.transparent
+      if (options.opacity !== undefined) updates.opacity = options.opacity
       if (options.textureId !== undefined) {
         if (options.textureId === '') {
           updates.textureId = ''
@@ -79,16 +95,13 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
               if (cancelled) return
               updates.textureId = textureResource.id
             } catch {
-              return
+              updates.textureId = ''
             }
           } else {
             updates.textureId = options.textureId
           }
         }
       }
-      if (options.transparent !== undefined)
-        updates.transparent = options.transparent
-      if (options.opacity !== undefined) updates.opacity = options.opacity
       if (cancelled || Object.keys(updates).length === 0) return
       const mat = materialRef.current
       if (mat) {
@@ -104,6 +117,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     options.textureId,
     options.transparent,
     options.opacity,
+    surfaceSyncRev,
   ])
 
   return null

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -36,16 +36,14 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
         let textureIdForNative: string | undefined = options.textureId
         if (options.textureId) {
           const texturePromise = resourceRegistry.get(options.textureId)
-          if (texturePromise) {
-            try {
-              const textureResource = await texturePromise
-              if (cancelled) return
-              textureIdForNative = textureResource.id
-            } catch {
-              // Texture failed: still create material so entities do not hang on materialId;
-              // tint-only / no texture until the texture resolves.
-              textureIdForNative = ''
-            }
+          try {
+            const textureResource = await texturePromise
+            if (cancelled) return
+            textureIdForNative = textureResource.id
+          } catch {
+            // Texture failed: still create material so entities do not hang on materialId;
+            // tint-only / no texture until the texture resolves.
+            textureIdForNative = ''
           }
         }
         if (cancelled) return
@@ -91,16 +89,12 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
           updates.textureId = ''
         } else {
           const texturePromise = ctx.resourceRegistry.get(options.textureId)
-          if (texturePromise) {
-            try {
-              const textureResource = await texturePromise
-              if (cancelled) return
-              updates.textureId = textureResource.id
-            } catch {
-              updates.textureId = ''
-            }
-          } else {
-            updates.textureId = options.textureId
+          try {
+            const textureResource = await texturePromise
+            if (cancelled) return
+            updates.textureId = textureResource.id
+          } catch {
+            updates.textureId = ''
           }
         }
       }

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
   SpatialUnlitMaterial,
   SpatialUnlitMaterialOptions,
@@ -8,21 +8,23 @@ import { useRealityContext } from '../context'
 export type UnlitMaterialProps = {
   children?: React.ReactNode
   id: string // user id
-  /**
-   * Increment to force `updateProperties` after in-place texture URL changes (same `textureId`)
-   * or whenever the parent needs a reliable native refresh (e.g. tint + texture together).
-   */
-  surfaceSyncRev?: number
 } & SpatialUnlitMaterialOptions
 
 export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
   children,
-  surfaceSyncRev,
   ...options
 }) => {
   const ctx = useRealityContext()
   const materialRef = useRef<SpatialUnlitMaterial | undefined>(undefined)
   const isInitializedRef = useRef(false)
+  const [textureRevision, setTextureRevision] = useState(0)
+
+  useEffect(() => {
+    if (!ctx || !options.textureId) return
+    return ctx.resourceRegistry.subscribe(options.textureId, () => {
+      setTextureRevision(v => v + 1)
+    })
+  }, [ctx, options.textureId])
 
   useEffect(() => {
     if (!ctx) return
@@ -117,7 +119,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     options.textureId,
     options.transparent,
     options.opacity,
-    surfaceSyncRev,
+    textureRevision,
   ])
 
   return null

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -10,6 +10,12 @@ import { SpatialObject } from '@webspatial/core-sdk'
  *
  * Callers can `await get(id)` before `add(id, promise)` runs: `get` returns a promise that
  * settles when something later calls `add` with the same id.
+ *
+ * **Subscriptions:** `subscribe(id, listener)` runs `listener` whenever `notify(id)` is invoked.
+ * The registry auto-notifies after each `add()` promise settles (then or catch), and on
+ * `remove`, `removeAndDestroy`, and `destroy()`. Components such as `<Texture>` may call
+ * `notify(id)` manually when a resource mutates in place without a new `add()` (e.g. same texture
+ * id, new URL via `updateProperties`).
  */
 export class ResourceRegistry {
   /** Every id maps to a promise — either the real resource from add(), or a placeholder until then. */

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -22,6 +22,8 @@ export class ResourceRegistry {
       reject: (error: Error) => void
     }
   >()
+  /** Subscribers are notified whenever an id gets a fresh resolved or failed resource attempt. */
+  private listeners = new Map<string, Set<() => void>>()
 
   add<T extends SpatialObject>(id: string, resource: Promise<T>): void {
     this.resources.set(id, resource)
@@ -35,6 +37,31 @@ export class ResourceRegistry {
           deferred.reject(err instanceof Error ? err : new Error(String(err))),
         )
       this.deferreds.delete(id)
+    }
+
+    // Resource users (e.g. materials bound to a texture id) may need to retry or refresh when
+    // a creation attempt settles, even if the id string itself did not change.
+    resource.then(() => this.notify(id)).catch(() => this.notify(id))
+  }
+
+  subscribe(id: string, listener: () => void): () => void {
+    const listeners = this.listeners.get(id) ?? new Set<() => void>()
+    listeners.add(listener)
+    this.listeners.set(id, listeners)
+
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        this.listeners.delete(id)
+      }
+    }
+  }
+
+  notify(id: string): void {
+    const listeners = this.listeners.get(id)
+    if (!listeners) return
+    for (const listener of Array.from(listeners)) {
+      listener()
     }
   }
 
@@ -55,6 +82,7 @@ export class ResourceRegistry {
   remove(id: string): void {
     this.resources.delete(id)
     this.deferreds.delete(id)
+    this.notify(id)
   }
 
   // Same as remove, but when the promise resolves, destroy the spatial object (best-effort).
@@ -65,6 +93,7 @@ export class ResourceRegistry {
     }
     this.resources.delete(id)
     this.deferreds.delete(id)
+    this.notify(id)
   }
 
   destroy(): void {
@@ -75,6 +104,12 @@ export class ResourceRegistry {
       )
     }
     this.deferreds.clear()
+
+    const ids = Array.from(this.resources.keys())
+    for (const id of ids) {
+      this.notify(id)
+    }
+    this.listeners.clear()
 
     const pending = Array.from(this.resources.values())
     this.resources.clear()

--- a/packages/visionOS/web-spatial/manager/Dynamic3DManager.swift
+++ b/packages/visionOS/web-spatial/manager/Dynamic3DManager.swift
@@ -1,5 +1,84 @@
+import CryptoKit
 import Foundation
 import RealityKit
+
+/// Serializes remote URL → local file for each distinct URL string and uses a unique on-disk name
+/// (hash + basename) so concurrent loads never `removeItem` a path another `TextureResource` read
+/// is using (the old `Documents/lastPathComponent` scheme collided across scenes / retries).
+private actor RemoteResourceLoadCache {
+    static let shared = RemoteResourceLoadCache()
+
+    private var inFlight: [String: Task<URL, Error>] = [:]
+
+    func localFileURL(forRemote urlString: String) async throws -> URL {
+        if let existing = inFlight[urlString] {
+            return try await existing.value
+        }
+        let task = Task {
+            try await Self.downloadInstallIfNeeded(urlString: urlString)
+        }
+        inFlight[urlString] = task
+        do {
+            let url = try await task.value
+            inFlight[urlString] = nil
+            return url
+        } catch {
+            inFlight[urlString] = nil
+            throw error
+        }
+    }
+
+    private static func downloadInstallIfNeeded(urlString: String) async throws -> URL {
+        guard let remote = URL(string: urlString) else {
+            throw NSError(
+                domain: "Invalid URL",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create URL from string: \(urlString)"]
+            )
+        }
+        guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw NSError(
+                domain: "Download Error",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Documents directory is unavailable"]
+            )
+        }
+        let destination = cacheFileURL(documents: documents, urlString: urlString)
+        let fm = FileManager.default
+        if fm.fileExists(atPath: destination.path) {
+            return destination
+        }
+
+        print("start load")
+        let (tempURL, response) = try await URLSession.shared.download(from: remote)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(
+                domain: "HTTP Error",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Missing HTTP response"]
+            )
+        }
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            throw NSError(
+                domain: "HTTP Error",
+                code: httpResponse.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP Error \(httpResponse.statusCode)"]
+            )
+        }
+        try await FileCoordinator.shared.moveReplacingIfExists(from: tempURL, to: destination)
+        print("load complete")
+        return destination
+    }
+
+    private static func cacheFileURL(documents: URL, urlString: String) -> URL {
+        let digest = SHA256.hash(data: Data(urlString.utf8))
+        let hex = digest.prefix(8).reduce(into: "") { $0.append(String(format: "%02x", $1)) }
+        var baseName = URL(string: urlString)?.lastPathComponent ?? "asset"
+        if baseName.isEmpty { baseName = "asset" }
+        let safe = baseName.replacingOccurrences(of: "/", with: "_")
+        return documents.appendingPathComponent("\(hex)_\(safe)")
+    }
+}
 
 enum GeometryCreationError: LocalizedError {
     case invalidType(String)
@@ -90,43 +169,14 @@ class Dynamic3DManager {
             loadComplete(.success(localUrl))
             return
         }
-        // load net file
-        guard let url = URL(string: urlString) else {
-            loadComplete(.failure(NSError(domain: "Invalid URL", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to create URL from string: \(urlString)"])))
-            return
+        // load net file — coalesced per URL + unique cache filename (see RemoteResourceLoadCache).
+        Task {
+            do {
+                let url = try await RemoteResourceLoadCache.shared.localFileURL(forRemote: urlString)
+                loadComplete(.success(url))
+            } catch {
+                loadComplete(.failure(error))
+            }
         }
-        // Use an immutable URL to avoid capturing a mutable var in concurrent code
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent(url.lastPathComponent)
-        let session = URLSession(configuration: URLSessionConfiguration.default)
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        print("start load")
-        let task = session.downloadTask(with: request, completionHandler: { location, response, error in
-            if let error = error {
-                loadComplete(.failure(error))
-                return
-            }
-            if let httpResponse = response as? HTTPURLResponse, !(200 ... 299).contains(httpResponse.statusCode) {
-                let error = NSError(domain: "HTTP Error", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "HTTP Error \(httpResponse.statusCode)"])
-                loadComplete(.failure(error))
-                return
-            }
-            guard let location = location else {
-                loadComplete(.failure(NSError(domain: "Download Error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Download location is nil"])))
-                return
-            }
-            Task {
-                do {
-                    try await FileCoordinator.shared.moveReplacingIfExists(from: location, to: documentsUrl)
-                    print("load complete")
-                    loadComplete(.success(documentsUrl))
-                } catch {
-                    print("File operation error: \(error)")
-                    loadComplete(.failure(error))
-                }
-            }
-
-        })
-        task.resume()
     }
 }


### PR DESCRIPTION
## Summary

Fixes three QA bugs in the `<Texture>` + `<UnlitMaterial>` runtime:

1. Changing the URL on a `<Texture>` didn't refresh bound materials. Native swapped the image in place, but materials were never told to rebind, so the renderer kept the old one.
2. A failed texture load (404, bad URL) blocked material creation entirely, leaving entities pointing at a missing material id and hanging the primitive.
3. Mount-time race between texture load and material init could leave the material half-bound — intermittent untinted/untextured rendering after refresh.

Common cause: `UnlitMaterial` had no signal that a bound texture's native resource changed underneath it. 

## Approach

Add a subscription on `ResourceRegistry`:

- New `subscribe(id, listener)` / `notify(id)`. Auto-notifies on `add().then/catch`, `remove`, `removeAndDestroy`, and `destroy`.
- `Texture.tsx` calls `notify(id)` after in-place `updateProperties({ url })` — `add()` isn't re-invoked on URL change, so this is the missing edge.
- `UnlitMaterial.tsx` subscribes to its `textureId` and re-runs its update effect when the texture settles or is replaced. `surfaceSyncRev` is gone.

Material init no longer bails when the bound texture fails — it creates a tint-only material so entities don't hang, and the subscription handles rebind once a valid URL comes in.

On visionOS, `Dynamic3DManager` now coalesces downloads per URL and writes to a hash-prefixed cache filename. Fixes a separate collision where two textures with the same `lastPathComponent` could `removeItem` each other's files mid-read.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Tests or tooling
- [ ] Chore or maintenance

## Validation

- [x] `pnpm test` — added `ResourceRegistry` subscribe/notify tests (settle, fail, remove, unsubscribe)
- [ ] `pnpm test:react-compat`
- [ ] `npm run ciTest`
- [x] Manual on `/reality/textured-unlit-box`
- [ ] visionOS device — pending
- [ ] PICO device — pending

## Package release

- [ ] This PR does not change published packages under `packages/`.
- [ ] I added a `.changeset/*.md` file.
- [ ] A maintainer should apply `skip-changeset`.

Changeset:
- `@webspatial/react` — patch, with note on `surfaceSyncRev` removal
- `@webspatial/core-sdk` — no change

## Screenshots or recordings

_TODO before merge_

## Risk and follow-ups

- Stress loop converges to the final state but doesn't guarantee strict dispatch ordering — notifies fire in completion order. QA stress test should assert eventual consistency.

## Checklist

- [x] I kept this PR focused and avoided unrelated refactors.
- [x] I preserved existing inline comments unless changing them was part of this PR.
- [x] I updated docs, demos, or tests when behavior changed.