### PR TITLE
fix(visionos): sync nav button state from webview

### DIFF
--- a/.changeset/nav-state-visionos.md
+++ b/.changeset/nav-state-visionos.md
@@ -1,0 +1,5 @@
+---
+"@webspatial/platform-visionos": patch
+---
+
+fix(visionos): sync nav button state from webview

--- a/packages/visionOS/web-spatial/view/SpatialNavView.swift
+++ b/packages/visionOS/web-spatial/view/SpatialNavView.swift
@@ -76,12 +76,10 @@ struct SpatialNavView: View {
     @State private var showEnter: Double = 1
     @State private var showNav: Double = 0
     @State private var showUrl: Double = 0
+    @State private var canGoBack = false
+    @State private var canGoForward = false
+    @State private var navigationStateListener: ((SpatialWebViewState) -> Void)?
     @Namespace var hoverNamespace
-
-    func checkButtonState() {
-        canGoBack = model!.getController().webview!.canGoBack
-        canGoForward = model!.getController().webview!.canGoForward
-    }
 
     func goBack() {
         spatialScene.resetForNavigation()
@@ -107,9 +105,35 @@ struct SpatialNavView: View {
         return model?.getController().webview?.url
     }
 
-    @State var canGoBack: Bool = false
+    func checkButtonState() {
+        canGoBack = model?.getController().webview?.canGoBack ?? false
+        canGoForward = model?.getController().webview?.canGoForward ?? false
+    }
 
-    @State var canGoForward: Bool = false
+    func registerNavigationStateListener() {
+        guard navigationStateListener == nil else { return }
+
+        let listener: (SpatialWebViewState) -> Void = { state in
+            switch state {
+            case .didUpdateNavigationState:
+                DispatchQueue.main.async {
+                    self.checkButtonState()
+                }
+            default:
+                break
+            }
+        }
+
+        navigationStateListener = listener
+        model?.addStateListener(listener)
+    }
+
+    func unregisterNavigationStateListener() {
+        guard let navigationStateListener else { return }
+
+        model?.removeStateListener(navigationStateListener)
+        self.navigationStateListener = nil
+    }
 
     var navHoverGroup: HoverEffectGroup {
         HoverEffectGroup(hoverNamespace)
@@ -128,6 +152,7 @@ struct SpatialNavView: View {
                             children: Image("arrow_left"),
                             clearBackGround: true
                         )
+                        .opacity(self.canGoBack ? 1 : 0.5)
                         .disabled(!(self.canGoBack))
                         NavButton(
                             action: { self.goForward()
@@ -135,7 +160,8 @@ struct SpatialNavView: View {
                             children: Image("arrow_right"),
                             clearBackGround: true
                         )
-                        .disabled(!(self.canGoBack))
+                        .opacity(self.canGoForward ? 1 : 0.5)
+                        .disabled(!(self.canGoForward))
                         NavButton(action: { self.reload() }, children: Image("refresh"), clearBackGround: true)
                         NavDivider()
                     }
@@ -160,13 +186,15 @@ struct SpatialNavView: View {
                         },
                         children: Image("arrow_left")
                     )
+                    .opacity(self.canGoBack ? 1 : 0.5)
                     .disabled(!(self.canGoBack))
                     NavButton(
                         action: { self.goForward()
                         },
                         children: Image("arrow_right")
                     )
-                    .disabled(!(self.canGoBack))
+                    .opacity(self.canGoForward ? 1 : 0.5)
+                    .disabled(!(self.canGoForward))
                     NavButton(action: { self.reload() }, children: Image("refresh"))
                     NavDivider()
                 }
@@ -238,9 +266,11 @@ struct SpatialNavView: View {
             .opacity(showUrl)
         }
         .onAppear {
-            model?.addStateListener(.didFinishLoad) {
-                self.checkButtonState()
-            }
+            checkButtonState()
+            registerNavigationStateListener()
+        }
+        .onDisappear {
+            unregisterNavigationStateListener()
         }
     }
 

--- a/packages/visionOS/web-spatial/view/SpatialNavView.swift
+++ b/packages/visionOS/web-spatial/view/SpatialNavView.swift
@@ -114,13 +114,9 @@ struct SpatialNavView: View {
         guard navigationStateListenerID == nil else { return }
 
         let listener: (SpatialWebViewState) -> Void = { state in
-            switch state {
-            case .didUpdateNavigationState:
-                DispatchQueue.main.async {
-                    self.checkButtonState()
-                }
-            default:
-                break
+            guard case .didUpdateNavigationState = state else { return }
+            Task { @MainActor in
+                self.checkButtonState()
             }
         }
 

--- a/packages/visionOS/web-spatial/view/SpatialNavView.swift
+++ b/packages/visionOS/web-spatial/view/SpatialNavView.swift
@@ -78,7 +78,7 @@ struct SpatialNavView: View {
     @State private var showUrl: Double = 0
     @State private var canGoBack = false
     @State private var canGoForward = false
-    @State private var navigationStateListener: ((SpatialWebViewState) -> Void)?
+    @State private var navigationStateListenerID: UUID?
     @Namespace var hoverNamespace
 
     func goBack() {
@@ -111,7 +111,7 @@ struct SpatialNavView: View {
     }
 
     func registerNavigationStateListener() {
-        guard navigationStateListener == nil else { return }
+        guard navigationStateListenerID == nil else { return }
 
         let listener: (SpatialWebViewState) -> Void = { state in
             switch state {
@@ -124,15 +124,14 @@ struct SpatialNavView: View {
             }
         }
 
-        navigationStateListener = listener
-        model?.addStateListener(listener)
+        navigationStateListenerID = model?.addStateListener(listener)
     }
 
     func unregisterNavigationStateListener() {
-        guard let navigationStateListener else { return }
+        guard let navigationStateListenerID else { return }
 
-        model?.removeStateListener(navigationStateListener)
-        self.navigationStateListener = nil
+        model?.removeStateListener(navigationStateListenerID)
+        self.navigationStateListenerID = nil
     }
 
     var navHoverGroup: HoverEffectGroup {

--- a/packages/visionOS/web-spatial/webview/SpatialWebController.swift
+++ b/packages/visionOS/web-spatial/webview/SpatialWebController.swift
@@ -5,6 +5,9 @@ class SpatialWebController: NSObject, WKNavigationDelegate, WKScriptMessageHandl
     weak var model: SpatialWebViewModel?
     var webview: WKWebView?
     private var isObserving = false
+    private var urlObservation: NSKeyValueObservation?
+    private var canGoBackObservation: NSKeyValueObservation?
+    private var canGoForwardObservation: NSKeyValueObservation?
     private var navigationInvoke: ((_ data: URL) -> Bool)?
     private var openWindowInvoke: ((_ data: URL) -> WebViewElementInfo?)?
     private var webviewStateChangeInvoke: ((_ type: SpatialWebViewState) -> Void)?
@@ -205,42 +208,35 @@ class SpatialWebController: NSObject, WKNavigationDelegate, WKScriptMessageHandl
 
     func startObserving() {
         guard !isObserving else { return }
-        webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
-        webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
-        webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
+        urlObservation = webview?.observe(\.url, options: [.new]) { [weak self] webView, _ in
+            guard let self, let url = webView.url?.absoluteString else { return }
+            Task { @MainActor in
+                self.model?.url = url
+                self.webviewStateChangeInvoke?(.didUpdateURL)
+            }
+        }
+        canGoBackObservation = webview?.observe(\.canGoBack, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.webviewStateChangeInvoke?(.didUpdateNavigationState)
+            }
+        }
+        canGoForwardObservation = webview?.observe(\.canGoForward, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.webviewStateChangeInvoke?(.didUpdateNavigationState)
+            }
+        }
         isObserving = true
     }
 
     func stopObserving() {
         guard isObserving else { return }
-        webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
-        webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
-        webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward))
+        urlObservation?.invalidate()
+        canGoBackObservation?.invalidate()
+        canGoForwardObservation?.invalidate()
+        urlObservation = nil
+        canGoBackObservation = nil
+        canGoForwardObservation = nil
         isObserving = false
-    }
-
-    override func observeValue(
-        forKeyPath keyPath: String?,
-        of object: Any?,
-        change: [NSKeyValueChangeKey: Any]?,
-        context: UnsafeMutableRawPointer?
-    ) {
-        guard let webView = object as? WKWebView else { return }
-
-        if keyPath == #keyPath(WKWebView.url),
-           let url = webView.url?.absoluteString
-        {
-            DispatchQueue.main.async {
-                self.model?.url = url
-                self.webviewStateChangeInvoke?(.didUpdateURL)
-            }
-        } else if keyPath == #keyPath(WKWebView.canGoBack) ||
-            keyPath == #keyPath(WKWebView.canGoForward)
-        {
-            DispatchQueue.main.async {
-                self.webviewStateChangeInvoke?(.didUpdateNavigationState)
-            }
-        }
     }
 
     func destroy() {

--- a/packages/visionOS/web-spatial/webview/SpatialWebController.swift
+++ b/packages/visionOS/web-spatial/webview/SpatialWebController.swift
@@ -206,12 +206,16 @@ class SpatialWebController: NSObject, WKNavigationDelegate, WKScriptMessageHandl
     func startObserving() {
         guard !isObserving else { return }
         webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: .new, context: nil)
+        webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: .new, context: nil)
+        webview?.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward), options: .new, context: nil)
         isObserving = true
     }
 
     func stopObserving() {
         guard isObserving else { return }
         webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
+        webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack))
+        webview?.removeObserver(self, forKeyPath: #keyPath(WKWebView.canGoForward))
         isObserving = false
     }
 
