### PR TITLE
fix: Model reloads when switching from eager to lazy

### DIFF
--- a/.changeset/quiet-cars-run.md
+++ b/.changeset/quiet-cars-run.md
@@ -1,0 +1,6 @@
+---
+'web-content': patch
+'@webspatial/react-sdk': patch
+---
+
+fix: Model reloads when switching from eager to lazy

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -12,6 +12,7 @@ function App() {
   const [currentTime, setCurrentTime] = useState(0.0)
   const [playbackRate, setPlaybackRate] = useState(1.0)
   const [loop, setLoop] = useState(true)
+  const [loading, setLoading] = useState<'eager' | 'lazy'>('eager')
   useEffect(() => {
     modelRef
       .current!.ready?.then(() => logLine('ref.current.ready success'))
@@ -128,6 +129,15 @@ function App() {
           />
           <span className="label-text m-1">Loop</span>
         </label>
+        <label className="inline-flex items-center align-middle">
+          <input
+            type="checkbox"
+            className="checkbox"
+            checked={loading === 'eager'}
+            onChange={() => setLoading(loading === 'eager' ? 'lazy' : 'eager')}
+          />
+          <span className="label-text m-1">Eager</span>
+        </label>
         <select
           className="select m-1"
           value={playbackRate}
@@ -154,7 +164,7 @@ function App() {
       <Model
         enable-xr
         autoPlay
-        loading="lazy"
+        loading={loading}
         style={{
           height: '200px',
           '--xr-depth': '100px',

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SpatializedStatic3DElementContainer } from './SpatializedStatic3DElementContainer'
+import {
+  PortalInstanceContext,
+  PortalInstanceObject,
+} from './context/PortalInstanceContext'
+
+type LoadingMode = 'lazy' | 'eager'
+
+type UpdatePropertiesPayload = {
+  loading?: LoadingMode
+  modelURL?: string
+  sources?: Array<{ src: string; type?: string }>
+  autoplay?: boolean
+  loop?: boolean
+  posterURL?: string
+}
+
+type SpatializedElementStub = {
+  updateProperties: (payload: UpdatePropertiesPayload) => void
+  modelUrl: string
+}
+
+const updateProperties = vi.fn<(payload: UpdatePropertiesPayload) => void>()
+const spatializedElement: SpatializedElementStub = {
+  updateProperties,
+  modelUrl: '',
+}
+const portalInstanceValue = {
+  dom: document.createElement('div'),
+} as unknown as PortalInstanceObject
+
+vi.mock('@webspatial/core-sdk', () => ({
+  SpatializedStatic3DElement: class {},
+}))
+
+vi.mock('./SpatializedContainer', () => ({
+  SpatializedContainer: ({
+    spatializedContent: Content,
+    ...props
+  }: {
+    spatializedContent: React.ComponentType<Record<string, unknown>>
+  } & Record<string, unknown>) => {
+    return (
+      <PortalInstanceContext.Provider value={portalInstanceValue}>
+        <Content {...props} spatializedElement={spatializedElement} />
+      </PortalInstanceContext.Provider>
+    )
+  },
+}))
+
+type TestEntry = Pick<IntersectionObserverEntry, 'isIntersecting'>
+
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = []
+
+  callback: (entries: TestEntry[]) => void
+  observe = vi.fn<(target: Element) => void>()
+  disconnect = vi.fn<() => void>()
+
+  constructor(callback: (entries: TestEntry[]) => void) {
+    this.callback = callback
+    IntersectionObserverMock.instances.push(this)
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback([{ isIntersecting }])
+  }
+}
+
+function lastObserver() {
+  return IntersectionObserverMock.instances.at(-1)
+}
+
+describe('SpatializedStatic3DElementContainer lazy/eager loading behavior', () => {
+  beforeEach(() => {
+    updateProperties.mockClear()
+    IntersectionObserverMock.instances = []
+    globalThis.IntersectionObserver =
+      IntersectionObserverMock as unknown as typeof IntersectionObserver
+  })
+
+  it('does not load until visible when loading="lazy"', () => {
+    render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="lazy" />,
+    )
+
+    expect(updateProperties).toHaveBeenCalledTimes(1)
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'lazy' }),
+    )
+
+    expect(lastObserver()).toBeDefined()
+    expect(updateProperties).not.toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+  })
+
+  it('loads immediately when loading is eager or undefined', () => {
+    const { rerender } = render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="eager" />,
+    )
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+
+    rerender(<SpatializedStatic3DElementContainer src="/model2.usdz" />)
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+  })
+
+  it('loads immediately when switching loading from lazy to eager', () => {
+    const { rerender } = render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="lazy" />,
+    )
+
+    rerender(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="eager" />,
+    )
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+  })
+
+  it('keeps eager when switching from eager to lazy', () => {
+    const { rerender } = render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="eager" />,
+    )
+    updateProperties.mockClear()
+
+    rerender(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="lazy" />,
+    )
+
+    expect(updateProperties).toHaveBeenCalledTimes(1)
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+    expect(updateProperties).not.toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'lazy' }),
+    )
+  })
+
+  it('for lazy: loads on visible; when hidden and src changes, waits until visible again', () => {
+    const { rerender } = render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="lazy" />,
+    )
+
+    act(() => {
+      lastObserver()!.trigger(true)
+    })
+    expect(updateProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+
+    updateProperties.mockClear()
+    rerender(
+      <SpatializedStatic3DElementContainer src="/model2.usdz" loading="lazy" />,
+    )
+    expect(updateProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'lazy' }),
+    )
+    expect(updateProperties).not.toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+
+    act(() => {
+      lastObserver()!.trigger(true)
+    })
+    expect(updateProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+  })
+
+  it('loads immediately when switching from lazy to undefined', () => {
+    const { rerender } = render(
+      <SpatializedStatic3DElementContainer src="/model.usdz" loading="lazy" />,
+    )
+
+    rerender(<SpatializedStatic3DElementContainer src="/model.usdz" />)
+    expect(updateProperties).toHaveBeenLastCalledWith(
+      expect.objectContaining({ loading: 'eager' }),
+    )
+  })
+})

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -97,44 +97,37 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
     onError,
     autoPlay,
     loop,
