### PR TITLE
[codex] Add SRI to CI test CDN scripts

### DIFF
--- a/tests/ci-test/index.html
+++ b/tests/ci-test/index.html
@@ -9,8 +9,16 @@
   <body>
     <div id="mocha"></div>
     <div id="root"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/9.2.2/mocha.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/chai/4.3.6/chai.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/mocha/9.2.2/mocha.min.js"
+      integrity="sha384-NbJ/T+HE3C9nEDYGZeqWbQTImTDt3r+59d2FMzQ2k169Qw94NbP/wPyqjZODpSE8"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/chai/4.3.6/chai.min.js"
+      integrity="sha384-aFRaGFQeAdtU3J8JaglYm1AlTtYdTNQ7tnkjPqYxRBZmOQCnj/m2UXOYDGr8pbiu"
+      crossorigin="anonymous"
+    ></script>
     <script>
       mocha.setup('bdd');
     </script>


### PR DESCRIPTION
## Summary
- Add subresource integrity hashes to the fixed-version Mocha and Chai CDN scripts used by the CI test page.
- Add crossorigin="anonymous" so browsers can enforce SRI on the cross-origin script loads.

## Root cause
CodeQL flagged the CI test HTML page because it loaded executable CDN scripts without integrity checks, leaving those fixed external resources without tamper detection.

## Validation
- Recomputed sha384 hashes from the live cdnjs assets and verified they match the HTML integrity attributes.
- pnpm --filter ci-test lint
- pnpm --filter ci-test test
- git diff --check

Note: local codeql CLI is not installed, so the CodeQL alert closure should be confirmed by the GitHub code scanning run on this PR.