### PR TITLE
fix(react): mirror host intrinsic tag on transform probe

### DIFF
--- a/.changeset/probe-mirror-host-intrinsic-tag.md
+++ b/.changeset/probe-mirror-host-intrinsic-tag.md
@@ -1,0 +1,5 @@
+---
+"@webspatial/react-sdk": patch
+---
+
+Mirror the spatial host intrinsic HTML tag on the transform/visibility probe so tag selectors (for example `h1 { transform: ... }`) apply when reading computed styles for spatial transforms. Non-string component types still use a `div` probe.

--- a/.changeset/probe-mirror-host-intrinsic-tag.md
+++ b/.changeset/probe-mirror-host-intrinsic-tag.md
@@ -2,4 +2,8 @@
 "@webspatial/react-sdk": patch
 ---
 
-Mirror the spatial host intrinsic HTML tag on the transform/visibility probe so tag selectors (for example `h1 { transform: ... }`) apply when reading computed styles for spatial transforms. Non-string component types still use a `div` probe.
+Fix SpatialDiv transforms when stylesheets use **HTML tag selectors** on the host element (for example `h1 { transform: … }` or `h1.myClass { … }`). The off-screen transform/visibility probe now mirrors the host’s intrinsic tag (`<h1 enable-xr>` → probe `<h1>`); custom React component wrappers still use a `div` probe.
+
+**Limitations:** ancestor selectors tied to the page tree (e.g. `.page h1`) may not match the probe; prefer class selectors or inline `style` for those cases. See `docs/webspatial-quirks.md` and `packages/react/src/spatialized-container/ARCHITECTURE.md`.
+
+Fixes [#1263](https://github.com/webspatial/webspatial-sdk/issues/1263).

--- a/apps/test-server/src/pages/basic-transform/basictransform.css
+++ b/apps/test-server/src/pages/basic-transform/basictransform.css
@@ -1,0 +1,5 @@
+/* Tag + class selector: must match the spatial <h1 enable-xr> probe (same intrinsic tag). */
+h1.basicTransform {
+  --xr-back: 250px;
+  transform: translateZ(120px) rotateZ(30deg);
+}

--- a/apps/test-server/src/pages/basic-transform/index.tsx
+++ b/apps/test-server/src/pages/basic-transform/index.tsx
@@ -1,33 +1,41 @@
 import { enableDebugTool } from '@webspatial/react-sdk'
 import React from 'react'
+import './basictransform.css'
 
 enableDebugTool()
 
 export default function BasicTransform() {
-  const style = {
+  const style: React.CSSProperties = {
     width: '300px',
     height: '300px',
     backgroundColor: 'green',
-    '--xr-back': '10px',
-    transform: '  rotateZ(40deg) ',
   }
-  const ref = React.useRef<HTMLDivElement>(null)
+  const ref = React.useRef<HTMLHeadingElement>(null)
   return (
-    <div className="p-10 text-white">
+    <div className="p-10 text-white max-w-2xl">
       <h1 className="text-2xl mb-4">Basic Transform</h1>
+      <p className="text-gray-400 text-sm mb-6">
+        The green panel is an{' '}
+        <code className="text-gray-200">h1 enable-xr</code> styled only via{' '}
+        <code className="text-gray-200">basictransform.css</code> (
+        <code className="text-gray-200">
+          h1.basicTransform {'{ transform }'}
+        </code>
+        ). In spatial runtime the transform should appear on the 3D slab; edit
+        the CSS file and reload to iterate.
+      </p>
       <div className="flex flex-col gap-4">
-        <div>hello basic-transform</div>
-        <div
+        <h1
           enable-xr
           style={style}
-          className="rounded-lg shadow-xl"
+          className="rounded-lg shadow-xl basicTransform"
           ref={ref}
+          data-name="basic-transform-h1"
           onSpatialTap={evt => {
             console.log(
               'dbg tap spatialdiv ',
               'offsetZ:',
               evt.offsetZ,
-
               ' offsetX:',
               evt.offsetX,
               ' offsetY:',
@@ -41,7 +49,7 @@ export default function BasicTransform() {
             )
           }}
         />
-        <div>tail end</div>
+        <div className="text-gray-500 text-sm">tail end</div>
       </div>
     </div>
   )

--- a/apps/test-server/src/pages/basic-transform/index.tsx
+++ b/apps/test-server/src/pages/basic-transform/index.tsx
@@ -30,6 +30,7 @@ export default function BasicTransform() {
           style={style}
           className="rounded-lg shadow-xl basicTransform"
           ref={ref}
+          data-testid="basic-transform-spatial-h1"
           data-name="basic-transform-h1"
           onSpatialTap={evt => {
             console.log(

--- a/docs/webspatial-quirks.md
+++ b/docs/webspatial-quirks.md
@@ -23,3 +23,36 @@ Clicks often originate from a nested element inside an anchor, for example:
 ```
 
 In this case the `event.target` is the `<img>`, not the `<a>`. The polyfill therefore uses the anchor found during event bubbling rather than relying on `event.target` being the anchor itself.
+
+## SpatialDiv / `enable-xr` and CSS
+
+A `<div enable-xr>` (SpatialDiv) is **not** a single DOM node for styling purposes. The SDK keeps a **standard host** in your page tree (`ref.current`) and a separate off-screen **probe** that feeds `transform` / `visibility` into the spatial platform. The visible UI is rendered in a portal; 3D transforms come from the probe's computed style, not from painting CSS transforms on the portal surface.
+
+### Tag selectors (e.g. `h1 { transform: … }`)
+
+**Symptom:** Stylesheets that target an HTML tag work on a plain element but seem ignored in spatial mode (no rotation / depth).
+
+**Root cause (historical):** The probe was always a `<div>`, so rules like `h1 { transform: … }` never applied to the node `getComputedStyle` reads.
+
+**Current behavior:** The probe uses the **same intrinsic tag** as the host when you write `<h1 enable-xr>`, `<section enable-xr>`, etc. Tag selectors should work in that case.
+
+**Still broken or unreliable:**
+
+- Selectors that depend on **page ancestors** (`.sidebar h1`, `#app > h1`) — the probe sits under a hidden parser container, not your layout tree.
+- Wrapping a **custom React component** with `enable-xr` — the probe falls back to `div`; use a **class** or **inline `style`** instead of a tag selector on the component type.
+
+### What to use instead
+
+| Approach | Works for spatial transform |
+| --- | --- |
+| Class selector (`.panel { transform: … }`) | Yes — `className` is mirrored host → probe |
+| Inline `style={{ transform: … }}` | Yes — applied to the probe |
+| `ref.current.style.transform = '…'` | Yes — forwarded to the probe |
+| Tag selector on matching intrinsic (`h1 {}` with `<h1 enable-xr>`) | Yes (after probe tag mirror) |
+| Ancestor + tag (`.page h1 {}`) | Often **no** |
+
+### Dev workflow note
+
+Changing only a CSS file may not update the spatial slab until the host document reloads or the SDK re-samples the probe (see `useSpatialTransformVisibility` — head `childList` changes and `domUpdated` events). The test-server uses esbuild + LiveReload (full page refresh), not Vite-style CSS HMR. Spatial windows on a headset/simulator may need a manual refresh separately from your desktop browser tab.
+
+Maintainer details: `packages/react/src/spatialized-container/ARCHITECTURE.md`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,3 +22,7 @@ When using nested `SpatialDiv` (`enable-xr`) with `onSpatialContentReady`, callb
 - In non-WebSpatial fallback (plain web DOM), callback ordering between parent and child is not a guaranteed contract and should be treated as unspecified.
 
 Recommended practice: initialize imperative renderers from each container's own `ctx.host` and avoid coupling setup logic to parent/child callback sequence in fallback web mode.
+
+## SpatialDiv CSS and transforms
+
+Spatial transforms are sampled from an off-screen **probe** DOM node, not from the visible portal surface. Tag/class selectors, probe vs. host split, and workarounds are documented in [WebSpatial Quirks — SpatialDiv / `enable-xr` and CSS](../../docs/webspatial-quirks.md). Maintainer architecture notes live in [`src/spatialized-container/ARCHITECTURE.md`](src/spatialized-container/ARCHITECTURE.md).

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1095,14 +1095,15 @@ describe('TransformVisibilityTaskContainer', () => {
     ) as HTMLDivElement
     expect(host).toBeTruthy()
 
-    const div = host.querySelector('div') as HTMLDivElement
-    expect(div).toBeTruthy()
-    expect(div.getAttribute(SpatialID)).toBe('tv1')
-    expect(div.className).toBe('c')
-    expect(div.style.left).toBe('-10000px')
-    expect(div.style.top).toBe('-10000px')
-    expect(div.style.opacity).toBe('0')
-    expect(div.style.pointerEvents).toBe('none')
+    const probe = host.querySelector(
+      `div[${SpatialID}="tv1"]`,
+    ) as HTMLDivElement
+    expect(probe).toBeTruthy()
+    expect(probe.className).toBe('c')
+    expect(probe.style.left).toBe('-10000px')
+    expect(probe.style.top).toBe('-10000px')
+    expect(probe.style.opacity).toBe('0')
+    expect(probe.style.pointerEvents).toBe('none')
 
     r.unmount()
     host.remove()

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -23,7 +23,7 @@ flowchart LR
     end
 
     subgraph Hidden["off-screen / portal"]
-        Probe["<b>Probe</b><br/>portal'd into<br/>cssParserDivContainer<br/>(not in host's tree)"]
+        Probe["<b>Probe</b><br/>same intrinsic tag as host<br/>(class mirrored)<br/>portal'd into cssParserDivContainer"]
     end
 
     Watcher["useSpatial-<br/>TransformVisibility"]
@@ -46,6 +46,9 @@ flowchart LR
 | `ref.current` | **Yes** — exposed to user code | No |
 | `style.transform` / `visibility` | Written via `setAttribute` (data-attr toggle), never inline | Holds the **user's** spatial values inline |
 | Class | `xr-spatial-default` + user classes; mirrored to probe | Mirrored from host (class only, not data-\*) |
+| Element tag | User's intrinsic (`h1`, `div`, `section`, …) | Same intrinsic when `component` is a string; **`div` fallback** for custom React component types (`resolveProbeIntrinsicTag`) |
+
+`TransformVisibilityTaskContainer` receives `component` from `SpatializedContainer` so tag selectors in stylesheets (e.g. `h1 { transform: … }`) can reach the probe via `getComputedStyle`. Only **`class`** is mirrored from host → probe; `data-xr-*` stays host-only (I4).
 
 ## What `ref.current` is
 
@@ -195,6 +198,18 @@ This is a niche scenario (it requires React + WebSpatial inside an iframe, not j
 
 **Workaround in the meantime:** call `injectSpatialDefaultStyle()` once from inside the iframe's own realm (e.g. an entry script that runs there). Cross-origin iframes are out of scope — the SDK cannot reach across origins anyway.
 
+### Stylesheet selectors vs. the probe ([#1263](https://github.com/webspatial/webspatial-sdk/issues/1263))
+
+The probe lives under `cssParserDivContainer` in `<body>`, **not** under the user's page subtree. Therefore:
+
+- **Tag** and **class** selectors that do not depend on page ancestors usually work on the probe (tag matching requires the probe to use the same intrinsic element as the host — see table above).
+- **Ancestor** selectors tied to the page tree (e.g. `.page h1`, `.layout > h1`) may **not** match the probe even when they match the host.
+- **Inherited** properties can differ between host and probe because their ancestor chains differ.
+
+**Workarounds:** prefer class selectors (`.mySpatialPanel`), inline `style` on the element, or `ref.current.style.transform = …` (forwarded to the probe via the style proxy). For custom React components wrapped with `enable-xr`, the probe stays `div` — use class or inline style, not tag selectors on the wrapper's display name.
+
+End-user summary: [`docs/webspatial-quirks.md`](../../../../docs/webspatial-quirks.md) — *SpatialDiv / `enable-xr` and CSS*.
+
 ## Test coverage map
 
 Each invariant has at least one regression test pinned in this directory:
@@ -214,6 +229,8 @@ Each invariant has at least one regression test pinned in this directory:
 | CSS rule is class-scoped, not global (I2) | `coverage-boost.test.ts` — *"injectSpatialDefaultStyle is idempotent and emits class-scoped data-xr-host rules"* |
 | Stylesheet injected per host root incl. shadow roots (I7) | `useDomProxy.coverage.test.ts` — *"injects spatial default stylesheet into the host shadow root"* |
 | Stylesheet injection is idempotent per root (I7) | `coverage-boost.test.ts` — same as above (asserts `length === 1` after three calls) |
+| Probe mirrors host intrinsic tag; tag-selector CSS on probe | `TransformVisibilityTaskContainer.test.tsx` — *"portals an h1 probe"*, *"applies tag selectors from document stylesheets"* |
+| Non-intrinsic `component` → `div` probe | `TransformVisibilityTaskContainer.test.tsx` — `resolveProbeIntrinsicTag` |
 
 ## Quick reference for new contributors
 

--- a/packages/react/src/spatialized-container/SpatializedContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedContainer.tsx
@@ -252,6 +252,7 @@ export function SpatializedContainerBase<T extends SpatializedElementRef>(
           <TransformVisibilityTaskContainer
             ref={transformVisibilityTaskContainerCallback}
             {...spatialIdProps}
+            component={props.component}
             className={probeClassName}
             style={props.style}
           />
@@ -325,6 +326,7 @@ export function SpatializedContainerBase<T extends SpatializedElementRef>(
           <TransformVisibilityTaskContainer
             ref={transformVisibilityTaskContainerCallback}
             {...spatialIdProps}
+            component={props.component}
             className={probeClassName}
             style={props.style}
           />

--- a/packages/react/src/spatialized-container/TransformVisibilityTaskContainer.test.tsx
+++ b/packages/react/src/spatialized-container/TransformVisibilityTaskContainer.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { SpatializedContainerContext } from './context/SpatializedContainerContext'
+import { SpatialID } from './SpatialID'
+import {
+  TransformVisibilityTaskContainer,
+  initCSSParserDivContainer,
+  resolveProbeIntrinsicTag,
+} from './TransformVisibilityTaskContainer'
+
+describe('resolveProbeIntrinsicTag', () => {
+  it('returns the intrinsic tag string when component is a string', () => {
+    expect(resolveProbeIntrinsicTag('h1')).toBe('h1')
+    expect(resolveProbeIntrinsicTag('section')).toBe('section')
+  })
+
+  it('falls back to div for function or exotic component types', () => {
+    function Custom() {
+      return null
+    }
+    expect(resolveProbeIntrinsicTag(Custom)).toBe('div')
+    expect(resolveProbeIntrinsicTag(undefined)).toBe('div')
+  })
+})
+
+describe('TransformVisibilityTaskContainer probe tag', () => {
+  let originalMutationObserver: typeof MutationObserver
+
+  beforeEach(() => {
+    originalMutationObserver = globalThis.MutationObserver
+    globalThis.MutationObserver = class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+      constructor(public callback: (mutations: unknown[]) => void) {}
+    } as unknown as typeof MutationObserver
+    initCSSParserDivContainer()
+  })
+
+  afterEach(() => {
+    globalThis.MutationObserver = originalMutationObserver
+    document
+      .querySelectorAll('[data-id="css-parser-div-container"]')
+      .forEach(el => el.remove())
+  })
+
+  function renderProbe(
+    props: React.ComponentProps<typeof TransformVisibilityTaskContainer>,
+  ) {
+    const updateSpatialTransformVisibility = vi.fn()
+    const spatializedContainerObject = {
+      updateSpatialTransformVisibility,
+    }
+    return render(
+      <SpatializedContainerContext.Provider
+        value={spatializedContainerObject as never}
+      >
+        <TransformVisibilityTaskContainer {...props} />
+      </SpatializedContainerContext.Provider>,
+    )
+  }
+
+  it('portals a div probe by default', () => {
+    renderProbe({
+      [SpatialID]: 'tv-div',
+      className: 'c',
+    } as never)
+
+    const parserHost = document.querySelector(
+      '[data-id="css-parser-div-container"]',
+    )!
+    const probe = parserHost.querySelector(`[${SpatialID}="tv-div"]`)
+    expect(probe?.tagName).toBe('DIV')
+  })
+
+  it('portals an h1 probe when component is h1', () => {
+    renderProbe({
+      [SpatialID]: 'tv-h1',
+      component: 'h1',
+      className: 'basicTransform',
+    } as never)
+
+    const parserHost = document.querySelector(
+      '[data-id="css-parser-div-container"]',
+    )!
+    const probe = parserHost.querySelector(
+      `h1[${SpatialID}="tv-h1"]`,
+    ) as HTMLHeadingElement
+    expect(probe).toBeTruthy()
+    expect(probe.className).toBe('basicTransform')
+  })
+
+  it('applies tag selectors from document stylesheets to the probe', () => {
+    const style = document.createElement('style')
+    style.textContent = `
+      h1.basicTransform {
+        transform: translateZ(120px) rotateZ(30deg);
+      }
+    `
+    document.head.appendChild(style)
+
+    renderProbe({
+      [SpatialID]: 'tv-h1-css',
+      component: 'h1',
+      className: 'basicTransform',
+    } as never)
+
+    const probe = document.querySelector(
+      `h1[${SpatialID}="tv-h1-css"]`,
+    ) as HTMLHeadingElement
+    const computed = getComputedStyle(probe)
+    expect(computed.transform).not.toBe('none')
+    expect(computed.transform).toContain('rotateZ')
+    expect(computed.transform).toContain('translateZ')
+
+    style.remove()
+  })
+})

--- a/packages/react/src/spatialized-container/TransformVisibilityTaskContainer.tsx
+++ b/packages/react/src/spatialized-container/TransformVisibilityTaskContainer.tsx
@@ -1,6 +1,8 @@
 import {
+  createElement,
   forwardRef,
   type CSSProperties,
+  type ElementType,
   type ForwardedRef,
   useCallback,
   useRef,
@@ -48,7 +50,14 @@ function useInternalRef(ref: ForwardedRef<HTMLElement | null>) {
 interface TransformVisibilityTaskContainerProps {
   className?: string
   style?: CSSProperties
+  /** Mirrors the spatial host intrinsic tag so tag selectors (e.g. `h1 {}`) apply to the probe. Non-string types fall back to `div`. */
+  component?: ElementType
   [SpatialID]: string
+}
+
+/** Probe must be a real HTMLElement for getComputedStyle; custom components use `div`. */
+export function resolveProbeIntrinsicTag(component?: ElementType): string {
+  return typeof component === 'string' ? component : 'div'
 }
 
 // using css layout engine to calculate SpatializedContainer transform and visibility
@@ -56,7 +65,8 @@ export function TransformVisibilityTaskContainerBase(
   props: TransformVisibilityTaskContainerProps,
   ref: ForwardedRef<HTMLElement | null>,
 ) {
-  const { style: inStyle, ...restProps } = props
+  const { style: inStyle, component, ...restProps } = props
+  const ProbeTag = resolveProbeIntrinsicTag(component)
   const extraStyle: CSSProperties = {
     // when width/height equal to zero, transform: translateX(-50%) won't work
     // to make sure the element is not visible, we set left/top to a very large negative value
@@ -83,7 +93,11 @@ export function TransformVisibilityTaskContainerBase(
   }
 
   return createPortal(
-    <div ref={refInternalCallback} style={style} {...restProps} />,
+    createElement(ProbeTag, {
+      ref: refInternalCallback,
+      style,
+      ...restProps,
+    }),
     cssParserDivContainer,
   )
 }

--- a/tests/autoTest/README.md
+++ b/tests/autoTest/README.md
@@ -118,6 +118,7 @@ The test suite verifies:
 4. Parsing and handling in WebspatialProtocolHandler
 5. Creation and management of Spatialized2DElement
 6. Full flow from protocol invocation to element creation
+7. SpatialDiv transform probe mirrors host intrinsic tag (`basicTransformProbeTag.test.ts` — `h1` + stylesheet `h1.basicTransformProbe { transform }`)
 
 ## License
 

--- a/tests/autoTest/src/testApp/App.tsx
+++ b/tests/autoTest/src/testApp/App.tsx
@@ -254,6 +254,15 @@ function App() {
         <h2 className="text-xl font-bold mb-2">Transform Test</h2>
         <p className="text-sm opacity-80">Test transform operations</p>
       </Link>
+      <Link
+        to="/basicTransformProbeTagTest"
+        className="p-6 bg-blue-500 bg-opacity-25 rounded-xl text-black hover:bg-opacity-40 transition-all"
+      >
+        <h2 className="text-xl font-bold mb-2">Probe tag (h1 CSS)</h2>
+        <p className="text-sm opacity-80">
+          Stylesheet tag selector on h1 enable-xr probe
+        </p>
+      </Link>
 
       {/* Spatial Elements Container */}
       <div

--- a/tests/autoTest/src/testApp/basicTransformProbeTagTest/basicTransformProbeTagTest.css
+++ b/tests/autoTest/src/testApp/basicTransformProbeTagTest/basicTransformProbeTagTest.css
@@ -1,0 +1,4 @@
+/* Tag + class: probe must be <h1> (not <div>) for spatial transform sampling. */
+h1.basicTransformProbe {
+  transform: translateZ(120px) rotateZ(30deg);
+}

--- a/tests/autoTest/src/testApp/basicTransformProbeTagTest/basicTransformProbeTagTest.tsx
+++ b/tests/autoTest/src/testApp/basicTransformProbeTagTest/basicTransformProbeTagTest.tsx
@@ -1,0 +1,25 @@
+import { enableDebugTool } from '@webspatial/react-sdk'
+import React from 'react'
+import './basicTransformProbeTagTest.css'
+
+enableDebugTool()
+
+export default function BasicTransformProbeTagTest() {
+  const style: React.CSSProperties = {
+    width: '200px',
+    height: '200px',
+    backgroundColor: 'green',
+  }
+
+  return (
+    <div className="p-8 text-white">
+      <h1 className="text-xl mb-4">Basic transform probe tag</h1>
+      <h1
+        enable-xr
+        data-testid="basic-transform-spatial-h1"
+        className="basicTransformProbe rounded-lg"
+        style={style}
+      />
+    </div>
+  )
+}

--- a/tests/autoTest/src/testApp/main.tsx
+++ b/tests/autoTest/src/testApp/main.tsx
@@ -8,6 +8,7 @@ import './index.css'
 import MaterialApiTest from './materialApiTest/materialapi'
 import CssApiTest from './CssAPITest/cssapi'
 import TransformTest from './transformTest/transformTest'
+import BasicTransformProbeTagTest from './basicTransformProbeTagTest/basicTransformProbeTagTest'
 
 declare const __XR_ENV_BASE__: string
 
@@ -20,6 +21,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Route path="/materialApiTest" element={<MaterialApiTest />} />
         <Route path="/cssApiTest" element={<CssApiTest />} />
         <Route path="/transformTest" element={<TransformTest />} />
+        <Route
+          path="/basicTransformProbeTagTest"
+          element={<BasicTransformProbeTagTest />}
+        />
       </Routes>
     </BrowserRouter>
   </ErrorBoundary>,

--- a/tests/autoTest/tests/basicTransformProbeTag.test.ts
+++ b/tests/autoTest/tests/basicTransformProbeTag.test.ts
@@ -1,0 +1,144 @@
+import { expect } from 'chai'
+import { PuppeteerRunner } from '../src/runtime/puppeteerRunner'
+import { spawn, ChildProcess } from 'child_process'
+import { before, after } from 'mocha'
+import 'source-map-support/register'
+
+const ROUTE = 'http://localhost:5173/basicTransformProbeTagTest'
+const TEST_ID = 'basic-transform-spatial-h1'
+const ROTATE_Z_DEG = 30
+const COS30 = Math.cos((ROTATE_Z_DEG * Math.PI) / 180)
+
+let runner: PuppeteerRunner | null = null
+let server: ChildProcess | null = null
+
+describe('SpatialDiv probe mirrors host intrinsic tag (h1 CSS transform)', function (this: Mocha.Suite) {
+  this.timeout(150000)
+
+  before(async () => {
+    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    server = spawn(npmCmd, ['run', 'devAVP'], {
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+    })
+
+    server.stdout?.on('data', (data: Buffer) => {
+      console.log(`Server stdout: ${data}`)
+    })
+    server.stderr?.on('data', (data: Buffer) => {
+      console.error(`Server stderr: ${data}`)
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 5000))
+
+    runner = new PuppeteerRunner()
+    runner.init({
+      width: 1280,
+      height: 800,
+      headless: true,
+      timeout: 30000,
+      enableXR: true,
+    })
+    await runner.start()
+  })
+
+  after(async () => {
+    if (runner?.close) {
+      await runner.close()
+    }
+    if (server) {
+      if (server.pid) {
+        try {
+          process.kill(-server.pid)
+        } catch {
+          server.kill('SIGTERM')
+        }
+      } else {
+        server.kill('SIGTERM')
+      }
+    }
+  })
+
+  it('applies h1.basicTransformProbe stylesheet transform to the spatial slab', async () => {
+    if (!runner) throw new Error('Puppeteer runner not initialized')
+
+    await runner.navigate(ROUTE, {
+      waitUntil: 'networkidle0',
+      timeout: 30000,
+    })
+
+    await runner.waitForFunction(
+      () => !!document.querySelector(`[data-testid="${TEST_ID}"]`),
+    )
+
+    await runner.waitForFunction(() => {
+      const el = document.querySelector(
+        `[data-testid="${TEST_ID}"]`,
+      ) as HTMLElement | null
+      const fn = (window as any).getSpatialized2DElement
+      return !!el && typeof fn === 'function' && !!fn(el)
+    })
+
+    const probeInfo = await runner.evaluate((testId: string) => {
+      const host = document.querySelector(
+        `[data-testid="${testId}"]`,
+      ) as HTMLElement | null
+      const parser = document.querySelector(
+        '[data-id="css-parser-div-container"]',
+      )
+      const probe = parser?.querySelector('h1') as HTMLElement | null
+      const hostTag = host?.tagName ?? null
+      const probeTag = probe?.tagName ?? null
+      const probeTransform = probe ? getComputedStyle(probe).transform : null
+      const hostSpatialId = host?.getAttribute('data-spatial-id')
+      const probeSpatialId = probe?.getAttribute('data-spatial-id')
+      return {
+        hostTag,
+        probeTag,
+        probeTransform,
+        hostSpatialId,
+        probeSpatialId,
+        probeClass: probe?.className ?? null,
+      }
+    }, TEST_ID)
+
+    expect(probeInfo.hostTag).to.equal('H1')
+    expect(probeInfo.probeTag).to.equal('H1')
+    expect(probeInfo.probeTransform).to.be.a('string').and.not.equal('none')
+    expect(probeInfo.probeClass).to.contain('basicTransformProbe')
+    expect(probeInfo.hostSpatialId).to.be.a('string').and.not.empty
+    expect(probeInfo.probeSpatialId).to.equal(probeInfo.hostSpatialId)
+
+    const spatialId = await runner.evaluate((testId: string) => {
+      const el = document.querySelector(
+        `[data-testid="${testId}"]`,
+      ) as HTMLElement | null
+      if (!el) return null
+      const spatializedElement = (window as any).getSpatialized2DElement?.(el)
+      return spatializedElement ? spatializedElement.id : null
+    }, TEST_ID)
+    expect(spatialId).to.be.not.null
+
+    let matrix: number[] | null = null
+    for (let i = 0; i < 50; i++) {
+      const spatialObj = runner
+        .getCurrentScene()
+        ?.findSpatialObject(spatialId as string) as {
+        transform?: { matrix?: number[] }
+      } | null
+      matrix = (spatialObj?.transform?.matrix as number[]) ?? null
+      const ok =
+        Array.isArray(matrix) &&
+        matrix.length === 16 &&
+        Math.abs(Math.abs(matrix[0]) - COS30) < 0.05 &&
+        Math.abs(Math.abs(matrix[5]) - COS30) < 0.05
+      if (ok) break
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+
+    expect(matrix).to.be.an('array').with.lengthOf(16)
+    expect(Math.abs((matrix as number[])[0])).to.be.closeTo(COS30, 0.05)
+    expect(Math.abs((matrix as number[])[5])).to.be.closeTo(COS30, 0.05)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes [#1263](https://github.com/webspatial/webspatial-sdk/issues/1263)

### React SDK (`@webspatial/react-sdk`)

- Pass spatial host `component` into `TransformVisibilityTaskContainer` so the transform/visibility **probe** uses the same intrinsic HTML tag as the host (`h1 enable-xr` → probe `h1`, not always `div`).
- Add `resolveProbeIntrinsicTag()` — non-string `component` types (custom React wrappers) fall back to a `div` probe.
- Unit tests: `TransformVisibilityTaskContainer.test.tsx` (tag selector CSS on `h1` probe).

### Documentation

- `packages/react/src/spatialized-container/ARCHITECTURE.md` — probe tag mirror, selector limitations, test map.
- `docs/webspatial-quirks.md` — **SpatialDiv / `enable-xr` and CSS** (app-developer guide).
- `packages/react/README.md` — link to quirks + architecture.

### Demos & automation

- **test-server:** `/#/basic-transform` — green `h1 enable-xr` styled via `basictransform.css` (`h1.basicTransform`).
- **autoTest:** `tests/basicTransformProbeTag.test.ts` — Puppeteer asserts probe is `H1` and `rotateZ(30deg)` from CSS reaches the spatial matrix.

## Why

Spatial transforms are read from the probe with `getComputedStyle`. While the probe was hard-coded to `<div>`, tag selectors never applied and the 3D slab stayed at an identity transform.

## Known limitations

- Ancestor selectors (e.g. `.page h1`) may not match — probe is under `css-parser-div-container`, not the page DOM tree.
- Custom component + `enable-xr` → `div` probe; use class or inline `style`.

## Test plan

- [x] `pnpm --filter @webspatial/react-sdk test` — `TransformVisibilityTaskContainer.test.tsx`
- [x] `pnpm run test:auto:setup-local` && `cd tests/autoTest && pnpm run test` — `basicTransformProbeTag.test.ts`
- [ ] CI on PR
- [x] Manual: `npm run dev` → `http://localhost:5173/#/basic-transform` in spatial runtime