### PR TITLE
Fix CodeQL Swift analysis build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
   analyze-swift:
     name: Analyze Swift
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Install visionOS simulator runtime
         run: |
           xcodebuild -downloadPlatform visionOS
+          xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"
           xcrun simctl list runtimes
+          xcrun simctl list devices available
           xcrun simctl list devicetypes
 
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,7 @@ jobs:
   analyze-swift:
     name: Analyze Swift
     runs-on: macos-15
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -50,6 +51,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
           xcodebuild -version
           xcodebuild -showsdks
+
+      - name: Install visionOS simulator runtime
+        run: |
+          xcodebuild -downloadPlatform visionOS
+          xcrun simctl list runtimes
+          xcrun simctl list devicetypes
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,17 @@ jobs:
 
   analyze-swift:
     name: Analyze Swift
-    runs-on: macos-26
+    runs-on: macos-15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+          xcodebuild -version
+          xcodebuild -showsdks
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,10 +52,38 @@ jobs:
           xcodebuild -version
           xcodebuild -showsdks
 
-      - name: Install visionOS simulator runtime
+      - name: Prepare visionOS simulator
         run: |
-          xcodebuild -downloadPlatform visionOS
-          xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"
+          set -euo pipefail
+
+          if ! xcrun simctl list runtimes | grep -q 'com.apple.CoreSimulator.SimRuntime.xrOS-26-2'; then
+            downloaded=false
+            for attempt in 1 2 3; do
+              if xcodebuild -downloadPlatform visionOS; then
+                downloaded=true
+                break
+              fi
+              sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+              sleep 10
+            done
+            if [ "$downloaded" != true ]; then
+              exit 1
+            fi
+          fi
+
+          created=false
+          for attempt in 1 2 3; do
+            if xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro-4K" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"; then
+              created=true
+              break
+            fi
+            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+            sleep 10
+          done
+          if [ "$created" != true ]; then
+            exit 1
+          fi
+
           xcrun simctl list runtimes
           xcrun simctl list devices available
           xcrun simctl list devicetypes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,8 +72,9 @@ jobs:
           fi
 
           created=false
+          device_udid=""
           for attempt in 1 2 3; do
-            if xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro-4K" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"; then
+            if device_udid=$(xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro-4K" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"); then
               created=true
               break
             fi
@@ -83,6 +84,9 @@ jobs:
           if [ "$created" != true ]; then
             exit 1
           fi
+
+          xcrun simctl boot "$device_udid" || true
+          xcrun simctl bootstatus "$device_udid" -b
 
           xcrun simctl list runtimes
           xcrun simctl list devices available

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - stable
+  pull_request:
+    branches:
+      - main
+      - stable
+  schedule:
+    - cron: '31 4 * * 2'
+
+permissions:
+  security-events: write
+  packages: read
+  actions: read
+  contents: read
+
+jobs:
+  analyze-javascript-typescript:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:javascript-typescript'
+
+  analyze-swift:
+    name: Analyze Swift
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: swift
+          build-mode: manual
+
+      - name: Build visionOS app
+        run: |
+          xcodebuild build \
+            -project packages/visionOS/web-spatial.xcodeproj \
+            -scheme web-spatial \
+            -configuration Debug \
+            -sdk xrsimulator \
+            -destination 'generic/platform=visionOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
+            ARCH=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:swift'


### PR DESCRIPTION
## Summary
- Add CodeQL advanced setup workflow for JavaScript/TypeScript and Swift.
- Run JavaScript/TypeScript analysis on `ubuntu-latest`.
- Run Swift analysis on `macos-15` with manual build mode and the visionOS simulator build command.
- Select Xcode 26.3, ensure the visionOS simulator runtime is available, and create an Apple Vision Pro simulator device for RealityKit asset compilation on GitHub-hosted runners.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "YAML syntax OK"'`
- `git diff --check`
- `xcodebuild -list -project packages/visionOS/web-spatial.xcodeproj`
- `xcodebuild -showsdks`
- Local visionOS simulator build with the same `xcodebuild build` command succeeded.

## Follow-up after merge
After this workflow is merged, switch GitHub CodeQL from default setup to advanced setup / disable default setup so GitHub accepts analysis uploaded by `.github/workflows/codeql.yml`.
