### PR TITLE
fix(react): handle missing texture ids for UnlitMaterial without breaking render

### DIFF
--- a/.changeset/bright-pandas-bloom.md
+++ b/.changeset/bright-pandas-bloom.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Fix `<UnlitMaterial>` so providing an undeclared `textureId` no longer blocks material creation. It now falls back to color-only rendering (empty native `textureId`) and continues to support binding once the texture resource is later declared.

--- a/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
+++ b/apps/test-server/src/pages/reality/texturedUnlitBox.tsx
@@ -9,6 +9,7 @@ import {
   Texture,
   UnlitMaterial,
 } from '@webspatial/react-sdk'
+import type { CSSProperties } from 'react'
 import { useState } from 'react'
 
 function buildPublicUrl(path: string): string {
@@ -25,12 +26,12 @@ const TEX_APPLE = 'https://threejs.org/examples/textures/sprite0.png'
 const TEX_BADGE = 'https://threejs.org/examples/textures/disturb.jpg'
 
 const SC = { x: 0.51, y: 0.51, z: 0.51 }
-const view: React.CSSProperties = {
+const view: CSSProperties = {
   maxHeight: 168,
   overflow: 'hidden',
   marginBottom: 8,
 }
-const rv: React.CSSProperties = {
+const rv: CSSProperties = {
   width: '100%',
   height: 160,
   maxWidth: 440,
@@ -38,7 +39,7 @@ const rv: React.CSSProperties = {
   background: '#111',
   '--xr-depth': 80,
   '--xr-back': 140,
-} as React.CSSProperties
+} as CSSProperties
 const hint = { fontSize: 13, color: '#888' }
 
 function carUrl() {
@@ -65,6 +66,10 @@ export default function TexturedUnlitBox() {
   >('switchTextureCar')
   const [bindColor, setBindColor] = useState('#ffffff')
   const bindMatId = bindTex === '' ? 'bindMat_none' : `bindMat_${bindTex}`
+
+  // 4c remount simulates page refresh
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [refreshLoads, setRefreshLoads] = useState(0)
   return (
     <div
       style={{ padding: 16, color: '#eee', fontFamily: 'system-ui,sans-serif' }}
@@ -180,8 +185,9 @@ export default function TexturedUnlitBox() {
       >
         Buttons exercise runtime URL changes (7306526129), bad URL with tint
         (7306537111, 7306500112), cache-bust with <code>?v=1</code> /{' '}
-        <code>?v=2</code>, and a fast URL+color loop. Refresh the page to repeat
-        any sequence.
+        <code>?v=2</code>, and a fast URL+color loop. Try Car → Badge → Car
+        again to confirm the second swap works. Refresh the page to repeat any
+        sequence.
       </p>
       <div
         style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 8 }}
@@ -359,6 +365,124 @@ export default function TexturedUnlitBox() {
       <div style={{ fontSize: 12 }}>
         textureId: <strong>{bindTex || '(none)'}</strong> · material:{' '}
         <code>{bindMatId}</code>
+      </div>
+
+      <h2 style={{ fontSize: 16, marginTop: 22 }}>
+        4 — Swan / AVP regressions
+      </h2>
+
+      <h3 style={{ fontSize: 14, marginTop: 12 }}>
+        4a — Material tint (red material, not green)
+      </h3>
+      <p style={hint}>
+        Box uses <code>matRed</code> (<code>#ff0000</code>) with{' '}
+        <code>tintTex</code>. Expect a red-tinted image — not an untinted /
+        green-looking box.
+      </p>
+      <div style={view}>
+        <Reality id="realityTint" style={rv}>
+          <Texture id="tintTex" url={buildPublicUrl(IMG_CAR)} />
+          <UnlitMaterial
+            id="matRed"
+            color="#ff0000"
+            textureId="tintTex"
+            transparent={false}
+            opacity={1}
+          />
+          <SceneGraph>
+            <Entity scale={SC} rotation={{ x: 0, y: 0.4, z: 0 }}>
+              <BoxEntity
+                id="redTintBox"
+                name="redTintBox"
+                width={0.1}
+                height={0.1}
+                depth={0.1}
+                cornerRadius={0.01}
+                materials={['matRed']}
+              />
+            </Entity>
+          </SceneGraph>
+        </Reality>
+      </div>
+
+      <h3 style={{ fontSize: 14, marginTop: 16 }}>
+        4b — Missing textureId still renders (tint-only)
+      </h3>
+      <p style={hint}>
+        <code>ghostMat</code> references <code>ghostTex</code>, which is never
+        declared. Expect a solid green box — material must not fail to load.
+      </p>
+      <div style={view}>
+        <Reality id="realityGhost" style={rv}>
+          <UnlitMaterial
+            id="ghostMat"
+            color="#00ff00"
+            textureId="ghostTex"
+            transparent={false}
+            opacity={1}
+          />
+          <SceneGraph>
+            <Entity scale={SC} rotation={{ x: 0, y: 0.4, z: 0 }}>
+              <BoxEntity
+                id="ghostBox"
+                name="ghostBox"
+                width={0.1}
+                height={0.1}
+                depth={0.1}
+                cornerRadius={0.01}
+                materials={['ghostMat']}
+              />
+            </Entity>
+          </SceneGraph>
+        </Reality>
+      </div>
+
+      <h3 style={{ fontSize: 14, marginTop: 16 }}>
+        4c — Remount (refresh stability)
+      </h3>
+      <p style={hint}>
+        Remounts the scene like a page refresh. After each remount the car
+        texture should apply to the box; <code>loads</code> should increment.
+      </p>
+      <button
+        type="button"
+        style={{ marginBottom: 8 }}
+        onClick={() => setRefreshKey(k => k + 1)}
+      >
+        Remount scene
+      </button>
+      <div style={view}>
+        <Reality key={refreshKey} id="realityRefresh" style={rv}>
+          <Texture
+            id="refreshTex"
+            url={buildPublicUrl(IMG_CAR)}
+            onLoad={() => setRefreshLoads(n => n + 1)}
+          />
+          <UnlitMaterial
+            id="refreshMat"
+            color="#ffffff"
+            textureId="refreshTex"
+            transparent={false}
+            opacity={1}
+          />
+          <SceneGraph>
+            <Entity scale={SC} rotation={{ x: 0, y: 0.4, z: 0 }}>
+              <BoxEntity
+                id="refreshBox"
+                name="refreshBox"
+                width={0.1}
+                height={0.1}
+                depth={0.1}
+                cornerRadius={0.01}
+                materials={['refreshMat']}
+              />
+            </Entity>
+          </SceneGraph>
+        </Reality>
+      </div>
+      <div style={{ fontSize: 12 }}>
+        remounts: <strong>{refreshKey}</strong> · loads:{' '}
+        <strong>{refreshLoads}</strong>
       </div>
     </div>
   )

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -16,11 +16,8 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
 }) => {
   const ctx = useRealityContext()
   const materialRef = useRef<SpatialUnlitMaterial | undefined>(undefined)
-  const isInitializedRef = useRef(false)
-  const latestTextureIdRef = useRef<string | undefined>(options.textureId)
+  const [isInitialized, setIsInitialized] = useState(false)
   const [textureRevision, setTextureRevision] = useState(0)
-
-  latestTextureIdRef.current = options.textureId
 
   useEffect(() => {
     if (!ctx || !options.textureId) return
@@ -37,37 +34,20 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     const init = async () => {
       try {
         let textureIdForNative: string | undefined = options.textureId
-        if (options.textureId) {
-          if (!resourceRegistry.has(options.textureId)) {
-            // Texture id was never declared: still create material so entities do not hang on
-            // materialId; tint-only / no texture until the texture resolves in the future.
+        if (options.textureId && resourceRegistry.has(options.textureId)) {
+          try {
+            const textureResource = await resourceRegistry.get(
+              options.textureId,
+            )
+            if (cancelled) return
+            textureIdForNative = textureResource.id
+          } catch {
+            // failed texture → tint-only
             textureIdForNative = ''
-            const targetTextureId = options.textureId
-            void resourceRegistry
-              .get(targetTextureId)
-              .then(textureResource => {
-                if (cancelled || latestTextureIdRef.current !== targetTextureId)
-                  return
-                const mat = materialRef.current
-                if (mat) {
-                  void mat
-                    .updateProperties({ textureId: textureResource.id })
-                    .catch(() => {})
-                }
-              })
-              .catch(() => {})
-          } else {
-            const texturePromise = resourceRegistry.get(options.textureId)
-            try {
-              const textureResource = await texturePromise
-              if (cancelled) return
-              textureIdForNative = textureResource.id
-            } catch {
-              // Texture failed: still create material so entities do not hang on materialId;
-              // tint-only / no texture until the texture resolves.
-              textureIdForNative = ''
-            }
           }
+        } else if (options.textureId) {
+          // no Texture for this id yet → tint-only; subscribe picks up add() later
+          textureIdForNative = ''
         }
         if (cancelled) return
         const commandOptions: SpatialUnlitMaterialOptions = {
@@ -81,7 +61,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
         const mat = await materialPromise
         if (cancelled) return
         materialRef.current = mat
-        isInitializedRef.current = true
+        setIsInitialized(true)
       } catch (error) {
         console.error(' ~ UnlitMaterial ~ error:', error)
       }
@@ -93,13 +73,13 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
       // Use registry to schedule destruction after promise resolves
       resourceRegistry.removeAndDestroy(materialId)
       materialRef.current = undefined
-      isInitializedRef.current = false
+      setIsInitialized(false)
     }
   }, [ctx, options.id])
 
   // Dynamic property updates
   useEffect(() => {
-    if (!ctx || !isInitializedRef.current || !materialRef.current) return
+    if (!ctx || !isInitialized || !materialRef.current) return
     let cancelled = false
     void (async () => {
       const updates: Partial<SpatialUnlitMaterialOptions> = {}
@@ -112,20 +92,6 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
           updates.textureId = ''
         } else if (!ctx.resourceRegistry.has(options.textureId)) {
           updates.textureId = ''
-          const targetTextureId = options.textureId
-          void ctx.resourceRegistry
-            .get(targetTextureId)
-            .then(textureResource => {
-              if (cancelled || latestTextureIdRef.current !== targetTextureId)
-                return
-              const mat = materialRef.current
-              if (mat) {
-                void mat
-                  .updateProperties({ textureId: textureResource.id })
-                  .catch(() => {})
-              }
-            })
-            .catch(() => {})
         } else {
           const texturePromise = ctx.resourceRegistry.get(options.textureId)
           try {
@@ -148,6 +114,7 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
     }
   }, [
     ctx,
+    isInitialized,
     options.color,
     options.textureId,
     options.transparent,

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -35,15 +35,21 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
       try {
         let textureIdForNative: string | undefined = options.textureId
         if (options.textureId) {
-          const texturePromise = resourceRegistry.get(options.textureId)
-          try {
-            const textureResource = await texturePromise
-            if (cancelled) return
-            textureIdForNative = textureResource.id
-          } catch {
-            // Texture failed: still create material so entities do not hang on materialId;
-            // tint-only / no texture until the texture resolves.
+          if (!resourceRegistry.has(options.textureId)) {
+            // Texture id was never declared: still create material so entities do not hang on
+            // materialId; tint-only / no texture until the texture resolves in the future.
             textureIdForNative = ''
+          } else {
+            const texturePromise = resourceRegistry.get(options.textureId)
+            try {
+              const textureResource = await texturePromise
+              if (cancelled) return
+              textureIdForNative = textureResource.id
+            } catch {
+              // Texture failed: still create material so entities do not hang on materialId;
+              // tint-only / no texture until the texture resolves.
+              textureIdForNative = ''
+            }
           }
         }
         if (cancelled) return
@@ -86,6 +92,8 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
       if (options.opacity !== undefined) updates.opacity = options.opacity
       if (options.textureId !== undefined) {
         if (options.textureId === '') {
+          updates.textureId = ''
+        } else if (!ctx.resourceRegistry.has(options.textureId)) {
           updates.textureId = ''
         } else {
           const texturePromise = ctx.resourceRegistry.get(options.textureId)

--- a/packages/react/src/reality/components/UnlitMaterial.tsx
+++ b/packages/react/src/reality/components/UnlitMaterial.tsx
@@ -17,7 +17,10 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
   const ctx = useRealityContext()
   const materialRef = useRef<SpatialUnlitMaterial | undefined>(undefined)
   const isInitializedRef = useRef(false)
+  const latestTextureIdRef = useRef<string | undefined>(options.textureId)
   const [textureRevision, setTextureRevision] = useState(0)
+
+  latestTextureIdRef.current = options.textureId
 
   useEffect(() => {
     if (!ctx || !options.textureId) return
@@ -39,6 +42,20 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
             // Texture id was never declared: still create material so entities do not hang on
             // materialId; tint-only / no texture until the texture resolves in the future.
             textureIdForNative = ''
+            const targetTextureId = options.textureId
+            void resourceRegistry
+              .get(targetTextureId)
+              .then(textureResource => {
+                if (cancelled || latestTextureIdRef.current !== targetTextureId)
+                  return
+                const mat = materialRef.current
+                if (mat) {
+                  void mat
+                    .updateProperties({ textureId: textureResource.id })
+                    .catch(() => {})
+                }
+              })
+              .catch(() => {})
           } else {
             const texturePromise = resourceRegistry.get(options.textureId)
             try {
@@ -95,6 +112,20 @@ export const UnlitMaterial: React.FC<UnlitMaterialProps> = ({
           updates.textureId = ''
         } else if (!ctx.resourceRegistry.has(options.textureId)) {
           updates.textureId = ''
+          const targetTextureId = options.textureId
+          void ctx.resourceRegistry
+            .get(targetTextureId)
+            .then(textureResource => {
+              if (cancelled || latestTextureIdRef.current !== targetTextureId)
+                return
+              const mat = materialRef.current
+              if (mat) {
+                void mat
+                  .updateProperties({ textureId: textureResource.id })
+                  .catch(() => {})
+              }
+            })
+            .catch(() => {})
         } else {
           const texturePromise = ctx.resourceRegistry.get(options.textureId)
           try {

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -71,6 +71,10 @@ export class ResourceRegistry {
     }
   }
 
+  has(id: string): boolean {
+    return this.resources.has(id)
+  }
+
   get(id: string): Promise<SpatialObject> {
     const existing = this.resources.get(id)
     if (existing) {

--- a/packages/react/src/reality/utils/ResourceRegistry.ts
+++ b/packages/react/src/reality/utils/ResourceRegistry.ts
@@ -8,18 +8,16 @@ import { SpatialObject } from '@webspatial/core-sdk'
  * JSX order does not need to match registration order. Callers are responsible for using the
  * correct id for each resource kind (same as with string ids today).
  *
- * Callers can `await get(id)` before `add(id, promise)` runs: `get` returns a promise that
- * settles when something later calls `add` with the same id.
+ * `get(id)` before `add()` is fine — resolves when `add()` runs.
+ * `has(id)` is true only after `add()`, not after `get()` alone.
  *
- * **Subscriptions:** `subscribe(id, listener)` runs `listener` whenever `notify(id)` is invoked.
- * The registry auto-notifies after each `add()` promise settles (then or catch), and on
- * `remove`, `removeAndDestroy`, and `destroy()`. Components such as `<Texture>` may call
- * `notify(id)` manually when a resource mutates in place without a new `add()` (e.g. same texture
- * id, new URL via `updateProperties`).
+ * `subscribe` / `notify`: run when a resource settles, is removed, or updates in place (e.g. texture URL).
  */
 export class ResourceRegistry {
   /** Every id maps to a promise — either the real resource from add(), or a placeholder until then. */
   private resources: Map<string, Promise<SpatialObject>> = new Map()
+  /** ids registered via add(), not get()-only waiters */
+  private registered = new Set<string>()
   /** If get() ran first, we stash resolve/reject so add() can complete the waiting promise. */
   private deferreds = new Map<
     string,
@@ -32,6 +30,7 @@ export class ResourceRegistry {
   private listeners = new Map<string, Set<() => void>>()
 
   add<T extends SpatialObject>(id: string, resource: Promise<T>): void {
+    this.registered.add(id)
     this.resources.set(id, resource)
 
     // Anyone who awaited get(id) early is still holding the placeholder; wire them to this promise.
@@ -72,7 +71,7 @@ export class ResourceRegistry {
   }
 
   has(id: string): boolean {
-    return this.resources.has(id)
+    return this.registered.has(id)
   }
 
   get(id: string): Promise<SpatialObject> {
@@ -90,6 +89,7 @@ export class ResourceRegistry {
   }
 
   remove(id: string): void {
+    this.registered.delete(id)
     this.resources.delete(id)
     this.deferreds.delete(id)
     this.notify(id)
@@ -101,6 +101,7 @@ export class ResourceRegistry {
     if (p) {
       p.then(obj => obj.destroy()).catch(() => {})
     }
+    this.registered.delete(id)
     this.resources.delete(id)
     this.deferreds.delete(id)
     this.notify(id)
@@ -120,6 +121,7 @@ export class ResourceRegistry {
       this.notify(id)
     }
     this.listeners.clear()
+    this.registered.clear()
 
     const pending = Array.from(this.resources.values())
     this.resources.clear()


### PR DESCRIPTION
### Motivation
- Creating an `UnlitMaterial` with a `textureId` that was never declared caused `ResourceRegistry.get()` to return a deferred promise and blocked material creation, which could make entities not render.
- The native/AVP expectation is that a missing texture should yield a tint-only material (no texture) rather than blocking render.
- The web/react layer should detect undeclared texture ids and fall back to no-texture while still allowing the texture to be bound later.

### Description
- Added `ResourceRegistry.has(id): boolean` to detect whether a resource id is known without creating a deferred `get()` placeholder.
- Updated `UnlitMaterial` initialization to check `resourceRegistry.has(options.textureId)` and use `textureId = ''` fallback when the id is undeclared so the material is created immediately.
- Updated `UnlitMaterial` dynamic property update path to apply the same undeclared-id fallback when `textureId` changes.
- Kept existing subscription/notify flow so the material can bind the texture later when the `textureId` is added.

### Testing
- Ran `pnpm -C packages/react build` which completed successfully.
- The TypeScript build/DTS generation (`tsup`) completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a162277fc188323973adf9ac7df8539)