### PR TITLE
[codex] Fix CodeQL Swift analysis for visionOS app

### DIFF
--- a/.changeset/quiet-visionos-codeql.md
+++ b/.changeset/quiet-visionos-codeql.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Remove the unused RealityKitContent product dependency from the visionOS app target so automated builds do not compile unused Reality Composer Pro assets.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
             -sdk xrsimulator \
             -destination "generic/platform=visionOS Simulator" \
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
-            ARCH=arm64 \
+            ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,47 +52,6 @@ jobs:
           xcodebuild -version
           xcodebuild -showsdks
 
-      - name: Prepare visionOS simulator
-        run: |
-          set -euo pipefail
-
-          if ! xcrun simctl list runtimes | grep -q 'com.apple.CoreSimulator.SimRuntime.xrOS-26-2'; then
-            downloaded=false
-            for attempt in 1 2 3; do
-              if xcodebuild -downloadPlatform visionOS; then
-                downloaded=true
-                break
-              fi
-              sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
-              sleep 10
-            done
-            if [ "$downloaded" != true ]; then
-              exit 1
-            fi
-          fi
-
-          created=false
-          device_udid=""
-          for attempt in 1 2 3; do
-            if device_udid=$(xcrun simctl create "CodeQL Apple Vision Pro" "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro-4K" "com.apple.CoreSimulator.SimRuntime.xrOS-26-2"); then
-              created=true
-              break
-            fi
-            sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
-            sleep 10
-          done
-          if [ "$created" != true ]; then
-            exit 1
-          fi
-
-          xcrun simctl boot "$device_udid" || true
-          xcrun simctl bootstatus "$device_udid" -b
-          echo "CODEQL_VISIONOS_DEVICE_UDID=$device_udid" >> "$GITHUB_ENV"
-
-          xcrun simctl list runtimes
-          xcrun simctl list devices available
-          xcrun simctl list devicetypes
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -106,7 +65,7 @@ jobs:
             -scheme web-spatial \
             -configuration Debug \
             -sdk xrsimulator \
-            -destination "id=${CODEQL_VISIONOS_DEVICE_UDID:?Prepare visionOS simulator did not export CODEQL_VISIONOS_DEVICE_UDID}" \
+            -destination "generic/platform=visionOS Simulator" \
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
             ARCH=arm64 \
             ONLY_ACTIVE_ARCH=YES \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,18 +58,56 @@ jobs:
           languages: swift
           build-mode: manual
 
-      - name: Typecheck visionOS Swift sources
+      - name: Build visionOS app
         shell: bash
         run: |
-          SDKROOT="$(xcrun --sdk xrsimulator --show-sdk-path)"
-          find packages/visionOS/web-spatial -name '*.swift' -print | LC_ALL=C sort > "$RUNNER_TEMP/webspatial-swift-files.txt"
-          xargs xcrun --sdk xrsimulator swiftc -typecheck \
-            -module-name WebSpatial \
-            -target arm64-apple-xros26.0-simulator \
-            -sdk "$SDKROOT" \
-            -swift-version 5 \
-            -D DEBUG \
-            < "$RUNNER_TEMP/webspatial-swift-files.txt"
+          set -o pipefail
+          log_file="$RUNNER_TEMP/visionos-build.log"
+          set +e
+          xcodebuild build \
+            -project packages/visionOS/web-spatial.xcodeproj \
+            -scheme web-spatial \
+            -configuration Debug \
+            -sdk xrsimulator \
+            -destination "generic/platform=visionOS Simulator" \
+            -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=YES \
+            SWIFT_ENABLE_EXPLICIT_MODULES=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO 2>&1 | tee "$log_file"
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+
+          # Tolerate ONLY known incompatibilities between CodeQL's libtrace
+          # (DYLD_INSERT_LIBRARIES) and Xcode 26 build phases that run under
+          # sandbox-exec on visionOS. Swift source compilation completes before
+          # these phases run, so the CodeQL Swift trap is already populated and
+          # the analyze step can still produce a useful SARIF.
+          # Upstream tracking: actions/runner-images#12592
+          tolerated_err_re='Failed to find newest available Device type for visionOS'
+          tolerated_cmd_re='^Command (GenerateAssetSymbols|RealityAssetsCompile) failed with a nonzero exit code'
+
+          unexpected_err=$(grep -E '^(error:|.+ error:)' "$log_file" | grep -Ev "$tolerated_err_re" || true)
+          unexpected_cmd=$(grep -E '^Command [A-Za-z]+ failed with a nonzero exit code' "$log_file" | grep -Ev "$tolerated_cmd_re" || true)
+
+          if [[ -n "$unexpected_err" || -n "$unexpected_cmd" ]]; then
+            echo "::error::xcodebuild failed (exit $status) with unexpected errors:"
+            [[ -n "$unexpected_err" ]] && printf '%s\n' "$unexpected_err"
+            [[ -n "$unexpected_cmd" ]] && printf '%s\n' "$unexpected_cmd"
+            exit "$status"
+          fi
+
+          if ! grep -qE "$tolerated_err_re|$tolerated_cmd_re" "$log_file"; then
+            echo "::error::xcodebuild failed (exit $status) but the log does not match any known tolerated failure pattern. Treating as a hard failure."
+            exit "$status"
+          fi
+
+          echo "::warning::xcodebuild exited $status, but the only failures match known CodeQL x visionOS RealityKit/actool sandbox-exec incompatibilities (actions/runner-images#12592). Swift compilation completed earlier, so the CodeQL trap is intact; continuing to the analyze step."
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,32 @@ jobs:
           xcodebuild -version
           xcodebuild -showsdks
 
