### PR TITLE
fix: Model show poster when there no sources

### DIFF
--- a/.changeset/some-spies-wait.md
+++ b/.changeset/some-spies-wait.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Show 3D Model poster when no sources are defined

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -23,10 +23,8 @@ class SpatializedStatic3DElement: SpatializedElement {
     /// fetching until the web layer flips it back to `"eager"`.
     var loading: String = "eager"
     var allSources: [ModelSource] {
-        guard loading == "eager" else { return [] }
-        return if let modelURL {
-            [ModelSource(src: modelURL, type: nil)] + sources
-        } else { sources }
+        if let modelURL { [ModelSource(src: modelURL, type: nil)] + sources }
+        else { sources }
     }
 
     enum CodingKeys: String, CodingKey {

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -35,7 +35,7 @@ struct SpatializedStatic3DView: View {
         let z = translation.z
 
         let enableGesture = spatializedElement.enableGesture
-        if !spatializedStatic3DElement.allSources.isEmpty {
+        if spatializedStatic3DElement.loading == "eager" {
             Group {
                 switch loadState {
                 case .idle, .loading:


### PR DESCRIPTION
## Summary

Decouple allSources from the loading mode so it always reflects the real sources, and gate fetching on the loading mode. Lazy elements remain empty until the web layer flips them to eager. https://claude.ai/code/session_01M5Gp4UxShaWGyJWfnGiCC3

## Type of change

- [x] Bug fix

## Validation

<!-- Check everything you ran, or explain why it was not run. -->

- [x] `pnpm test`
- [x] Manual validation:

## Package release

<!-- If this PR changes anything under `packages/`, add a changeset with `pnpm changeset` unless a maintainer applies `skip-changeset`. -->

- [x] I added a `.changeset/*.md` file.

## Screenshots or recordings

### Before
<img width="1385" height="880" alt="Screenshot 2026-05-28 at 16 47 29" src="https://github.com/user-attachments/assets/5ebf2486-3fa2-4721-885a-ededc1e1576f" />

### After
<img width="1385" height="880" alt="Screenshot 2026-05-28 at 16 48 32" src="https://github.com/user-attachments/assets/cea539cc-891d-48f7-bcdc-69a7f7deaec7" />


## Checklist

- [x] I kept this PR focused and avoided unrelated refactors.
- [x] I preserved existing inline comments unless changing them was part of this PR.

