### PR TITLE
[codex] Bump actions/checkout from v4 to v5

### DIFF
--- a/.github/workflows/auto-test-pages.yml
+++ b/.github/workflows/auto-test-pages.yml
@@ -28,7 +28,7 @@ jobs:
       PUPPETEER_SKIP_DOWNLOAD: '1'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,7 @@ jobs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Use full git history to enable tagging
 
@@ -92,7 +92,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: 'main'
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: [22, 24, latest]
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode 26
         run: |

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Use full git history to enable tagging
 

--- a/.github/workflows/validate-changeset.yml
+++ b/.github/workflows/validate-changeset.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary

- Update every `actions/checkout@v4` reference in `.github/workflows/*.yml` to `@v5` (9 occurrences across 6 workflow files).

## Root Cause

GitHub Actions runners surface a deprecation warning on every job that uses `actions/checkout@v4`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`actions/checkout@v5.0.0` (released 2025-08-11, [release notes](https://github.com/actions/checkout/releases/tag/v5.0.0)) is the first release built on Node.js 24. Bumping to `@v5` clears the warning without changing checkout behaviour for our usage.

## Scope

Intentionally narrow: only `actions/checkout` is bumped. Other actions still on Node.js 20 in this repo (`actions/setup-node@v4`, `actions/upload-artifact@v4`, `actions/github-script@v6/v7`) are left for separate follow-up PRs to keep this change easy to review and revert.

No `packages/` files change, so no changeset is required by `Validate changeset`.

## Validation

- `for f in .github/workflows/*.yml; do ruby -e "require 'yaml'; YAML.load_file('$f')"; done` (all files parse)
- `rg -n 'actions/checkout@v4' .github/workflows/` (no remaining matches)
- `git diff --check`

Made with [Cursor](https://cursor.com)