+      # The macos-15-arm64 runner ships the visionOS SDK but not the simulator
+      # runtime / device types. Without them, RealityAssetsCompile (realitytool)
+      # fails with: "Failed to find newest available Device type for visionOS ...".
+      # We only need to download the platform; we do NOT need to create or boot a
+      # concrete simulator device (that's what previously caused
+      # "Unable to find a device matching id=..." after long SPM resolution).
+      - name: Ensure visionOS simulator runtime
+        run: |
+          set -euo pipefail
+          if ! xcrun simctl list runtimes | grep -q 'com.apple.CoreSimulator.SimRuntime.xrOS-'; then
+            downloaded=false
+            for attempt in 1 2 3; do
+              if xcodebuild -downloadPlatform visionOS; then
+                downloaded=true
+                break
+              fi
+              sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
+              sleep 10
+            done
+            if [ "$downloaded" != true ]; then
+              exit 1
+            fi
+          fi
+          xcrun simctl list runtimes
+          xcrun simctl list devicetypes | grep -i 'Apple Vision' || true
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,20 +58,18 @@ jobs:
           languages: swift
           build-mode: manual
 
-      - name: Build visionOS app
+      - name: Typecheck visionOS Swift sources
+        shell: bash
         run: |
-          xcodebuild build \
-            -project packages/visionOS/web-spatial.xcodeproj \
-            -scheme web-spatial \
-            -configuration Debug \
-            -sdk xrsimulator \
-            -destination "generic/platform=visionOS Simulator" \
-            -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
-            ARCHS=arm64 \
-            ONLY_ACTIVE_ARCH=YES \
-            SWIFT_ENABLE_EXPLICIT_MODULES=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO
+          SDKROOT="$(xcrun --sdk xrsimulator --show-sdk-path)"
+          find packages/visionOS/web-spatial -name '*.swift' -print | LC_ALL=C sort > "$RUNNER_TEMP/webspatial-swift-files.txt"
+          xargs xcrun --sdk xrsimulator swiftc -typecheck \
+            -module-name WebSpatial \
+            -target arm64-apple-xros26.0-simulator \
+            -sdk "$SDKROOT" \
+            -swift-version 5 \
+            -D DEBUG \
+            < "$RUNNER_TEMP/webspatial-swift-files.txt"
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,8 +64,8 @@ jobs:
             -project packages/visionOS/web-spatial.xcodeproj \
             -scheme web-spatial \
             -configuration Debug \
-            -sdk xros \
-            -destination "generic/platform=visionOS" \
+            -sdk xrsimulator \
+            -destination "generic/platform=visionOS Simulator" \
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
             ARCH=arm64 \
             ONLY_ACTIVE_ARCH=YES \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,32 +52,6 @@ jobs:
           xcodebuild -version
           xcodebuild -showsdks
 
-      # The macos-15-arm64 runner ships the visionOS SDK but not the simulator
-      # runtime / device types. Without them, RealityAssetsCompile (realitytool)
-      # fails with: "Failed to find newest available Device type for visionOS ...".
-      # We only need to download the platform; we do NOT need to create or boot a
-      # concrete simulator device (that's what previously caused
-      # "Unable to find a device matching id=..." after long SPM resolution).
-      - name: Ensure visionOS simulator runtime
-        run: |
-          set -euo pipefail
-          if ! xcrun simctl list runtimes | grep -q 'com.apple.CoreSimulator.SimRuntime.xrOS-'; then
-            downloaded=false
-            for attempt in 1 2 3; do
-              if xcodebuild -downloadPlatform visionOS; then
-                downloaded=true
-                break
-              fi
-              sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService || true
-              sleep 10
-            done
-            if [ "$downloaded" != true ]; then
-              exit 1
-            fi
-          fi
-          xcrun simctl list runtimes
-          xcrun simctl list devicetypes | grep -i 'Apple Vision' || true
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -90,8 +64,8 @@ jobs:
             -project packages/visionOS/web-spatial.xcodeproj \
             -scheme web-spatial \
             -configuration Debug \
-            -sdk xrsimulator \
-            -destination "generic/platform=visionOS Simulator" \
+            -sdk xros \
+            -destination "generic/platform=visionOS" \
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
             ARCH=arm64 \
             ONLY_ACTIVE_ARCH=YES \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,7 @@ jobs:
             -derivedDataPath "$RUNNER_TEMP/webspatial-derived-data" \
             ARCHS=arm64 \
             ONLY_ACTIVE_ARCH=YES \
+            SWIFT_ENABLE_EXPLICIT_MODULES=NO \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO
 

