### PR TITLE
Fix CodeQL Swift simulator destination

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,6 +87,7 @@ jobs:
 
           xcrun simctl boot "$device_udid" || true
           xcrun simctl bootstatus "$device_udid" -b
+          echo "CODEQL_VISIONOS_DEVICE_UDID=$device_udid" >> "$GITHUB_ENV"
 
           xcrun simctl list runtimes
           xcrun simctl list devices available
@@ -105,7 +106,7 @@ jobs:
             -scheme web-spatial \
             -configuration Debug \
             -sdk xrsimulator \
-            -destination 'generic/platform=visionOS Simulator' \
+            -destination "id=${CODEQL_VISIONOS_DEVICE_UDID:?Prepare visionOS simulator did not export CODEQL_VISIONOS_DEVICE_UDID}" \
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
             ARCH=arm64 \
             ONLY_ACTIVE_ARCH=YES \


### PR DESCRIPTION
## Summary
- export the prepared visionOS simulator UDID from the CodeQL Swift setup step
- build against that explicit simulator instead of the generic visionOS Simulator destination

## Why
The Swift CodeQL job currently reaches RealityAssetsCompile and fails with `Failed to find newest available Device type for visionOS 26.2`. The workflow already creates and boots a valid Apple Vision Pro simulator; passing that concrete destination avoids making xcodebuild/realitytool infer a device type from the generic destination.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml")'
- git diff --check