### PR TITLE
Revert "chore(visionos): bump package version to 1.7.0"

### DIFF
--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspatial/platform-visionos",
-  "version": "1.7.0",
+  "version": "1.6.1",
   "description": "Used to publish WebSpatial projects to Apple Vision Pro",
   "type": "commonjs",
   "main": "package.json",


### PR DESCRIPTION
Manually bumping package versions breaks the automatic versioning by changeset.

This reverts commit 78b28a5cadf3f8f4135c29bd468b96ed225e1ea6.