--- a/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
+++ b/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		2B06AEE62E4C1AE8000327E9 /* JSBCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B06AEC02E4C1AE8000327E9 /* JSBCommand.swift */; };
 		2B06AEE92E4C1AE8000327E9 /* EventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B06AEBF2E4C1AE8000327E9 /* EventEmitter.swift */; };
 		2B1008A22F0B000800000002 /* NavigationCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */; };
-		2B2F1D692BEBFAAA006897EE /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = 2B2F1D682BEBFAAA006897EE /* RealityKitContent */; };
 		2B2F1D712BEBFAAC006897EE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D702BEBFAAC006897EE /* Assets.xcassets */; };
 		2B2F1D742BEBFAAC006897EE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D732BEBFAAC006897EE /* Preview Assets.xcassets */; };
 		2B89E38C2E699104004079AA /* WebMsgCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B89E38B2E699104004079AA /* WebMsgCommand.swift */; };
@@ -143,7 +142,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B2F1D692BEBFAAA006897EE /* RealityKitContent in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,7 +243,6 @@
 			);
 			name = "web-spatial";
 			packageProductDependencies = (
-				2B2F1D682BEBFAAA006897EE /* RealityKitContent */,
 			);
 			productName = "web-spatial";
 			productReference = 2B2F1D632BEBFAAA006897EE /* WebSpatial.app */;
@@ -606,12 +603,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCSwiftPackageProductDependency section */
-		2B2F1D682BEBFAAA006897EE /* RealityKitContent */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = RealityKitContent;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 2B2F1D5B2BEBFAAA006897EE /* Project object */;
 }


### PR DESCRIPTION
## Summary

- Use a generic visionOS Simulator destination for the Swift CodeQL build instead of a concrete simulator UDID.
- Remove the unused `RealityKitContent` product dependency from the `web-spatial` app target so normal app builds no longer compile unused Reality Composer Pro assets.
- Keep the traced CodeQL build focused to arm64 and disable explicit Swift modules to reduce Xcode/CodeQL overhead.
- Tolerate the known Xcode 26 visionOS resource-tool failures that happen only under CodeQL's traced environment, allowing CodeQL analysis to run after Swift extraction succeeds.
- Add a patch changeset for `@webspatial/platform-visionos` because the packaged Xcode project changed.

## Root Cause

The original CodeQL job created and booted a concrete `CodeQL Apple Vision Pro` simulator, then later failed because `xcodebuild` no longer saw that simulator UDID after CodeQL initialization.

Switching to `generic/platform=visionOS Simulator` fixed the destination lookup, but exposed that Xcode 26 visionOS resource build phases are unreliable under CodeQL's traced environment:

```text
error: Failed to find newest available Device type for visionOS 26.2
Command GenerateAssetSymbols failed with a nonzero exit code
```

Those failures come from resource tooling (`RealityAssetsCompile` / `actool`) running inside `sandbox-exec`, where CodeQL's `DYLD_INSERT_LIBRARIES=libtrace.dylib` is rejected by macOS dyld and the tools can no longer reach the CoreSimulator device-type catalog. This is the same upstream incompatibility tracked in [actions/runner-images#12592](https://github.com/actions/runner-images/issues/12592), and is unrelated to CodeQL query evaluation itself.

The final workflow treats only those known resource-tool failures as tolerated (downgraded to a `::warning::`), while still failing on any unexpected `xcodebuild` error or `Command ... failed` line. Swift source compilation has already completed by the time these phases run, so the CodeQL Swift trap is intact and the analyze step can still produce a useful SARIF.

`RealityKitContent` was also linked by the app target even though the repository does not import or reference `RealityKitContent` / `realityKitContentBundle` anywhere. Removing that unused product dependency keeps regular app builds from compiling unused `.rkassets`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "YAML parsed"'`
- `plutil -lint packages/visionOS/web-spatial.xcodeproj/project.pbxproj`
- `git diff --check`
- `node ./tools/scripts/check-valid-characters.js .changeset/quiet-visionos-codeql.md && node ./tools/scripts/check-filesize.js .changeset/quiet-visionos-codeql.md`
- `xcodebuild build -project packages/visionOS/web-spatial.xcodeproj -scheme web-spatial -configuration Debug -sdk xrsimulator -destination 'generic/platform=visionOS Simulator' -derivedDataPath /tmp/webspatial-codeql-sim-verify ARCH=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild build -project packages/visionOS/web-spatial.xcodeproj -scheme web-spatial -configuration Debug -sdk xrsimulator -destination 'generic/platform=visionOS Simulator' -derivedDataPath /tmp/webspatial-no-explicit-modules-verify ARCHS=arm64 ONLY_ACTIVE_ARCH=YES SWIFT_ENABLE_EXPLICIT_MODULES=NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`

Latest PR checks are green on head `e967e8f812a937b3b8fbb8d96f00a13de9285b8b`, including `Analyze Swift`. The Swift CodeQL log reports successful query evaluation/upload, `Number of extracted AST nodes = 314470`, and `Number of unresolved AST nodes = 0`.