@@ -221,12 +225,20 @@ class SpatialWebController: NSObject, WKNavigationDelegate, WKScriptMessageHandl
         change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?
     ) {
+        guard let webView = object as? WKWebView else { return }
+
         if keyPath == #keyPath(WKWebView.url),
-           let url = (object as? WKWebView)?.url?.absoluteString
+           let url = webView.url?.absoluteString
         {
             DispatchQueue.main.async {
-//                print("url change", url)
                 self.model?.url = url
+                self.webviewStateChangeInvoke?(.didUpdateURL)
+            }
+        } else if keyPath == #keyPath(WKWebView.canGoBack) ||
+            keyPath == #keyPath(WKWebView.canGoForward)
+        {
+            DispatchQueue.main.async {
+                self.webviewStateChangeInvoke?(.didUpdateNavigationState)
             }
         }
     }

--- a/packages/visionOS/web-spatial/webview/SpatialWebViewModel.swift
+++ b/packages/visionOS/web-spatial/webview/SpatialWebViewModel.swift
@@ -10,7 +10,7 @@ class SpatialWebViewModel {
     private var navigationList: [String: (_ data: URL) -> Bool] = [:]
     private var openWindowList: [String: (_ data: URL) -> WebViewElementInfo?] = [:]
     private var stateListeners: [SpatialWebViewState: [() -> Void]] = [:]
-    private var stateChangeListeners: [(_ type: SpatialWebViewState) -> Void] = []
+    private var stateChangeListeners: [(id: UUID, listener: (_ type: SpatialWebViewState) -> Void)] = []
     private var scrollUpdateListeners: [(_ type: ScrollState, _ point: CGPoint) -> Void] = []
     private var backgroundTransparent: Bool = false
 
@@ -150,8 +150,11 @@ class SpatialWebViewModel {
     }
 
     /// webview state event
-    func addStateListener(_ event: @escaping (_ type: SpatialWebViewState) -> Void) {
-        stateChangeListeners.append(event)
+    @discardableResult
+    func addStateListener(_ event: @escaping (_ type: SpatialWebViewState) -> Void) -> UUID {
+        let id = UUID()
+        stateChangeListeners.append((id: id, listener: event))
+        return id
     }
 
     func addStateListener(_ state: SpatialWebViewState, _ event: @escaping () -> Void) {
@@ -161,9 +164,9 @@ class SpatialWebViewModel {
         stateListeners[state]?.append(event)
     }
 
-    func removeStateListener(_ event: @escaping (_ type: SpatialWebViewState) -> Void) {
+    func removeStateListener(_ id: UUID) {
         stateChangeListeners.removeAll(where: {
-            $0 as AnyObject === event as AnyObject
+            $0.id == id
         })
     }
 
@@ -235,7 +238,7 @@ class SpatialWebViewModel {
             load()
         }
         for onStateChange in stateChangeListeners {
-            onStateChange(state)
+            onStateChange.listener(state)
         }
         stateListeners[state]?.forEach { onStateChange in
             onStateChange()

--- a/packages/visionOS/web-spatial/webview/SpatialWebViewModel.swift
+++ b/packages/visionOS/web-spatial/webview/SpatialWebViewModel.swift
@@ -161,13 +161,13 @@ class SpatialWebViewModel {
         stateListeners[state]?.append(event)
     }
 
-    func removeStateListener(_ event: @escaping (_ type: String) -> Void) {
+    func removeStateListener(_ event: @escaping (_ type: SpatialWebViewState) -> Void) {
         stateChangeListeners.removeAll(where: {
             $0 as AnyObject === event as AnyObject
         })
     }
 
-    func removeStateListener(_ state: SpatialWebViewState, _ event: @escaping (_ object: Any, _ data: Any) -> Void) {
+    func removeStateListener(_ state: SpatialWebViewState, _ event: @escaping () -> Void) {
         stateListeners[state]?.removeAll(where: {
             $0 as AnyObject === event as AnyObject
         })
@@ -300,6 +300,8 @@ enum SpatialWebViewState: String, CaseIterable {
     case didReceive
     case didFinishLoad
     case didFailLoad
+    case didUpdateURL
+    case didUpdateNavigationState
     case didUnload
     case didClose
     case didMakeView


### PR DESCRIPTION
## Summary
Fix visionOS nav button state sync for SPA navigation.

## Problem
The nav UI previously refreshed `canGoBack` and `canGoForward` from URL/load-related callbacks, and also read them immediately after `goBack()` / `goForward()`.

For test-server sidebar navigation, most route changes are SPA hash-route updates. In this flow, the URL can change before `WKWebView.canGoBack` and `WKWebView.canGoForward` settle, which makes the nav button state lag one step behind the actual back-forward stack.

## Fix
- Observe `WKWebView.canGoBack` directly
- Observe `WKWebView.canGoForward` directly
- Emit a dedicated navigation-state update event from the webview layer
- Update `SpatialNavView` only from that navigation-state event
- Keep URL updates separate for address changes
- Align state-listener removal signatures with the registered callback types

## Files
- `packages/visionOS/web-spatial/view/SpatialNavView.swift`
- `packages/visionOS/web-spatial/webview/SpatialWebController.swift`
- `packages/visionOS/web-spatial/webview/SpatialWebViewModel.swift`

## Validation
- Verified Swift diagnostics for the touched files
- Branch is isolated from earlier non-navigation fixes and can be reviewed independently against `main`

<img width="1510" height="901" alt="image" src="https://github.com/user-attachments/assets/79c19010-1c74-4c6d-b170-541188d83a5c" />
<img width="1510" height="901" alt="image" src="https://github.com/user-attachments/assets/758a90ad-eaec-43b1-9462-a0016575afd6" />
<img width="1510" height="901" alt="image" src="https://github.com/user-attachments/assets/9c0777b5-3c44-4721-88a1-cd22acacb871" />