-    loading,
+    loading = 'eager',
   } = props
   const portalInstanceObject = useContext(PortalInstanceContext)!
-  const [effectiveLoading, setEffectiveLoading] = useState<ModelLoadingMode>(
-    () => (loading === 'lazy' ? 'lazy' : 'eager'),
-  )
+  const wasVisible = useRef(false)
 
   const modelURL = useMemo(() => getAbsoluteURL(src), [src])
   const posterURL = useMemo(() => getAbsoluteURL(poster), [poster])
   const sources = useMemo(() => collectSources(children), [children])
   const sourcesKey = useMemo(() => JSON.stringify(sources), [sources])
 
+  // Observe when model becomes visible and then stop until sources change
   useEffect(() => {
-    setEffectiveLoading(loading === 'lazy' ? 'lazy' : 'eager')
-  }, [loading, modelURL, sourcesKey])
-
-  // `effectiveLoading` is `'lazy'` only while `loading === 'lazy'` and the
-  // portal element has not yet intersected the viewport. Once it flips to
-  // `'eager'` the observer disconnects and the value sticks until the sources
-  // change while still requested as lazy.
-  useEffect(() => {
-    if (effectiveLoading !== 'lazy') return
+    wasVisible.current = false
     const target = portalInstanceObject.dom
-    if (!target || typeof IntersectionObserver === 'undefined') {
-      setEffectiveLoading('eager')
+    if (loading !== 'lazy' || !target) {
+      wasVisible.current = true
       return
     }
     const observer = new IntersectionObserver(entries => {
       if (entries.some(entry => entry.isIntersecting)) {
-        setEffectiveLoading('eager')
+        wasVisible.current = true
         observer.disconnect()
+        spatializedElement.updateProperties({ loading: 'eager' })
       }
     })
     observer.observe(target)
     return () => observer.disconnect()
-  }, [effectiveLoading, portalInstanceObject])
+  }, [modelURL, sourcesKey, portalInstanceObject])
 
   useEffect(() => {
+    if (loading !== 'lazy') wasVisible.current = true
     // If modelURL was previously set and now is undefined then a dummy
     // value needs to be sent to clear the old value
     // TODO: Can native side handle null instead of ''
@@ -144,9 +137,9 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       autoplay: autoPlay,
       loop,
       posterURL: posterURL ?? '',
-      loading: effectiveLoading,
+      loading: loading === 'lazy' && wasVisible.current ? 'eager' : loading,
     })
-  }, [modelURL, sourcesKey, autoPlay, loop, posterURL, effectiveLoading])
+  }, [modelURL, sourcesKey, autoPlay, loop, posterURL, loading])
 
   useEffect(() => {
     if (onLoad) {


### PR DESCRIPTION
When switching loading mode from eager to lazy nothing should happen since the Model is already loaded.

Fixes https://meego.larkoffice.com/pico/issue/detail/7307253009


https://github.com/user-attachments/assets/b24635d8-b79f-4406-8241-688b057325df

