### PR TITLE
[codex] Fix portal head style sync for CSS-in-JS

### DIFF
--- a/.changeset/fix-head-style-cssom-sync.md
+++ b/.changeset/fix-head-style-cssom-sync.md
@@ -2,4 +2,4 @@
 '@webspatial/react-sdk': patch
 ---
 
-Fix portal head style sync for CSS-in-JS (e.g. styled-components). Serialize `style.sheet.cssRules` when syncing parent styles into portal windows, update portal `<style>` nodes in place, incrementally mirror parent rules via `insertRule`/`deleteRule`, observe parent head style text changes even for portal callers that opt out of subtree observation, and re-sync before portal re-rendering after 2D-frame updates.
+Fix portal head style sync for CSS-in-JS (e.g. styled-components). Serialize `style.sheet.cssRules` when syncing parent styles into portal windows, update portal `<style>` nodes in place, incrementally mirror parent rules via `insertRule`/`deleteRule`, observe parent head style text changes even for portal callers that opt out of subtree observation, re-sync before portal re-rendering after 2D-frame updates, and coalesce active portal syncs through a singleton parent-head registry that captures one parent head snapshot per broadcast wave.

--- a/.changeset/fix-head-style-cssom-sync.md
+++ b/.changeset/fix-head-style-cssom-sync.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Fix portal head style sync for CSS-in-JS (e.g. styled-components). Serialize `style.sheet.cssRules` when syncing parent styles into portal windows, update portal `<style>` nodes in place, incrementally mirror parent rules via `insertRule`/`deleteRule`, observe parent head style text changes even for portal callers that opt out of subtree observation, and re-sync before portal re-rendering after 2D-frame updates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ From repo root:
 
 - Root scripts: `package.json`.
 - Portal / 2D sync / HMR invariants (when editing `packages/react/src/spatialized-container/`): `packages/react/src/spatialized-container/ARCHITECTURE.md` — section **Portal lifecycle and local dev (HMR)**; tests: `useSpatializedElement.hmr.test.ts`, `useSpatialContentReady.test.ts`, `SpatializedStatic3DElementContainer.test.tsx`.
+- Portal head sync / CSS-in-JS (when editing `windowStyleSync.ts`, `useSyncHeadStyles.ts`, `useSync2DFrame.ts`): `packages/react/src/spatialized-container/ARCHITECTURE.md` — section **Portal head sync (CSS-in-JS)**; tests: `windowStyleSync.test.ts`, `useSyncHeadStyles.test.tsx`; demo: `#/styledComponentsSpatialTest`.
 - Dev server docs: `apps/test-server/README.md`.
 - E2E harness docs: `tests/ci-test/README.md`.
 - Browser auto test docs: `tests/autoTest/README.md`.

--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -25,6 +25,7 @@ import RealitySpatialDiv from './src/pages/reality/spatialDivDynamic'
 import BasicTransform from './src/pages/basic-transform/index'
 import ModelTest from './src/pages/model-test/index'
 import SpatialStyleTest from './src/pages/spatialStyleTest/index'
+import StyledComponentsSpatialTest from './src/pages/styledComponentsSpatialTest/index'
 import CanvasTest from './src/pages/canvas-test/index'
 import JSAPITest from './src/pages/jsapi-test/index'
 import SpatialDivRefreshValidation from './src/pages/jsapi-refresh-validation/index'
@@ -123,6 +124,10 @@ function App() {
                 <Route
                   path="/spatialStyleTest"
                   element={<SpatialStyleTest />}
+                />
+                <Route
+                  path="/styledComponentsSpatialTest"
+                  element={<StyledComponentsSpatialTest />}
                 />
                 <Route path="/canvas-test" element={<CanvasTest />} />
                 <Route path="/jsapi-test" element={<JSAPITest />} />

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -41,6 +41,10 @@ export const routes = [
   { path: '/basic-transform', label: 'Basic Transform' },
   { path: '/model-test', label: 'Model Test' },
   { path: '/spatialStyleTest', label: 'Spatial Style' },
+  {
+    path: '/styledComponentsSpatialTest',
+    label: 'Styled-components Spatial',
+  },
   { path: '/canvas-test', label: 'Canvas Test' },
   { path: '/jsapi-test', label: 'JS API Test' },
   {

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/StyledNestedSpatialSection.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/StyledNestedSpatialSection.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import {
+  CompareLabel,
+  ControlRow,
+  OpacityLabel,
+  OpacityRange,
+  OpacityValue,
+  PageSection,
+  PlainSpatialShell,
+  SectionHeading,
+  SectionNote,
+  StyledSpatialBox,
+  StyledSpatialBoxCssVar,
+  ToggleButton,
+} from './shared'
+
+declare global {
+  interface Window {
+    __setStyledComponentsNestedOpacity?: (value: number) => number
+    __getStyledComponentsNestedOpacity?: () => number
+    __probeStyledComponentsNestedHeadSync?: () => StyledComponentsNestedHeadSyncProbe
+  }
+}
+
+interface StyledComponentsNestedHeadSyncProbe {
+  opacity: number
+  targets: Array<{
+    name: string
+    hostClassName: string
+    portalClassName: string
+    portalOpacity: string | null
+    syncedStyleCount: number
+    portalHasRuleForClass: boolean
+  }>
+}
+
+const NESTED_TARGETS = [
+  'Nested styled inner A — $opacity',
+  'Nested styled inner B — CSS var',
+]
+
+function findHostElement(name: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLDivElement>('[data-name]'),
+  ).find(element => element.getAttribute('data-name') === name)
+}
+
+function classListFrom(className: string) {
+  return className.split(/\s+/).filter(Boolean)
+}
+
+function getSyncedRuleText(documentToRead: Document) {
+  return Array.from(
+    documentToRead.querySelectorAll<HTMLStyleElement>(
+      'style[data-webspatial-sync="1"]',
+    ),
+  )
+    .flatMap(style => {
+      const sheet = style.sheet
+      if (!sheet) return [style.textContent ?? '']
+      try {
+        return Array.from(sheet.cssRules).map(rule => rule.cssText)
+      } catch {
+        return [style.textContent ?? '']
+      }
+    })
+    .join('\n')
+}
+
+function hasRuleForAnyClass(ruleText: string, className: string) {
+  return classListFrom(className).some(name => {
+    const escaped = window.CSS?.escape?.(name) ?? name
+    return ruleText.includes(`.${escaped}`) || ruleText.includes(`.${name}`)
+  })
+}
+
+export function StyledNestedSpatialSection() {
+  const [hidden, setHidden] = useState(false)
+  const [opacity, setOpacity] = useState(1)
+  const opacityRef = useRef(opacity)
+
+  opacityRef.current = opacity
+
+  useEffect(() => {
+    window.__setStyledComponentsNestedOpacity = value => {
+      const next = Math.min(1, Math.max(0, value > 1 ? value / 100 : value))
+      setOpacity(next)
+      return next
+    }
+    window.__getStyledComponentsNestedOpacity = () => opacityRef.current
+    window.__probeStyledComponentsNestedHeadSync = () => {
+      return {
+        opacity: opacityRef.current,
+        targets: NESTED_TARGETS.map(name => {
+          const host = findHostElement(name)
+          const portalWindow =
+            host && window.getSpatialized2DElement?.(host)?.windowProxy
+          const portalDocument = portalWindow?.document
+          const portalElement = portalDocument?.body
+            .firstElementChild as HTMLElement | null
+          const ruleText = portalDocument
+            ? getSyncedRuleText(portalDocument)
+            : ''
+          const portalClassName = portalElement?.className ?? ''
+
+          return {
+            name,
+            hostClassName: host?.className ?? '',
+            portalClassName,
+            portalOpacity: portalElement
+              ? portalWindow!.getComputedStyle(portalElement).opacity
+              : null,
+            syncedStyleCount:
+              portalDocument?.querySelectorAll(
+                'style[data-webspatial-sync="1"]',
+              ).length ?? 0,
+            portalHasRuleForClass: hasRuleForAnyClass(
+              ruleText,
+              portalClassName,
+            ),
+          }
+        }),
+      }
+    }
+    console.log('[test-server-route] mounted StyledNestedSpatialSection')
+    return () => {
+      delete window.__setStyledComponentsNestedOpacity
+      delete window.__getStyledComponentsNestedOpacity
+      delete window.__probeStyledComponentsNestedHeadSync
+    }
+  }, [])
+
+  return (
+    <PageSection>
+      <SectionHeading>4. Nested SpatialDiv styled host</SectionHeading>
+      <SectionNote>
+        Expected: the outer SpatialDiv owns one portal webview, and each nested
+        styled host owns another child webview. Opacity changes on A should keep
+        syncing styled-components rules into the nested child head.
+      </SectionNote>
+      <ControlRow>
+        <ToggleButton type="button" onClick={() => setHidden(v => !v)}>
+          {hidden ? 'Show' : 'Hide'}
+        </ToggleButton>
+        <OpacityLabel>
+          Opacity
+          <OpacityRange
+            min={0}
+            max={100}
+            step={1}
+            value={Math.round(opacity * 100)}
+            onChange={e => setOpacity(Number(e.target.value) / 100)}
+          />
+          <OpacityValue>{opacity.toFixed(2)}</OpacityValue>
+        </OpacityLabel>
+      </ControlRow>
+      <PlainSpatialShell
+        enable-xr
+        data-name="Nested styled outer shell"
+        style={{ '--xr-back': 100 } as CSSProperties}
+      >
+        <CompareLabel>A — nested SC prop ($opacity)</CompareLabel>
+        <StyledSpatialBox
+          enable-xr
+          data-name="Nested styled inner A — $opacity"
+          $hidden={hidden}
+          $opacity={opacity}
+        >
+          Nested inner A — opacity from styled prop
+        </StyledSpatialBox>
+        <CompareLabel>B — nested CSS variable (--spatial-opacity)</CompareLabel>
+        <StyledSpatialBoxCssVar
+          enable-xr
+          data-name="Nested styled inner B — CSS var"
+          $hidden={hidden}
+          style={{ '--spatial-opacity': opacity } as CSSProperties}
+        >
+          Nested inner B — opacity from CSS variable
+        </StyledSpatialBoxCssVar>
+      </PlainSpatialShell>
+    </PageSection>
+  )
+}

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialChildSection.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialChildSection.tsx
@@ -17,6 +17,9 @@ import {
 export function StyledSpatialChildSection() {
   const [hidden, setHidden] = useState(false)
   const [opacity, setOpacity] = useState(1)
+  const childVisibilityStyle: CSSProperties = {
+    visibility: hidden ? 'hidden' : 'inherit',
+  }
 
   return (
     <PageSection>
@@ -50,13 +53,22 @@ export function StyledSpatialChildSection() {
         style={{ '--xr-back': 100 } as CSSProperties}
       >
         <CompareLabel>A — SC prop ($opacity)</CompareLabel>
-        <StyledSpatialBox $hidden={hidden} $opacity={opacity}>
+        <StyledSpatialBox
+          $hidden={hidden}
+          $opacity={opacity}
+          style={childVisibilityStyle}
+        >
           Child A — opacity from styled prop
         </StyledSpatialBox>
         <CompareLabel>B — CSS variable (--spatial-opacity)</CompareLabel>
         <StyledSpatialBoxCssVar
           $hidden={hidden}
-          style={{ '--spatial-opacity': opacity } as CSSProperties}
+          style={
+            {
+              ...childVisibilityStyle,
+              '--spatial-opacity': opacity,
+            } as CSSProperties
+          }
         >
           Child B — opacity from CSS variable
         </StyledSpatialBoxCssVar>

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialChildSection.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialChildSection.tsx
@@ -1,0 +1,66 @@
+import { useState, type CSSProperties } from 'react'
+import {
+  CompareLabel,
+  ControlRow,
+  OpacityLabel,
+  OpacityRange,
+  OpacityValue,
+  PageSection,
+  PlainSpatialShell,
+  SectionHeading,
+  SectionNote,
+  StyledSpatialBox,
+  StyledSpatialBoxCssVar,
+  ToggleButton,
+} from './shared'
+
+export function StyledSpatialChildSection() {
+  const [hidden, setHidden] = useState(false)
+  const [opacity, setOpacity] = useState(1)
+
+  return (
+    <PageSection>
+      <SectionHeading>
+        2. Styled child inside plain enable-xr shell
+      </SectionHeading>
+      <SectionNote>
+        Expected: visual changes mostly as CSS inside the portal webview only.
+        Same A/B opacity comparison as section 1 (SC prop vs CSS variable).
+        Green border = B. Compare with section 1 on device.
+      </SectionNote>
+      <ControlRow>
+        <ToggleButton type="button" onClick={() => setHidden(v => !v)}>
+          {hidden ? 'Show' : 'Hide'}
+        </ToggleButton>
+        <OpacityLabel>
+          Opacity
+          <OpacityRange
+            min={0}
+            max={100}
+            step={1}
+            value={Math.round(opacity * 100)}
+            onChange={e => setOpacity(Number(e.target.value) / 100)}
+          />
+          <OpacityValue>{opacity.toFixed(2)}</OpacityValue>
+        </OpacityLabel>
+      </ControlRow>
+      <PlainSpatialShell
+        enable-xr
+        data-name="Plain shell (enable-xr)"
+        style={{ '--xr-back': 100 } as CSSProperties}
+      >
+        <CompareLabel>A — SC prop ($opacity)</CompareLabel>
+        <StyledSpatialBox $hidden={hidden} $opacity={opacity}>
+          Child A — opacity from styled prop
+        </StyledSpatialBox>
+        <CompareLabel>B — CSS variable (--spatial-opacity)</CompareLabel>
+        <StyledSpatialBoxCssVar
+          $hidden={hidden}
+          style={{ '--spatial-opacity': opacity } as CSSProperties}
+        >
+          Child B — opacity from CSS variable
+        </StyledSpatialBoxCssVar>
+      </PlainSpatialShell>
+    </PageSection>
+  )
+}

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialHostSection.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/StyledSpatialHostSection.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState, type CSSProperties } from 'react'
+import {
+  CompareLabel,
+  ControlRow,
+  OpacityLabel,
+  OpacityRange,
+  OpacityValue,
+  PageSection,
+  SectionHeading,
+  SectionNote,
+  StyledSpatialBox,
+  StyledSpatialBoxCssVar,
+  ToggleButton,
+} from './shared'
+
+declare global {
+  interface Window {
+    __setStyledComponentsSpatialOpacity?: (value: number) => number
+    __getStyledComponentsSpatialOpacity?: () => number
+    __probeStyledComponentsSpatialHeadSync?: () => StyledComponentsSpatialHeadSyncProbe
+    __runStyledComponentsSpatialOpacitySweep?: (
+      values?: number[],
+    ) => Promise<StyledComponentsSpatialHeadSyncSweep>
+    getSpatialized2DElement?: (element: HTMLDivElement) => {
+      windowProxy?: WindowProxy
+    }
+  }
+}
+
+type ProbeTargetLabel = 'A' | 'B'
+
+interface StyledComponentsSpatialHeadSyncProbeTarget {
+  label: ProbeTargetLabel
+  hostClassName: string
+  portalClassName: string
+  portalOpacity: string | null
+  syncedStyleCount: number
+  portalHasRuleForClass: boolean
+}
+
+interface StyledComponentsSpatialHeadSyncProbe {
+  opacity: number
+  mismatchTargets: ProbeTargetLabel[]
+  targets: StyledComponentsSpatialHeadSyncProbeTarget[]
+}
+
+interface StyledComponentsSpatialHeadSyncSweep {
+  mismatchFrames: number
+  frames: StyledComponentsSpatialHeadSyncProbe[]
+}
+
+const PROBE_TARGETS: Array<{ label: ProbeTargetLabel; name: string }> = [
+  { label: 'A', name: 'Styled host A — $opacity' },
+  { label: 'B', name: 'Styled host B — CSS var' },
+]
+
+function waitForFrames(count: number) {
+  return new Promise<void>(resolve => {
+    const tick = () => {
+      count -= 1
+      if (count <= 0) {
+        resolve()
+        return
+      }
+      window.requestAnimationFrame(tick)
+    }
+    window.requestAnimationFrame(tick)
+  })
+}
+
+function findHostElement(name: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLDivElement>('[data-name]'),
+  ).find(element => element.getAttribute('data-name') === name)
+}
+
+function classListFrom(className: string) {
+  return className.split(/\s+/).filter(Boolean)
+}
+
+function getStyleRuleText(documentToRead: Document) {
+  return Array.from(
+    documentToRead.querySelectorAll<HTMLStyleElement>(
+      'style[data-webspatial-sync="1"]',
+    ),
+  )
+    .flatMap(style => {
+      const sheet = style.sheet
+      if (!sheet) return [style.textContent ?? '']
+      try {
+        return Array.from(sheet.cssRules).map(rule => rule.cssText)
+      } catch {
+        return [style.textContent ?? '']
+      }
+    })
+    .join('\n')
+}
+
+function hasRuleForAnyClass(ruleText: string, className: string) {
+  return classListFrom(className).some(name => {
+    const escaped = window.CSS?.escape?.(name) ?? name
+    return ruleText.includes(`.${escaped}`) || ruleText.includes(`.${name}`)
+  })
+}
+
+export function StyledSpatialHostSection() {
+  const [hidden, setHidden] = useState(false)
+  const [opacity, setOpacity] = useState(1)
+
+  useEffect(() => {
+    window.__setStyledComponentsSpatialOpacity = value => {
+      const next = Math.min(1, Math.max(0, value > 1 ? value / 100 : value))
+      setOpacity(next)
+      return next
+    }
+    window.__getStyledComponentsSpatialOpacity = () => opacity
+    window.__probeStyledComponentsSpatialHeadSync = () => {
+      const targets = PROBE_TARGETS.map(({ label, name }) => {
+        const host = findHostElement(name)
+        const portalWindow =
+          host && window.getSpatialized2DElement?.(host)?.windowProxy
+        const portalDocument = portalWindow?.document
+        const portalElement = portalDocument?.body
+          .firstElementChild as HTMLElement | null
+        const ruleText = portalDocument ? getStyleRuleText(portalDocument) : ''
+        const portalClassName = portalElement?.className ?? ''
+        return {
+          label,
+          hostClassName: host?.className ?? '',
+          portalClassName,
+          portalOpacity: portalElement
+            ? portalWindow!.getComputedStyle(portalElement).opacity
+            : null,
+          syncedStyleCount:
+            portalDocument?.querySelectorAll('style[data-webspatial-sync="1"]')
+              .length ?? 0,
+          portalHasRuleForClass: hasRuleForAnyClass(ruleText, portalClassName),
+        }
+      })
+      return {
+        opacity,
+        mismatchTargets: targets
+          .filter(target => !target.portalHasRuleForClass)
+          .map(target => target.label),
+        targets,
+      }
+    }
+    window.__runStyledComponentsSpatialOpacitySweep = async values => {
+      const frames: StyledComponentsSpatialHeadSyncProbe[] = []
+      for (const value of values ?? [1, 0.1, 0.9, 0.2, 0.8, 0.05, 1]) {
+        window.__setStyledComponentsSpatialOpacity?.(value)
+        await waitForFrames(2)
+        frames.push(window.__probeStyledComponentsSpatialHeadSync!())
+      }
+      return {
+        mismatchFrames: frames.filter(frame => frame.mismatchTargets.length > 0)
+          .length,
+        frames,
+      }
+    }
+    console.log('[test-server-route] mounted StyledSpatialHostSection')
+    return () => {
+      delete window.__setStyledComponentsSpatialOpacity
+      delete window.__getStyledComponentsSpatialOpacity
+      delete window.__probeStyledComponentsSpatialHeadSync
+      delete window.__runStyledComponentsSpatialOpacitySweep
+    }
+  }, [])
+
+  useEffect(() => {
+    window.__getStyledComponentsSpatialOpacity = () => opacity
+  }, [opacity])
+
+  return (
+    <PageSection>
+      <SectionHeading>1. Styled host with enable-xr</SectionHeading>
+      <SectionNote>
+        Expected in spatial runtime: opacity / visibility / transform /
+        --xr-back sync to the native spatial layer (whole panel). Two boxes
+        below share one slider: <strong>A</strong> uses <code>$opacity</code>{' '}
+        (new SC rules per step); <strong>B</strong> uses{' '}
+        <code>--spatial-opacity</code> (stable class, inline var only). If B is
+        smooth and A flickers, churn is likely class/head-sync timing—not native
+        opacity alone.
+      </SectionNote>
+      <ControlRow>
+        <ToggleButton type="button" onClick={() => setHidden(v => !v)}>
+          {hidden ? 'Show' : 'Hide'}
+        </ToggleButton>
+        <OpacityLabel>
+          Opacity
+          <OpacityRange
+            min={0}
+            max={100}
+            step={1}
+            value={Math.round(opacity * 100)}
+            onChange={e => setOpacity(Number(e.target.value) / 100)}
+          />
+          <OpacityValue>{opacity.toFixed(2)}</OpacityValue>
+        </OpacityLabel>
+      </ControlRow>
+      <CompareLabel>A — SC prop ($opacity)</CompareLabel>
+      <StyledSpatialBox
+        enable-xr
+        data-name="Styled host A — $opacity"
+        $hidden={hidden}
+        $opacity={opacity}
+      >
+        Portaled content — opacity from styled prop (head grows per step)
+      </StyledSpatialBox>
+      <CompareLabel>B — CSS variable (--spatial-opacity)</CompareLabel>
+      <StyledSpatialBoxCssVar
+        enable-xr
+        data-name="Styled host B — CSS var"
+        $hidden={hidden}
+        style={{ '--spatial-opacity': opacity } as CSSProperties}
+      >
+        Portaled content — opacity from CSS variable (stable SC class)
+      </StyledSpatialBoxCssVar>
+    </PageSection>
+  )
+}

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/StyledTitleSection.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/StyledTitleSection.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import {
+  PageSection,
+  SectionHeading,
+  SectionNote,
+  ToggleButton,
+} from './shared'
+
+const StyledTitle = styled.h1<{ $primary?: boolean }>`
+  font-size: 1.25em;
+  text-align: center;
+  position: relative;
+  margin: 8px;
+  padding: 12px;
+  color: ${props => (props.$primary ? '#1d4ed8' : '#b91c1c')};
+  --xr-back: ${props => (props.$primary ? 60 : 120)};
+  background: #fff;
+  border-radius: 8px;
+`
+
+export function StyledTitleSection() {
+  const [isPrimary, setIsPrimary] = useState(true)
+
+  return (
+    <PageSection>
+      <SectionHeading>3. Styled title host (color + --xr-back)</SectionHeading>
+      <SectionNote>
+        Tap the title in spatial runtime to toggle primary color and --xr-back
+        on the enable-xr styled host.
+      </SectionNote>
+      <ToggleButton type="button" onClick={() => setIsPrimary(v => !v)}>
+        Toggle primary ({isPrimary ? 'on' : 'off'})
+      </ToggleButton>
+      <StyledTitle
+        enable-xr
+        data-name="Styled title (enable-xr)"
+        $primary={isPrimary}
+        onClick={() => setIsPrimary(v => !v)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            setIsPrimary(v => !v)
+          }
+        }}
+      >
+        Styled spatial title — click to toggle
+      </StyledTitle>
+    </PageSection>
+  )
+}

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/index.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/index.tsx
@@ -1,0 +1,96 @@
+import { enableDebugTool } from '@webspatial/react-sdk'
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { StyledSpatialChildSection } from './StyledSpatialChildSection'
+import { StyledSpatialHostSection } from './StyledSpatialHostSection'
+import { StyledTitleSection } from './StyledTitleSection'
+
+enableDebugTool()
+
+type DemoTab = 'host' | 'child' | 'title'
+
+const DEMO_TABS: { id: DemoTab; label: string }[] = [
+  { id: 'host', label: 'Styled host' },
+  { id: 'child', label: 'Styled child' },
+  { id: 'title', label: 'Styled title' },
+]
+
+export default function StyledComponentsSpatialTest() {
+  const [tab, setTab] = useState<DemoTab>('host')
+
+  useEffect(() => {
+    console.log('[test-server-route] mounted StyledComponentsSpatialTest')
+  }, [])
+
+  return (
+    <div className="p-10 text-white min-h-full max-w-3xl">
+      <h1 className="text-2xl mb-2">Styled-components × SpatialDiv</h1>
+      <p className="text-sm text-gray-400 mb-4 leading-relaxed">
+        Manual matrix for styled-components with WebSpatial. Use visionOS or
+        PICO spatial runtime; switch tabs to preview one scenario at a time.
+        Compare <strong className="text-gray-300">Styled host</strong> vs{' '}
+        <strong className="text-gray-300">Styled child</strong> on device. Host
+        and child tabs each show <strong className="text-gray-300">A</strong>{' '}
+        (SC <code className="text-gray-400">$opacity</code>) vs{' '}
+        <strong className="text-gray-300">B</strong> (CSS variable) under one
+        slider to isolate head/class churn. Related:{' '}
+        <Link className="text-blue-400 underline" to="/spatialStyleTest">
+          Spatial Style (general)
+        </Link>
+        ,{' '}
+        <Link className="text-blue-400 underline" to="/head-style-sync">
+          Head style sync
+        </Link>
+        .
+      </p>
+
+      <div
+        role="tablist"
+        aria-label="Styled-components spatial demos"
+        className="mb-6 flex flex-wrap gap-0 border-b border-gray-700"
+      >
+        {DEMO_TABS.map(t => {
+          const selected = tab === t.id
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              id={`styled-spatial-tab-${t.id}`}
+              aria-selected={selected}
+              aria-controls={`styled-spatial-panel-${t.id}`}
+              onClick={() => setTab(t.id)}
+              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 ${
+                selected
+                  ? 'border-sky-400 text-white'
+                  : 'border-transparent text-gray-500 hover:border-gray-600 hover:text-gray-300'
+              }`}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="w-full">
+        {DEMO_TABS.map(t => (
+          <div
+            key={t.id}
+            role="tabpanel"
+            id={`styled-spatial-panel-${t.id}`}
+            aria-labelledby={`styled-spatial-tab-${t.id}`}
+            hidden={tab !== t.id}
+          >
+            {tab === t.id && (
+              <>
+                {t.id === 'host' && <StyledSpatialHostSection />}
+                {t.id === 'child' && <StyledSpatialChildSection />}
+                {t.id === 'title' && <StyledTitleSection />}
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/index.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/index.tsx
@@ -1,18 +1,20 @@
 import { enableDebugTool } from '@webspatial/react-sdk'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { StyledNestedSpatialSection } from './StyledNestedSpatialSection'
 import { StyledSpatialChildSection } from './StyledSpatialChildSection'
 import { StyledSpatialHostSection } from './StyledSpatialHostSection'
 import { StyledTitleSection } from './StyledTitleSection'
 
 enableDebugTool()
 
-type DemoTab = 'host' | 'child' | 'title'
+type DemoTab = 'host' | 'child' | 'title' | 'nested'
 
 const DEMO_TABS: { id: DemoTab; label: string }[] = [
   { id: 'host', label: 'Styled host' },
   { id: 'child', label: 'Styled child' },
   { id: 'title', label: 'Styled title' },
+  { id: 'nested', label: 'Nested' },
 ]
 
 export default function StyledComponentsSpatialTest() {
@@ -86,6 +88,7 @@ export default function StyledComponentsSpatialTest() {
                 {t.id === 'host' && <StyledSpatialHostSection />}
                 {t.id === 'child' && <StyledSpatialChildSection />}
                 {t.id === 'title' && <StyledTitleSection />}
+                {t.id === 'nested' && <StyledNestedSpatialSection />}
               </>
             )}
           </div>

--- a/apps/test-server/src/pages/styledComponentsSpatialTest/shared.tsx
+++ b/apps/test-server/src/pages/styledComponentsSpatialTest/shared.tsx
@@ -1,0 +1,123 @@
+import styled from 'styled-components'
+
+export const PageSection = styled.section`
+  margin-bottom: 28px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(18, 20, 30, 0.72);
+  color: #f8fafc;
+`
+
+export const SectionHeading = styled.h2`
+  margin: 0 0 8px;
+  font-size: 1.125rem;
+  font-weight: 600;
+`
+
+export const SectionNote = styled.p`
+  margin: 0 0 12px;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: #94a3b8;
+`
+
+export const ToggleButton = styled.button`
+  margin: 8px 8px 8px 0;
+  padding: 7px 14px;
+  border: 1px solid #475569;
+  border-radius: 6px;
+  color: #e2e8f0;
+  background: #1e293b;
+  cursor: pointer;
+
+  &:hover {
+    background: #334155;
+  }
+`
+
+export const ControlRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  margin: 8px 0 12px;
+`
+
+export const OpacityLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8125rem;
+  color: #cbd5e1;
+  cursor: pointer;
+`
+
+export const OpacityRange = styled.input.attrs({ type: 'range' })`
+  width: 160px;
+  accent-color: #38bdf8;
+  cursor: pointer;
+`
+
+export const OpacityValue = styled.span`
+  min-width: 2.5rem;
+  font-variant-numeric: tabular-nums;
+  color: #f8fafc;
+`
+
+export const CompareLabel = styled.span`
+  display: block;
+  margin: 12px 8px 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #38bdf8;
+`
+
+/** Opacity via transient prop — styled-components emits new rules/classes as opacity changes. */
+export const StyledSpatialBox = styled.div<{
+  $hidden?: boolean
+  $opacity: number
+}>`
+  visibility: ${props => (props.$hidden ? 'hidden' : 'visible')};
+  opacity: ${props => props.$opacity};
+  position: relative;
+  margin: 8px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  color: #0f172a;
+  background: #f8fafc;
+  transform: ${props => (props.$hidden ? 'rotate(45deg)' : 'none')};
+  --xr-back: ${props => (props.$hidden ? '24' : '100')};
+`
+
+/**
+ * Opacity via CSS variable — stable styled class; only inline --spatial-opacity updates.
+ * Use for A/B against StyledSpatialBox when testing portal head-sync flicker.
+ */
+export const StyledSpatialBoxCssVar = styled.div<{
+  $hidden?: boolean
+}>`
+  visibility: ${props => (props.$hidden ? 'hidden' : 'visible')};
+  opacity: var(--spatial-opacity, 1);
+  position: relative;
+  margin: 8px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #a7f3d0;
+  color: #0f172a;
+  background: #ecfdf5;
+  transform: ${props => (props.$hidden ? 'rotate(45deg)' : 'none')};
+  --xr-back: ${props => (props.$hidden ? '24' : '100')};
+`
+
+export const PlainSpatialShell = styled.div`
+  position: relative;
+  margin: 8px;
+  padding: 4px;
+  border-radius: 10px;
+  border: 1px dashed #64748b;
+  min-width: 280px;
+  min-height: 88px;
+`

--- a/docs/webspatial-quirks.md
+++ b/docs/webspatial-quirks.md
@@ -51,6 +51,28 @@ A `<div enable-xr>` (SpatialDiv) is **not** a single DOM node for styling purpos
 | Tag selector on matching intrinsic (`h1 {}` with `<h1 enable-xr>`) | Yes (after probe tag mirror) |
 | Ancestor + tag (`.page h1 {}`) | Often **no** |
 
+### CSS-in-JS in SpatialDiv (styled-components, Emotion, …)
+
+**Symptom:** Prop-driven styled updates (for example an opacity slider) briefly flash unstyled content in the spatial portal on visionOS / PICO.
+
+**Root cause:** Portal UI renders in a separate child webview. Runtime CSS-in-JS libraries inject rules into the host `document.head` (often via `insertRule`, without changing visible `<style>` text). The portal must mirror those rules into its own `<head>` **before** the new class is painted.
+
+**Current behavior:** The SDK mirrors host `document.head` into each active portal webview. This covers typical styled-components / Emotion setups that inject into the host page.
+
+**Works when:**
+
+- Styles are injected into the **host** `document.head` (default for styled-components and Emotion).
+- You use SpatialDiv (`enable-xr`) or Attachment portal content with the shared `useSyncHeadStyles` path.
+
+**Does not work / not supported:**
+
+- `StyleSheetManager` (or similar) with a **custom target** outside the host document (for example a portal or shadow-root `document.head`).
+- Compile-time CSS only (Tailwind, CSS Modules, Vanilla Extract) — different sync path; issues tend to be missing global `<link>` styles, not CSSOM flicker.
+
+**Manual check:** test-server `#/styledComponentsSpatialTest` (host, child, nested tabs). On device, drag the opacity slider and/or run `window.__runStyledComponentsSpatialOpacitySweep()`; expect `mismatchFrames === 0`.
+
+Maintainer details: `packages/react/src/spatialized-container/ARCHITECTURE.md` — *Portal head sync (CSS-in-JS)*.
+
 ### Dev workflow note
 
 Changing only a CSS file may not update the spatial slab until the host document reloads or the SDK re-samples the probe (see `useSpatialTransformVisibility` — head `childList` changes and `domUpdated` events). The test-server uses esbuild + LiveReload (full page refresh), not Vite-style CSS HMR. Spatial windows on a headset/simulator may need a manual refresh separately from your desktop browser tab.

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -214,6 +214,66 @@ SpatialDiv / Model / Reality entities that open a **portal** (native sub-webview
 3. **Never read `portalInstanceObject.dom` bare in hook dependency arrays.** React evaluates deps before the effect body. Use optional chaining (`portalInstanceObject?.dom`) and allow `portalInstanceObject | null`. Prefer passing `portalInstanceObject` from `PortalSpatializedContainer` as a prop instead of `useContext` inside `SpatializedContent` so linked-SDK HMR is less sensitive to duplicate `PortalInstanceContext` module instances.
 4. **Do not promote lazy 3D loading while `dom` is missing.** `SpatializedStatic3DElementContainer` must wait for frame sync when `portalInstanceObject.dom` is undefined; do not call `setEffectiveLoading('eager')` as a shortcut (regression for [#1192](https://github.com/webspatial/webspatial-sdk/issues/1192)).
 
+### Portal head sync (CSS-in-JS) ([#1265](https://github.com/webspatial/webspatial-sdk/issues/1265))
+
+> **Audience:** maintainers editing `windowStyleSync.ts`, `useSyncHeadStyles.ts`, `useSync2DFrame.ts`, or `Spatialized2DElementContainer`.
+>
+> **Background:** SpatialDiv / Attachment portal content is rendered via `createPortal(..., windowProxy.document.body)`, but React and CSS-in-JS runtimes still execute in the **host** page. Runtime libraries such as styled-components and Emotion inject rules into the host `document.head` (often via `CSSStyleSheet.insertRule` / `deleteRule`). Each portal is a separate child webview and needs its own mirrored copy of those rules.
+
+#### Model
+
+| Layer | Document | Role |
+| --- | --- | --- |
+| Host page | `document` | React tree, styled-components / Emotion injection target |
+| Portal webview | `windowProxy.document` | Visible UI via `createPortal`; `<head>` is mirrored from the host |
+
+Sync is **host → portal**, never portal → portal. Nested SpatialDivs and many flat SpatialDivs each get their own `windowProxy`, but all read from the same host `document.head` source.
+
+#### Key pieces
+
+| Piece | Role |
+| --- | --- |
+| `useSyncHeadStyles` | Thin hook: `registerParentHeadSyncTarget(childWindow)` on mount, `disposeSyncParentHeadToChild` on unmount (`Spatialized2DElementContainer`, `AttachmentEntity`) |
+| `registerParentHeadSyncTarget` | Adds the portal to the global registry and schedules an initial head sync |
+| `windowStyleSync.ts` registry | One `MutationObserver` on host `document.head`, one `domUpdated` listener, one CSSOM `insertRule` / `deleteRule` patch while any target is active |
+| `captureParentHeadSnapshot` | Reads host `<style>` / `<link rel=stylesheet>` once per sync wave; serializes `sheet.cssRules` when available |
+| `syncStyleSheetRulesToChild` | Reuses portal `<style data-webspatial-sync>` nodes in place; incremental `insertRule` / `deleteRule` when possible |
+| `useSync2DFrame` | Before portal `forceUpdate`, runs `scheduleSyncParentHeadToChild(childWindow, 'afterHostLayout', onComplete)` so CSS-in-JS can commit head rules after host layout |
+
+#### Sync waves
+
+The registry coalesces work into **waves** to avoid O(N) parent-head reads when N portals are active:
+
+- **Broadcast** (all active portals): host `MutationObserver`, CSSOM patch, `domUpdated` event.
+- **Single-target** (one portal): `scheduleSyncParentHeadToChild` from `useSync2DFrame` (`afterHostLayout`) or direct callers.
+
+Timing priority within a wave: `immediate` > `afterHostLayout` > `delayed`. `immediate` cancels a pending `delayTimer`. Portal head **writes** remain O(N) — each webview must be updated separately.
+
+#### Invariants (do not break)
+
+1. **Serialize from `cssRules`, not `cloneNode` alone.** CSS-in-JS often updates CSSOM without mutating `<style>` text children.
+2. **Patch only parent head sheets.** `isParentHeadStyleSheet` must gate the CSSOM prototype patch so child-portal `insertRule` during sync does not recurse.
+3. **Restore the CSSOM patch when the last target unregisters.** Do not leave `CSSStyleSheet.prototype` patched globally.
+4. **Sync before 2D-frame portal refresh.** `useSync2DFrame` must keep the `afterHostLayout` → sync → `forceUpdate` ordering for prop-driven styled updates.
+5. **Mixed mutation batches prefer `immediate`.** A `<link rel=stylesheet>` record in the same batch must not downgrade co-occurring `<style>` text / `characterData` updates to `delayed`.
+6. **`<link>` sync stays idempotent.** Keep `data-webspatial-sync-key`, per-window `version`, and `isCurrent()` guards for async stylesheet loads ([#1033](https://github.com/webspatial/webspatial-sdk/issues/1033)).
+7. **Dispose stops further sync for that window.** `disposeSyncParentHeadToChild` must filter disposed targets out of pending waves.
+
+#### Manual validation (test-server)
+
+| Route | What it exercises |
+| --- | --- |
+| `#/styledComponentsSpatialTest` | styled-components on host, child, nested SpatialDiv; inspector helpers `__probeStyledComponentsSpatialHeadSync`, `__runStyledComponentsSpatialOpacitySweep` |
+| `#/head-style-sync` | `<link rel=stylesheet>` dedupe / stress (not CSSOM flicker) |
+
+#### Known limitations
+
+- **Custom injection targets** (e.g. styled-components `StyleSheetManager` targeting a portal or shadow `document.head`) are not mirrored — sync reads host `document.head` only.
+- **Synced `<style>` nodes are paired by index** with parent `<style>` nodes. Append/update flows (typical CSS-in-JS) are stable; devtools/HMR that reorder parent `<style>` nodes may need future stable keying.
+- **`domUpdated` triggers a broadcast `afterHostLayout` wave** for all active portals (correctness-first).
+
+End-user summary: [`docs/webspatial-quirks.md`](../../../../docs/webspatial-quirks.md) — *CSS-in-JS in SpatialDiv*.
+
 ### Local development notes
 
 | Setup | What it exercises |
@@ -229,11 +289,14 @@ SpatialDiv / Model / Reality entities that open a **portal** (native sub-webview
 | `portalInstanceObject` null-safe deps / props | `hooks/useSpatialContentReady.test.ts` |
 | Lazy 3D when `dom` appears after sync | `SpatializedStatic3DElementContainer.test.tsx` |
 | `useSync2DFrame` mount + element-driven sync | `coverage-boost.test.ts` (filtered cases for `useSync2DFrame`) |
+| Portal head sync / CSSOM / registry waves | `utils/windowStyleSync.test.ts` |
+| `useSyncHeadStyles` register + dispose | `utils/useSyncHeadStyles.test.tsx` |
 
 Run focused checks:
 
 ```sh
 cd packages/react && pnpm exec vitest run src/spatialized-container/
+cd packages/react && pnpm exec vitest run src/utils/windowStyleSync.test.ts src/utils/useSyncHeadStyles.test.tsx
 ```
 
 ## Known limitations
@@ -283,6 +346,8 @@ Each invariant has at least one regression test pinned in this directory:
 ## Quick reference for new contributors
 
 If you are changing **portal** hooks or `PortalSpatializedContainer`, read [Portal lifecycle and local dev (HMR)](#portal-lifecycle-and-local-dev-hmr) first and run `src/spatialized-container/` vitest.
+
+If you are changing **portal head sync** (`windowStyleSync.ts`, `useSyncHeadStyles.ts`, `useSync2DFrame.ts`), read [Portal head sync (CSS-in-JS)](#portal-head-sync-css-in-js-1265) and run `src/utils/windowStyleSync.test.ts`.
 
 If you are adding behavior to the standard host:
 

--- a/packages/react/src/spatialized-container/ARCHITECTURE.md
+++ b/packages/react/src/spatialized-container/ARCHITECTURE.md
@@ -289,6 +289,7 @@ End-user summary: [`docs/webspatial-quirks.md`](../../../../docs/webspatial-quir
 | `portalInstanceObject` null-safe deps / props | `hooks/useSpatialContentReady.test.ts` |
 | Lazy 3D when `dom` appears after sync | `SpatializedStatic3DElementContainer.test.tsx` |
 | `useSync2DFrame` mount + element-driven sync | `coverage-boost.test.ts` (filtered cases for `useSync2DFrame`) |
+| `useSync2DFrame` `afterHostLayout` head sync before re-render | `hooks/useSync2DFrame.test.tsx` |
 | Portal head sync / CSSOM / registry waves | `utils/windowStyleSync.test.ts` |
 | `useSyncHeadStyles` register + dispose | `utils/useSyncHeadStyles.test.tsx` |
 

--- a/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/Spatialized2DElementContainer.tsx
@@ -125,9 +125,7 @@ function SpatializedContent<P extends ElementType>(
     onSpatialContentReady,
   })
 
-  useSyncHeadStyles(windowProxy, {
-    subtree: false,
-  })
+  useSyncHeadStyles(windowProxy)
 
   const name: string = (restProps as any)['data-name'] || ''
   useSyncDocumentTitle(windowProxy, spatialized2DElement, name)

--- a/packages/react/src/spatialized-container/hooks/useSync2DFrame.test.tsx
+++ b/packages/react/src/spatialized-container/hooks/useSync2DFrame.test.tsx
@@ -1,0 +1,229 @@
+import { act, render } from '@testing-library/react'
+import type { SpatializedElement } from '@webspatial/core-sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PortalInstanceObject } from '../context/PortalInstanceContext'
+import type { SpatializedContainerObject } from '../context/SpatializedContainerContext'
+import { useSync2DFrame } from './useSync2DFrame'
+import {
+  __parentHeadSyncRegistryTest__,
+  scheduleSyncParentHeadToChild,
+} from '../../utils/windowStyleSync'
+
+const actualScheduleSync = vi.hoisted(() => ({
+  fn: null as typeof scheduleSyncParentHeadToChild | null,
+}))
+
+vi.mock('../../utils/windowStyleSync', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../utils/windowStyleSync')>()
+  actualScheduleSync.fn = actual.scheduleSyncParentHeadToChild
+  return {
+    ...actual,
+    scheduleSyncParentHeadToChild: vi.fn(actual.scheduleSyncParentHeadToChild),
+  }
+})
+
+function createChildWindow() {
+  return {
+    document: document.implementation.createHTMLDocument(),
+    Event,
+  } as unknown as WindowProxy
+}
+
+function createSpatializedElement(childWindow: WindowProxy) {
+  return { windowProxy: childWindow } as SpatializedElement & {
+    windowProxy: WindowProxy
+  }
+}
+
+function createHarness(options?: { spatializedElement?: SpatializedElement }) {
+  const portalInstanceObject = {
+    notify2DFrameChange: vi.fn(),
+  } as unknown as PortalInstanceObject
+
+  let handler: (() => void) | undefined
+  const spatializedContainerObject = {
+    on2DFrameChange: vi.fn((_spatialId: string, cb: () => void) => {
+      handler = cb
+    }),
+    off2DFrameChange: vi.fn(),
+  } as unknown as SpatializedContainerObject
+
+  return {
+    portalInstanceObject,
+    spatializedContainerObject,
+    spatializedElement: options?.spatializedElement,
+    getHandler: () => handler,
+  }
+}
+
+describe('useSync2DFrame', () => {
+  beforeEach(() => {
+    vi.mocked(scheduleSyncParentHeadToChild).mockReset()
+    vi.mocked(scheduleSyncParentHeadToChild).mockImplementation((...args) =>
+      actualScheduleSync.fn!(...args),
+    )
+  })
+
+  afterEach(() => {
+    document.head
+      .querySelectorAll('style, link[rel="stylesheet"]')
+      .forEach(node => node.remove())
+    __parentHeadSyncRegistryTest__.reset()
+    vi.useRealTimers()
+  })
+
+  it('schedules afterHostLayout head sync and defers re-render until sync completes', () => {
+    const childWindow = createChildWindow()
+    const {
+      portalInstanceObject,
+      spatializedContainerObject,
+      spatializedElement,
+    } = createHarness({
+      spatializedElement: createSpatializedElement(childWindow),
+    })
+
+    const onCompletes: Array<() => void> = []
+    vi.mocked(scheduleSyncParentHeadToChild).mockImplementation(
+      (_childWindow, timing, onComplete) => {
+        expect(timing).toBe('afterHostLayout')
+        if (onComplete) onCompletes.push(onComplete)
+      },
+    )
+
+    let renders = 0
+    function Test() {
+      renders += 1
+      useSync2DFrame(
+        's1',
+        portalInstanceObject,
+        spatializedContainerObject,
+        spatializedElement,
+      )
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+
+    expect(portalInstanceObject.notify2DFrameChange).toHaveBeenCalled()
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'afterHostLayout',
+      expect.any(Function),
+    )
+    expect(renders).toBe(1)
+
+    act(() => {
+      onCompletes.forEach(onComplete => onComplete())
+    })
+
+    expect(renders).toBeGreaterThan(1)
+
+    unmount()
+    expect(spatializedContainerObject.off2DFrameChange).toHaveBeenCalledWith(
+      's1',
+    )
+  })
+
+  it('schedules afterHostLayout head sync when the 2D frame callback fires', () => {
+    const childWindow = createChildWindow()
+    const {
+      portalInstanceObject,
+      spatializedContainerObject,
+      spatializedElement,
+      getHandler,
+    } = createHarness({
+      spatializedElement: createSpatializedElement(childWindow),
+    })
+
+    render(
+      <TestHarness
+        spatialId="s1"
+        portalInstanceObject={portalInstanceObject}
+        spatializedContainerObject={spatializedContainerObject}
+        spatializedElement={spatializedElement}
+      />,
+    )
+
+    vi.mocked(scheduleSyncParentHeadToChild).mockClear()
+
+    act(() => {
+      getHandler()?.()
+    })
+
+    expect(portalInstanceObject.notify2DFrameChange).toHaveBeenCalled()
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'afterHostLayout',
+      expect.any(Function),
+    )
+  })
+
+  it('re-renders immediately when no child window is available', () => {
+    const { portalInstanceObject, spatializedContainerObject } = createHarness()
+
+    let renders = 0
+    function Test() {
+      renders += 1
+      useSync2DFrame('s1', portalInstanceObject, spatializedContainerObject)
+      return null
+    }
+
+    render(<Test />)
+
+    expect(scheduleSyncParentHeadToChild).not.toHaveBeenCalled()
+    expect(renders).toBeGreaterThan(1)
+  })
+
+  it('syncs parent head styles to the portal before forcing a re-render', async () => {
+    const childWindow = createChildWindow()
+    const parentStyle = document.createElement('style')
+    parentStyle.textContent = '.frame-sync { opacity: 0.5; }'
+    document.head.appendChild(parentStyle)
+
+    const {
+      portalInstanceObject,
+      spatializedContainerObject,
+      spatializedElement,
+    } = createHarness({
+      spatializedElement: createSpatializedElement(childWindow),
+    })
+
+    render(
+      <TestHarness
+        spatialId="s1"
+        portalInstanceObject={portalInstanceObject}
+        spatializedContainerObject={spatializedContainerObject}
+        spatializedElement={spatializedElement}
+      />,
+    )
+
+    await Promise.resolve()
+    await __parentHeadSyncRegistryTest__.flushPendingWaveForTest()
+
+    expect(
+      childWindow.document.head.querySelector('style[data-webspatial-sync="1"]')
+        ?.textContent,
+    ).toContain('opacity: 0.5')
+  })
+})
+
+function TestHarness({
+  spatialId,
+  portalInstanceObject,
+  spatializedContainerObject,
+  spatializedElement,
+}: {
+  spatialId: string
+  portalInstanceObject: PortalInstanceObject
+  spatializedContainerObject: SpatializedContainerObject
+  spatializedElement?: SpatializedElement
+}) {
+  useSync2DFrame(
+    spatialId,
+    portalInstanceObject,
+    spatializedContainerObject,
+    spatializedElement,
+  )
+  return null
+}

--- a/packages/react/src/spatialized-container/hooks/useSync2DFrame.ts
+++ b/packages/react/src/spatialized-container/hooks/useSync2DFrame.ts
@@ -1,11 +1,20 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import type { SpatializedElement } from '@webspatial/core-sdk'
+import { scheduleSyncParentHeadToChild } from '../../utils/windowStyleSync'
 import { SpatializedContainerObject } from '../context/SpatializedContainerContext'
 import { PortalInstanceObject } from '../context/PortalInstanceContext'
 
 function useForceUpdate() {
   const [, setToggle] = useState(false)
   return useCallback(() => setToggle(toggle => !toggle), [])
+}
+
+function getChildWindow(spatializedElement?: SpatializedElement) {
+  return (
+    spatializedElement as SpatializedElement & {
+      windowProxy?: WindowProxy
+    }
+  )?.windowProxy
 }
 
 export function useSync2DFrame(
@@ -15,11 +24,18 @@ export function useSync2DFrame(
   spatializedElement?: SpatializedElement,
 ) {
   const forceUpdate = useForceUpdate()
+  const childWindow = getChildWindow(spatializedElement)
 
   const sync = useCallback(() => {
     portalInstanceObject.notify2DFrameChange()
+    if (childWindow) {
+      scheduleSyncParentHeadToChild(childWindow, 'afterHostLayout', () => {
+        forceUpdate()
+      })
+      return
+    }
     forceUpdate()
-  }, [portalInstanceObject, forceUpdate])
+  }, [portalInstanceObject, childWindow, forceUpdate])
 
   useEffect(() => {
     spatializedContainerObject.on2DFrameChange(spatialId, sync)
@@ -33,6 +49,12 @@ export function useSync2DFrame(
   useLayoutEffect(() => {
     if (!spatializedElement) return
     portalInstanceObject.notify2DFrameChange()
+    if (childWindow) {
+      scheduleSyncParentHeadToChild(childWindow, 'afterHostLayout', () => {
+        forceUpdate()
+      })
+      return
+    }
     forceUpdate()
-  }, [spatializedElement, portalInstanceObject, forceUpdate])
+  }, [spatializedElement, childWindow, portalInstanceObject, forceUpdate])
 }

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -163,6 +163,44 @@ describe('useSyncHeadStyles', () => {
     unmount()
   })
 
+  it('schedules CSSOM rule sync for every active child window', () => {
+    const parentChildWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+    const nestedChildWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(parentChildWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      useSyncHeadStyles(nestedChildWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    const style = document.createElement('style')
+    document.head.appendChild(style)
+
+    act(() => {
+      style.sheet!.insertRule('.nested{opacity:.42;}', 0)
+    })
+
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      parentChildWindow,
+      'immediate',
+    )
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      nestedChildWindow,
+      'immediate',
+    )
+    style.remove()
+    unmount()
+  })
+
   it('restores CSSOM rule methods after the last synced child unmounts', () => {
     const childWindowA = {
       document: document.implementation.createHTMLDocument(),

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -17,7 +17,7 @@ describe('useSyncHeadStyles', () => {
     vi.mocked(registerParentHeadSyncTarget).mockClear()
   })
 
-  it('registers the child window with immediate sync on mount', () => {
+  it('registers and disposes the child window on mount', () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -1,10 +1,14 @@
 import { act, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSyncHeadStyles } from './useSyncHeadStyles'
-import { syncParentHeadToChild } from './windowStyleSync'
+import {
+  disposeSyncParentHeadToChild,
+  scheduleSyncParentHeadToChild,
+} from './windowStyleSync'
 
 vi.mock('./windowStyleSync', () => ({
-  syncParentHeadToChild: vi.fn(),
+  disposeSyncParentHeadToChild: vi.fn(),
+  scheduleSyncParentHeadToChild: vi.fn(),
 }))
 
 describe('useSyncHeadStyles', () => {
@@ -26,7 +30,8 @@ describe('useSyncHeadStyles', () => {
         observers.push(this)
       }
     }
-    vi.mocked(syncParentHeadToChild).mockClear()
+    vi.mocked(disposeSyncParentHeadToChild).mockClear()
+    vi.mocked(scheduleSyncParentHeadToChild).mockClear()
   })
 
   afterEach(() => {
@@ -34,7 +39,7 @@ describe('useSyncHeadStyles', () => {
     globalThis.MutationObserver = originalMutationObserver
   })
 
-  it('syncs stylesheet text changes before the next timer tick', async () => {
+  it('syncs stylesheet text changes immediately', async () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }
@@ -74,17 +79,15 @@ describe('useSyncHeadStyles', () => {
         observers[0] as unknown as MutationObserver,
       )
     })
-    expect(syncParentHeadToChild).not.toHaveBeenCalled()
 
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'immediate',
+    )
     unmount()
   })
 
-  it('coalesces multiple immediate stylesheet text changes in one microtask', async () => {
+  it('keeps observing stylesheet text changes when subtree is disabled by the caller', async () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }
@@ -92,55 +95,21 @@ describe('useSyncHeadStyles', () => {
     function Test() {
       useSyncHeadStyles(childWindow as unknown as WindowProxy, {
         immediate: false,
+        subtree: false,
       })
       return null
     }
 
     const { unmount } = render(<Test />)
-    const style = document.createElement('style')
-    const text = document.createTextNode('.a{padding:12px;}')
-    style.appendChild(text)
-    const mutation = {
-      type: 'characterData',
-      target: text,
-      addedNodes: [],
-      removedNodes: [],
-    } as unknown as MutationRecord
+    expect(observers[0].observe).toHaveBeenCalledWith(
+      document.head,
+      expect.objectContaining({
+        childList: true,
+        characterData: true,
+        subtree: true,
+      }),
+    )
 
-    act(() => {
-      observers[0].callback(
-        [mutation],
-        observers[0] as unknown as MutationObserver,
-      )
-      observers[0].callback(
-        [mutation],
-        observers[0] as unknown as MutationObserver,
-      )
-    })
-    expect(syncParentHeadToChild).not.toHaveBeenCalled()
-
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
-    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
-    unmount()
-  })
-
-  it('cancels queued immediate sync on unmount', async () => {
-    const childWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-
-    function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
     const style = document.createElement('style')
     const text = document.createTextNode('.a{padding:12px;}')
     style.appendChild(text)
@@ -157,14 +126,59 @@ describe('useSyncHeadStyles', () => {
         ],
         observers[0] as unknown as MutationObserver,
       )
-      unmount()
     })
 
-    await act(async () => {
-      await Promise.resolve()
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'immediate',
+    )
+    unmount()
+  })
+
+  it('schedules sync for CSSOM insertRule changes in parent head styles', () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    const style = document.createElement('style')
+    document.head.appendChild(style)
+
+    act(() => {
+      style.sheet!.insertRule('.a{padding:12px;}', 0)
     })
 
-    expect(syncParentHeadToChild).not.toHaveBeenCalled()
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'immediate',
+    )
+    style.remove()
+    unmount()
+  })
+
+  it('disposes scheduled sync on unmount', () => {
+    const childWindow = {
+      document: document.implementation.createHTMLDocument(),
+    }
+
+    function Test() {
+      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    unmount()
+
+    expect(disposeSyncParentHeadToChild).toHaveBeenCalledWith(childWindow)
   })
 
   it('prefers immediate when a batch mixes link stylesheet and style text changes', async () => {
@@ -208,17 +222,15 @@ describe('useSyncHeadStyles', () => {
         observers[0] as unknown as MutationObserver,
       )
     })
-    expect(syncParentHeadToChild).not.toHaveBeenCalled()
 
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
-    expect(syncParentHeadToChild).toHaveBeenCalledWith(childWindow)
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledTimes(1)
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
+      childWindow,
+      'immediate',
+    )
 
     vi.advanceTimersByTime(1000)
-    expect(syncParentHeadToChild).toHaveBeenCalledTimes(1)
+    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledTimes(1)
 
     unmount()
   })

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -1,258 +1,51 @@
-import { act, render } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSyncHeadStyles } from './useSyncHeadStyles'
 import {
   disposeSyncParentHeadToChild,
-  scheduleSyncParentHeadToChild,
+  registerParentHeadSyncTarget,
 } from './windowStyleSync'
 
 vi.mock('./windowStyleSync', () => ({
   disposeSyncParentHeadToChild: vi.fn(),
-  scheduleSyncParentHeadToChild: vi.fn(),
+  registerParentHeadSyncTarget: vi.fn(),
 }))
 
 describe('useSyncHeadStyles', () => {
-  const originalMutationObserver = globalThis.MutationObserver
-  const observers: Array<{
-    callback: MutationCallback
-    observe: ReturnType<typeof vi.fn>
-    disconnect: ReturnType<typeof vi.fn>
-  }> = []
-
   beforeEach(() => {
-    vi.useFakeTimers()
-    observers.length = 0
-    ;(globalThis as any).MutationObserver = class {
-      observe = vi.fn()
-      disconnect = vi.fn()
-
-      constructor(public callback: MutationCallback) {
-        observers.push(this)
-      }
-    }
     vi.mocked(disposeSyncParentHeadToChild).mockClear()
-    vi.mocked(scheduleSyncParentHeadToChild).mockClear()
+    vi.mocked(registerParentHeadSyncTarget).mockClear()
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-    globalThis.MutationObserver = originalMutationObserver
-  })
-
-  it('syncs stylesheet text changes immediately', async () => {
+  it('registers the child window with immediate sync by default', () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }
+    const unregister = vi.fn()
+    vi.mocked(registerParentHeadSyncTarget).mockReturnValue(unregister)
 
     function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
+      useSyncHeadStyles(childWindow as unknown as WindowProxy)
       return null
     }
 
     const { unmount } = render(<Test />)
-    expect(observers).toHaveLength(1)
-    expect(observers[0].observe).toHaveBeenCalledWith(
-      document.head,
-      expect.objectContaining({
-        childList: true,
-        characterData: true,
-        subtree: true,
-      }),
-    )
 
-    const style = document.createElement('style')
-    const text = document.createTextNode('.a{padding:12px;}')
-    style.appendChild(text)
-
-    act(() => {
-      observers[0].callback(
-        [
-          {
-            type: 'characterData',
-            target: text,
-            addedNodes: [],
-            removedNodes: [],
-          } as unknown as MutationRecord,
-        ],
-        observers[0] as unknown as MutationObserver,
-      )
+    expect(registerParentHeadSyncTarget).toHaveBeenCalledWith(childWindow, {
+      immediate: true,
     })
 
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      childWindow,
-      'immediate',
-    )
-    unmount()
-  })
-
-  it('keeps observing stylesheet text changes when subtree is disabled by the caller', async () => {
-    const childWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-
-    function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-        subtree: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-    expect(observers[0].observe).toHaveBeenCalledWith(
-      document.head,
-      expect.objectContaining({
-        childList: true,
-        characterData: true,
-        subtree: true,
-      }),
-    )
-
-    const style = document.createElement('style')
-    const text = document.createTextNode('.a{padding:12px;}')
-    style.appendChild(text)
-
-    act(() => {
-      observers[0].callback(
-        [
-          {
-            type: 'characterData',
-            target: text,
-            addedNodes: [],
-            removedNodes: [],
-          } as unknown as MutationRecord,
-        ],
-        observers[0] as unknown as MutationObserver,
-      )
-    })
-
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      childWindow,
-      'immediate',
-    )
-    unmount()
-  })
-
-  it('schedules sync for CSSOM insertRule changes in parent head styles', () => {
-    const childWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-
-    function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-    const style = document.createElement('style')
-    document.head.appendChild(style)
-
-    act(() => {
-      style.sheet!.insertRule('.a{padding:12px;}', 0)
-    })
-
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      childWindow,
-      'immediate',
-    )
-    style.remove()
-    unmount()
-  })
-
-  it('schedules CSSOM rule sync for every active child window', () => {
-    const parentChildWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-    const nestedChildWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-
-    function Test() {
-      useSyncHeadStyles(parentChildWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      useSyncHeadStyles(nestedChildWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-    const style = document.createElement('style')
-    document.head.appendChild(style)
-
-    act(() => {
-      style.sheet!.insertRule('.nested{opacity:.42;}', 0)
-    })
-
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      parentChildWindow,
-      'immediate',
-    )
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      nestedChildWindow,
-      'immediate',
-    )
-    style.remove()
-    unmount()
-  })
-
-  it('restores CSSOM rule methods after the last synced child unmounts', () => {
-    const childWindowA = {
-      document: document.implementation.createHTMLDocument(),
-    }
-    const childWindowB = {
-      document: document.implementation.createHTMLDocument(),
-    }
-    const originalInsertRule = CSSStyleSheet.prototype.insertRule
-    const originalDeleteRule = CSSStyleSheet.prototype.deleteRule
-
-    function Test() {
-      useSyncHeadStyles(childWindowA as unknown as WindowProxy, {
-        immediate: false,
-      })
-      useSyncHeadStyles(childWindowB as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-    expect(CSSStyleSheet.prototype.insertRule).not.toBe(originalInsertRule)
-    expect(CSSStyleSheet.prototype.deleteRule).not.toBe(originalDeleteRule)
-
     unmount()
 
-    expect(CSSStyleSheet.prototype.insertRule).toBe(originalInsertRule)
-    expect(CSSStyleSheet.prototype.deleteRule).toBe(originalDeleteRule)
-  })
-
-  it('disposes scheduled sync on unmount', () => {
-    const childWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-
-    function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-    unmount()
-
+    expect(unregister).toHaveBeenCalledTimes(1)
     expect(disposeSyncParentHeadToChild).toHaveBeenCalledWith(childWindow)
   })
 
-  it('prefers immediate when a batch mixes link stylesheet and style text changes', async () => {
+  it('passes immediate=false through to the registry', () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }
+    vi.mocked(registerParentHeadSyncTarget).mockReturnValue(vi.fn())
 
     function Test() {
       useSyncHeadStyles(childWindow as unknown as WindowProxy, {
@@ -263,43 +56,22 @@ describe('useSyncHeadStyles', () => {
 
     const { unmount } = render(<Test />)
 
-    const link = document.createElement('link')
-    link.rel = 'stylesheet'
-    link.href = 'https://example.com/a.css'
-
-    const style = document.createElement('style')
-    const text = document.createTextNode('.a{padding:12px;}')
-    style.appendChild(text)
-
-    act(() => {
-      observers[0].callback(
-        [
-          {
-            type: 'childList',
-            target: document.head,
-            addedNodes: [link] as unknown as NodeList,
-            removedNodes: [] as unknown as NodeList,
-          } as unknown as MutationRecord,
-          {
-            type: 'characterData',
-            target: text,
-            addedNodes: [],
-            removedNodes: [],
-          } as unknown as MutationRecord,
-        ],
-        observers[0] as unknown as MutationObserver,
-      )
+    expect(registerParentHeadSyncTarget).toHaveBeenCalledWith(childWindow, {
+      immediate: false,
     })
 
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledTimes(1)
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledWith(
-      childWindow,
-      'immediate',
-    )
-
-    vi.advanceTimersByTime(1000)
-    expect(scheduleSyncParentHeadToChild).toHaveBeenCalledTimes(1)
-
     unmount()
+  })
+
+  it('does not register without a child window', () => {
+    function Test() {
+      useSyncHeadStyles(null)
+      return null
+    }
+
+    render(<Test />)
+
+    expect(registerParentHeadSyncTarget).not.toHaveBeenCalled()
+    expect(disposeSyncParentHeadToChild).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -163,6 +163,36 @@ describe('useSyncHeadStyles', () => {
     unmount()
   })
 
+  it('restores CSSOM rule methods after the last synced child unmounts', () => {
+    const childWindowA = {
+      document: document.implementation.createHTMLDocument(),
+    }
+    const childWindowB = {
+      document: document.implementation.createHTMLDocument(),
+    }
+    const originalInsertRule = CSSStyleSheet.prototype.insertRule
+    const originalDeleteRule = CSSStyleSheet.prototype.deleteRule
+
+    function Test() {
+      useSyncHeadStyles(childWindowA as unknown as WindowProxy, {
+        immediate: false,
+      })
+      useSyncHeadStyles(childWindowB as unknown as WindowProxy, {
+        immediate: false,
+      })
+      return null
+    }
+
+    const { unmount } = render(<Test />)
+    expect(CSSStyleSheet.prototype.insertRule).not.toBe(originalInsertRule)
+    expect(CSSStyleSheet.prototype.deleteRule).not.toBe(originalDeleteRule)
+
+    unmount()
+
+    expect(CSSStyleSheet.prototype.insertRule).toBe(originalInsertRule)
+    expect(CSSStyleSheet.prototype.deleteRule).toBe(originalDeleteRule)
+  })
+
   it('disposes scheduled sync on unmount', () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),

--- a/packages/react/src/utils/useSyncHeadStyles.test.tsx
+++ b/packages/react/src/utils/useSyncHeadStyles.test.tsx
@@ -17,7 +17,7 @@ describe('useSyncHeadStyles', () => {
     vi.mocked(registerParentHeadSyncTarget).mockClear()
   })
 
-  it('registers the child window with immediate sync by default', () => {
+  it('registers the child window with immediate sync on mount', () => {
     const childWindow = {
       document: document.implementation.createHTMLDocument(),
     }
@@ -31,36 +31,12 @@ describe('useSyncHeadStyles', () => {
 
     const { unmount } = render(<Test />)
 
-    expect(registerParentHeadSyncTarget).toHaveBeenCalledWith(childWindow, {
-      immediate: true,
-    })
+    expect(registerParentHeadSyncTarget).toHaveBeenCalledWith(childWindow)
 
     unmount()
 
     expect(unregister).toHaveBeenCalledTimes(1)
     expect(disposeSyncParentHeadToChild).toHaveBeenCalledWith(childWindow)
-  })
-
-  it('passes immediate=false through to the registry', () => {
-    const childWindow = {
-      document: document.implementation.createHTMLDocument(),
-    }
-    vi.mocked(registerParentHeadSyncTarget).mockReturnValue(vi.fn())
-
-    function Test() {
-      useSyncHeadStyles(childWindow as unknown as WindowProxy, {
-        immediate: false,
-      })
-      return null
-    }
-
-    const { unmount } = render(<Test />)
-
-    expect(registerParentHeadSyncTarget).toHaveBeenCalledWith(childWindow, {
-      immediate: false,
-    })
-
-    unmount()
   })
 
   it('does not register without a child window', () => {

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 
-import { syncParentHeadToChild } from './windowStyleSync'
+import { SpatialStyleInfoUpdateEvent } from '../notifyUpdateStandInstanceLayout'
+import {
+  disposeSyncParentHeadToChild,
+  scheduleSyncParentHeadToChild,
+} from './windowStyleSync'
 
 interface Options {
   subtree?: boolean
@@ -9,11 +13,78 @@ interface Options {
 
 type SyncTiming = 'immediate' | 'delayed'
 
+const activeChildWindows = new Set<WindowProxy>()
+
+let patchedCssomUsers = 0
+let originalInsertRule: CSSStyleSheet['insertRule'] | undefined
+let originalDeleteRule: CSSStyleSheet['deleteRule'] | undefined
+
+function isParentHeadStyleSheet(sheet: CSSStyleSheet) {
+  const ownerNode = (sheet as CSSStyleSheet & { ownerNode?: Node }).ownerNode
+  if (
+    ownerNode instanceof HTMLStyleElement &&
+    ownerNode.ownerDocument === document &&
+    document.head.contains(ownerNode)
+  ) {
+    return true
+  }
+
+  return Array.from(document.head.querySelectorAll('style')).some(
+    style => style.sheet === sheet,
+  )
+}
+
+function scheduleActiveChildWindowSync() {
+  for (const childWindow of activeChildWindows) {
+    scheduleSyncParentHeadToChild(childWindow, 'immediate')
+  }
+}
+
+function installCssomRuleObserver() {
+  if (typeof CSSStyleSheet === 'undefined') return () => {}
+
+  patchedCssomUsers++
+  if (patchedCssomUsers > 1) {
+    return () => {
+      patchedCssomUsers--
+    }
+  }
+
+  originalInsertRule = CSSStyleSheet.prototype.insertRule
+  originalDeleteRule = CSSStyleSheet.prototype.deleteRule
+
+  CSSStyleSheet.prototype.insertRule = function patchedInsertRule(
+    rule: string,
+    index?: number,
+  ) {
+    const result = originalInsertRule!.call(this, rule, index)
+    if (isParentHeadStyleSheet(this)) scheduleActiveChildWindowSync()
+    return result
+  }
+
+  CSSStyleSheet.prototype.deleteRule = function patchedDeleteRule(
+    index: number,
+  ) {
+    originalDeleteRule!.call(this, index)
+    if (isParentHeadStyleSheet(this)) scheduleActiveChildWindowSync()
+  }
+
+  return () => {
+    patchedCssomUsers--
+    if (patchedCssomUsers > 0) return
+    if (originalInsertRule) {
+      CSSStyleSheet.prototype.insertRule = originalInsertRule
+    }
+    if (originalDeleteRule) {
+      CSSStyleSheet.prototype.deleteRule = originalDeleteRule
+    }
+    originalInsertRule = undefined
+    originalDeleteRule = undefined
+  }
+}
+
 function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {
   if (!Array.isArray(mutations) || mutations.length === 0) return null
-  // Scan the whole batch and take the highest priority across all records.
-  // `immediate` (inline <style> changes) wins over `delayed` (<link rel=stylesheet>),
-  // so a mixed batch is never downgraded to `delayed` by record ordering.
   let hasDelayed = false
   for (const mutation of mutations) {
     if (mutation.type === 'characterData') {
@@ -43,51 +114,43 @@ export function useSyncHeadStyles(
   childWindow: WindowProxy | null | undefined,
   options?: Options,
 ) {
-  const delayMs = 100
-  const subtree = options?.subtree ?? true
   const immediate = options?.immediate ?? true
 
   useEffect(() => {
     if (!childWindow) return
 
-    let timer: number | undefined
-    let immediateQueued = false
-    let disposed = false
-    const scheduleSync = (timing: SyncTiming = 'delayed') => {
-      if (timer) window.clearTimeout(timer)
-      if (timing === 'immediate') {
-        if (immediateQueued) return
-        immediateQueued = true
-        queueMicrotask(() => {
-          immediateQueued = false
-          if (disposed) return
-          syncParentHeadToChild(childWindow)
-        })
-        return
-      }
-      timer = window.setTimeout(() => {
-        if (disposed) return
-        syncParentHeadToChild(childWindow)
-      }, delayMs)
-    }
+    activeChildWindows.add(childWindow)
+    const uninstallCssomRuleObserver = installCssomRuleObserver()
 
-    if (immediate) scheduleSync()
+    if (immediate) scheduleSyncParentHeadToChild(childWindow)
 
     const observer = new MutationObserver(mutations => {
       const timing = getSyncTiming(mutations)
       if (!timing) return
-      scheduleSync(timing)
+      scheduleSyncParentHeadToChild(childWindow, timing)
     })
     observer.observe(document.head, {
       childList: true,
       characterData: true,
-      subtree,
+      subtree: true,
     })
 
+    const onDomUpdated = () =>
+      scheduleSyncParentHeadToChild(childWindow, 'afterHostLayout')
+    document.addEventListener(
+      SpatialStyleInfoUpdateEvent.domUpdated,
+      onDomUpdated,
+    )
+
     return () => {
-      disposed = true
-      if (timer) window.clearTimeout(timer)
+      activeChildWindows.delete(childWindow)
+      uninstallCssomRuleObserver()
       observer.disconnect()
+      document.removeEventListener(
+        SpatialStyleInfoUpdateEvent.domUpdated,
+        onDomUpdated,
+      )
+      disposeSyncParentHeadToChild(childWindow)
     }
-  }, [childWindow, delayMs, subtree, immediate])
+  }, [childWindow, immediate])
 }

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -45,9 +45,7 @@ function installCssomRuleObserver() {
 
   patchedCssomUsers++
   if (patchedCssomUsers > 1) {
-    return () => {
-      patchedCssomUsers--
-    }
+    return uninstallCssomRuleObserver
   }
 
   originalInsertRule = CSSStyleSheet.prototype.insertRule
@@ -69,18 +67,21 @@ function installCssomRuleObserver() {
     if (isParentHeadStyleSheet(this)) scheduleActiveChildWindowSync()
   }
 
-  return () => {
-    patchedCssomUsers--
-    if (patchedCssomUsers > 0) return
-    if (originalInsertRule) {
-      CSSStyleSheet.prototype.insertRule = originalInsertRule
-    }
-    if (originalDeleteRule) {
-      CSSStyleSheet.prototype.deleteRule = originalDeleteRule
-    }
-    originalInsertRule = undefined
-    originalDeleteRule = undefined
+  return uninstallCssomRuleObserver
+}
+
+function uninstallCssomRuleObserver() {
+  if (patchedCssomUsers <= 0) return
+  patchedCssomUsers--
+  if (patchedCssomUsers > 0) return
+  if (originalInsertRule) {
+    CSSStyleSheet.prototype.insertRule = originalInsertRule
   }
+  if (originalDeleteRule) {
+    CSSStyleSheet.prototype.deleteRule = originalDeleteRule
+  }
+  originalInsertRule = undefined
+  originalDeleteRule = undefined
 }
 
 function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -1,114 +1,14 @@
 import { useEffect } from 'react'
 
-import { SpatialStyleInfoUpdateEvent } from '../notifyUpdateStandInstanceLayout'
 import {
   disposeSyncParentHeadToChild,
-  scheduleSyncParentHeadToChild,
+  registerParentHeadSyncTarget,
 } from './windowStyleSync'
 
 interface Options {
+  /** @deprecated The singleton parent-head observer always watches subtree changes. */
   subtree?: boolean
   immediate?: boolean
-}
-
-type SyncTiming = 'immediate' | 'delayed'
-
-const activeChildWindows = new Set<WindowProxy>()
-
-let patchedCssomUsers = 0
-let originalInsertRule: CSSStyleSheet['insertRule'] | undefined
-let originalDeleteRule: CSSStyleSheet['deleteRule'] | undefined
-
-function isParentHeadStyleSheet(sheet: CSSStyleSheet) {
-  const ownerNode = (sheet as CSSStyleSheet & { ownerNode?: Node }).ownerNode
-  if (
-    ownerNode instanceof HTMLStyleElement &&
-    ownerNode.ownerDocument === document &&
-    document.head.contains(ownerNode)
-  ) {
-    return true
-  }
-
-  return Array.from(document.head.querySelectorAll('style')).some(
-    style => style.sheet === sheet,
-  )
-}
-
-function scheduleActiveChildWindowSync() {
-  for (const childWindow of activeChildWindows) {
-    scheduleSyncParentHeadToChild(childWindow, 'immediate')
-  }
-}
-
-function installCssomRuleObserver() {
-  if (typeof CSSStyleSheet === 'undefined') return () => {}
-
-  patchedCssomUsers++
-  if (patchedCssomUsers > 1) {
-    return uninstallCssomRuleObserver
-  }
-
-  originalInsertRule = CSSStyleSheet.prototype.insertRule
-  originalDeleteRule = CSSStyleSheet.prototype.deleteRule
-
-  CSSStyleSheet.prototype.insertRule = function patchedInsertRule(
-    rule: string,
-    index?: number,
-  ) {
-    const result = originalInsertRule!.call(this, rule, index)
-    if (isParentHeadStyleSheet(this)) scheduleActiveChildWindowSync()
-    return result
-  }
-
-  CSSStyleSheet.prototype.deleteRule = function patchedDeleteRule(
-    index: number,
-  ) {
-    originalDeleteRule!.call(this, index)
-    if (isParentHeadStyleSheet(this)) scheduleActiveChildWindowSync()
-  }
-
-  return uninstallCssomRuleObserver
-}
-
-function uninstallCssomRuleObserver() {
-  if (patchedCssomUsers <= 0) return
-  patchedCssomUsers--
-  if (patchedCssomUsers > 0) return
-  if (originalInsertRule) {
-    CSSStyleSheet.prototype.insertRule = originalInsertRule
-  }
-  if (originalDeleteRule) {
-    CSSStyleSheet.prototype.deleteRule = originalDeleteRule
-  }
-  originalInsertRule = undefined
-  originalDeleteRule = undefined
-}
-
-function getSyncTiming(mutations?: MutationRecord[] | null): SyncTiming | null {
-  if (!Array.isArray(mutations) || mutations.length === 0) return null
-  let hasDelayed = false
-  for (const mutation of mutations) {
-    if (mutation.type === 'characterData') {
-      const parent = mutation.target.parentElement
-      if (parent?.tagName === 'STYLE') return 'immediate'
-    }
-
-    const nodes: Node[] = [
-      mutation.target,
-      ...Array.from(mutation.addedNodes),
-      ...Array.from(mutation.removedNodes),
-    ]
-    for (const node of nodes) {
-      if (!(node instanceof Element)) continue
-      const tag = node.tagName
-      if (tag === 'STYLE') return 'immediate'
-      if (tag === 'LINK') {
-        const { rel } = node as HTMLLinkElement
-        if (rel && rel.toLowerCase() === 'stylesheet') hasDelayed = true
-      }
-    }
-  }
-  return hasDelayed ? 'delayed' : null
 }
 
 export function useSyncHeadStyles(
@@ -120,37 +20,10 @@ export function useSyncHeadStyles(
   useEffect(() => {
     if (!childWindow) return
 
-    activeChildWindows.add(childWindow)
-    const uninstallCssomRuleObserver = installCssomRuleObserver()
-
-    if (immediate) scheduleSyncParentHeadToChild(childWindow)
-
-    const observer = new MutationObserver(mutations => {
-      const timing = getSyncTiming(mutations)
-      if (!timing) return
-      scheduleSyncParentHeadToChild(childWindow, timing)
-    })
-    observer.observe(document.head, {
-      childList: true,
-      characterData: true,
-      subtree: true,
-    })
-
-    const onDomUpdated = () =>
-      scheduleSyncParentHeadToChild(childWindow, 'afterHostLayout')
-    document.addEventListener(
-      SpatialStyleInfoUpdateEvent.domUpdated,
-      onDomUpdated,
-    )
+    const unregister = registerParentHeadSyncTarget(childWindow, { immediate })
 
     return () => {
-      activeChildWindows.delete(childWindow)
-      uninstallCssomRuleObserver()
-      observer.disconnect()
-      document.removeEventListener(
-        SpatialStyleInfoUpdateEvent.domUpdated,
-        onDomUpdated,
-      )
+      unregister()
       disposeSyncParentHeadToChild(childWindow)
     }
   }, [childWindow, immediate])

--- a/packages/react/src/utils/useSyncHeadStyles.ts
+++ b/packages/react/src/utils/useSyncHeadStyles.ts
@@ -5,26 +5,15 @@ import {
   registerParentHeadSyncTarget,
 } from './windowStyleSync'
 
-interface Options {
-  /** @deprecated The singleton parent-head observer always watches subtree changes. */
-  subtree?: boolean
-  immediate?: boolean
-}
-
-export function useSyncHeadStyles(
-  childWindow: WindowProxy | null | undefined,
-  options?: Options,
-) {
-  const immediate = options?.immediate ?? true
-
+export function useSyncHeadStyles(childWindow: WindowProxy | null | undefined) {
   useEffect(() => {
     if (!childWindow) return
 
-    const unregister = registerParentHeadSyncTarget(childWindow, { immediate })
+    const unregister = registerParentHeadSyncTarget(childWindow)
 
     return () => {
       unregister()
       disposeSyncParentHeadToChild(childWindow)
     }
-  }, [childWindow, immediate])
+  }, [childWindow])
 }

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -298,8 +298,6 @@ describe('windowStyleSync', () => {
     style.appendChild(text)
     document.head.appendChild(style)
 
-    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
-
     observers[0]!.callback(
       [
         {
@@ -325,59 +323,12 @@ describe('windowStyleSync', () => {
       'style[data-webspatial-sync="1"]',
     ) as HTMLStyleElement
     expect(syncedStyle.textContent).toContain('color: red')
-    expect(
-      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
-    ).toHaveLength(1)
 
     text.textContent = '.a { padding: 12px; color: blue; }'
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(syncedStyle.textContent).toContain('color: red')
     expect(syncedStyle.textContent).not.toContain('color: blue')
-    expect(
-      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
-    ).toHaveLength(1)
-
-    querySpy.mockRestore()
-  })
-
-  it('reads the parent head once per broadcast wave', async () => {
-    const childWindowA = createChildWindow()
-    const childWindowB = createChildWindow()
-    const childWindowC = createChildWindow()
-    registerParentHeadSyncTarget(childWindowA, { immediate: false })
-    registerParentHeadSyncTarget(childWindowB, { immediate: false })
-    registerParentHeadSyncTarget(childWindowC, { immediate: false })
-
-    const parentStyle = document.createElement('style')
-    parentStyle.textContent = '.snapshot { opacity: .42; }'
-    document.head.appendChild(parentStyle)
-
-    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
-
-    observers[0]!.callback(
-      [
-        {
-          type: 'childList',
-          target: document.head,
-          addedNodes: [parentStyle] as unknown as NodeList,
-          removedNodes: [] as unknown as NodeList,
-        } as unknown as MutationRecord,
-      ],
-      observers[0] as unknown as MutationObserver,
-    )
-
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(
-      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
-    ).toHaveLength(1)
-    expect(
-      querySpy.mock.calls.filter(
-        ([selector]) => selector === 'link[rel="stylesheet"][href]',
-      ),
-    ).toHaveLength(1)
   })
 
   it('keeps afterHostLayout sync scoped to the requested target', async () => {

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   __parentHeadSyncRegistryTest__,
-  registerParentHeadSyncTarget,
   scheduleSyncParentHeadToChild,
   syncParentHeadToChild,
   syncStyleSheetRulesToChild,
 } from './windowStyleSync'
+
+const registerParentHeadSyncTarget =
+  __parentHeadSyncRegistryTest__.registerTarget
 
 function createChildWindow() {
   const childDocument = document.implementation.createHTMLDocument()

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  __parentHeadSyncRegistryTest__,
+  registerParentHeadSyncTarget,
   scheduleSyncParentHeadToChild,
   syncParentHeadToChild,
   syncStyleSheetRulesToChild,
@@ -20,9 +22,30 @@ function clearParentHead() {
 }
 
 describe('windowStyleSync', () => {
+  const originalMutationObserver = globalThis.MutationObserver
+  const observers: Array<{
+    callback: MutationCallback
+    observe: ReturnType<typeof vi.fn>
+    disconnect: ReturnType<typeof vi.fn>
+  }> = []
+
+  beforeEach(() => {
+    observers.length = 0
+    ;(globalThis as any).MutationObserver = class {
+      observe = vi.fn()
+      disconnect = vi.fn()
+
+      constructor(public callback: MutationCallback) {
+        observers.push(this)
+      }
+    }
+  })
+
   afterEach(() => {
     vi.useRealTimers()
     clearParentHead()
+    globalThis.MutationObserver = originalMutationObserver
+    __parentHeadSyncRegistryTest__.reset()
   })
 
   it('updates synced style nodes in place without retaining stale attributes', async () => {
@@ -130,7 +153,7 @@ describe('windowStyleSync', () => {
     scheduleSyncParentHeadToChild(childWindow, 'delayed')
     scheduleSyncParentHeadToChild(childWindow, 'immediate')
 
-    await vi.runAllTicks()
+    await Promise.resolve()
     await Promise.resolve()
 
     const syncedStyle = childWindow.document.head.querySelector(
@@ -143,5 +166,193 @@ describe('windowStyleSync', () => {
 
     expect(syncedStyle.textContent).toContain('color: red')
     expect(syncedStyle.textContent).not.toContain('color: blue')
+  })
+
+  it('installs one global head observer for multiple registered targets', () => {
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    const childWindowC = createChildWindow()
+
+    const unregisterA = registerParentHeadSyncTarget(childWindowA, {
+      immediate: false,
+    })
+    const unregisterB = registerParentHeadSyncTarget(childWindowB, {
+      immediate: false,
+    })
+    const unregisterC = registerParentHeadSyncTarget(childWindowC, {
+      immediate: false,
+    })
+
+    expect(observers).toHaveLength(1)
+    expect(observers[0]!.observe).toHaveBeenCalledWith(
+      document.head,
+      expect.objectContaining({
+        childList: true,
+        characterData: true,
+        subtree: true,
+      }),
+    )
+    expect(__parentHeadSyncRegistryTest__.getActiveTargetCount()).toBe(3)
+
+    unregisterA()
+    unregisterB()
+    expect(observers[0]!.disconnect).not.toHaveBeenCalled()
+    unregisterC()
+
+    expect(observers[0]!.disconnect).toHaveBeenCalledTimes(1)
+    expect(__parentHeadSyncRegistryTest__.getActiveTargetCount()).toBe(0)
+  })
+
+  it('restores CSSOM rule methods after the last target unregisters', () => {
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    const originalInsertRule = CSSStyleSheet.prototype.insertRule
+    const originalDeleteRule = CSSStyleSheet.prototype.deleteRule
+
+    const unregisterA = registerParentHeadSyncTarget(childWindowA, {
+      immediate: false,
+    })
+    const unregisterB = registerParentHeadSyncTarget(childWindowB, {
+      immediate: false,
+    })
+
+    expect(CSSStyleSheet.prototype.insertRule).not.toBe(originalInsertRule)
+    expect(CSSStyleSheet.prototype.deleteRule).not.toBe(originalDeleteRule)
+
+    unregisterA()
+    expect(CSSStyleSheet.prototype.insertRule).not.toBe(originalInsertRule)
+    expect(CSSStyleSheet.prototype.deleteRule).not.toBe(originalDeleteRule)
+
+    unregisterB()
+    expect(CSSStyleSheet.prototype.insertRule).toBe(originalInsertRule)
+    expect(CSSStyleSheet.prototype.deleteRule).toBe(originalDeleteRule)
+  })
+
+  it('broadcasts CSSOM rule changes to every active portal', async () => {
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    registerParentHeadSyncTarget(childWindowA, { immediate: false })
+    registerParentHeadSyncTarget(childWindowB, { immediate: false })
+
+    const parentStyle = document.createElement('style')
+    document.head.appendChild(parentStyle)
+    parentStyle.sheet!.insertRule('.cssom { opacity: .5; }', 0)
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    for (const childWindow of [childWindowA, childWindowB]) {
+      const syncedStyle = childWindow.document.head.querySelector(
+        'style[data-webspatial-sync="1"]',
+      ) as HTMLStyleElement
+      expect(syncedStyle.textContent).toContain('opacity: .5')
+    }
+  })
+
+  it('broadcast sync updates every active portal from one head mutation', async () => {
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    registerParentHeadSyncTarget(childWindowA, { immediate: false })
+    registerParentHeadSyncTarget(childWindowB, { immediate: false })
+
+    const parentStyle = document.createElement('style')
+    parentStyle.textContent = '.broadcast { color: red; }'
+    document.head.appendChild(parentStyle)
+
+    observers[0]!.callback(
+      [
+        {
+          type: 'childList',
+          target: document.head,
+          addedNodes: [parentStyle] as unknown as NodeList,
+          removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord,
+      ],
+      observers[0] as unknown as MutationObserver,
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    for (const childWindow of [childWindowA, childWindowB]) {
+      const syncedStyle = childWindow.document.head.querySelector(
+        'style[data-webspatial-sync="1"]',
+      ) as HTMLStyleElement
+      expect(syncedStyle.textContent).toContain('color: red')
+    }
+  })
+
+  it('reads the parent head once per broadcast wave', async () => {
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    const childWindowC = createChildWindow()
+    registerParentHeadSyncTarget(childWindowA, { immediate: false })
+    registerParentHeadSyncTarget(childWindowB, { immediate: false })
+    registerParentHeadSyncTarget(childWindowC, { immediate: false })
+
+    const parentStyle = document.createElement('style')
+    parentStyle.textContent = '.snapshot { opacity: .42; }'
+    document.head.appendChild(parentStyle)
+
+    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
+
+    observers[0]!.callback(
+      [
+        {
+          type: 'childList',
+          target: document.head,
+          addedNodes: [parentStyle] as unknown as NodeList,
+          removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord,
+      ],
+      observers[0] as unknown as MutationObserver,
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(
+      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
+    ).toHaveLength(1)
+    expect(
+      querySpy.mock.calls.filter(
+        ([selector]) => selector === 'link[rel="stylesheet"][href]',
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('keeps afterHostLayout sync scoped to the requested target', async () => {
+    vi.useFakeTimers()
+    const childWindowA = createChildWindow()
+    const childWindowB = createChildWindow()
+    registerParentHeadSyncTarget(childWindowA, { immediate: false })
+    registerParentHeadSyncTarget(childWindowB, { immediate: false })
+
+    const parentStyle = document.createElement('style')
+    parentStyle.textContent = '.targeted { color: blue; }'
+    document.head.appendChild(parentStyle)
+    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
+    const onComplete = vi.fn()
+
+    scheduleSyncParentHeadToChild(childWindowB, 'afterHostLayout', onComplete)
+
+    await vi.runAllTicks()
+    await vi.advanceTimersByTimeAsync(20)
+    await Promise.resolve()
+
+    expect(
+      childWindowA.document.head.querySelector(
+        'style[data-webspatial-sync="1"]',
+      ),
+    ).toBeNull()
+    expect(
+      childWindowB.document.head.querySelector(
+        'style[data-webspatial-sync="1"]',
+      )?.textContent,
+    ).toContain('color: blue')
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(
+      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
+    ).toHaveLength(1)
   })
 })

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -282,6 +282,63 @@ describe('windowStyleSync', () => {
     }
   })
 
+  it('prefers immediate when a batch mixes link stylesheet and style text changes', async () => {
+    vi.useFakeTimers()
+    const childWindow = createChildWindow()
+    registerParentHeadSyncTarget(childWindow, { immediate: false })
+
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = 'https://example.com/a.css'
+
+    const style = document.createElement('style')
+    const text = document.createTextNode('.a { padding: 12px; color: red; }')
+    style.appendChild(text)
+    document.head.appendChild(style)
+
+    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
+
+    observers[0]!.callback(
+      [
+        {
+          type: 'childList',
+          target: document.head,
+          addedNodes: [link] as unknown as NodeList,
+          removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord,
+        {
+          type: 'characterData',
+          target: text,
+          addedNodes: [],
+          removedNodes: [],
+        } as unknown as MutationRecord,
+      ],
+      observers[0] as unknown as MutationObserver,
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const syncedStyle = childWindow.document.head.querySelector(
+      'style[data-webspatial-sync="1"]',
+    ) as HTMLStyleElement
+    expect(syncedStyle.textContent).toContain('color: red')
+    expect(
+      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
+    ).toHaveLength(1)
+
+    text.textContent = '.a { padding: 12px; color: blue; }'
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(syncedStyle.textContent).toContain('color: red')
+    expect(syncedStyle.textContent).not.toContain('color: blue')
+    expect(
+      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
+    ).toHaveLength(1)
+
+    querySpy.mockRestore()
+  })
+
   it('reads the parent head once per broadcast wave', async () => {
     const childWindowA = createChildWindow()
     const childWindowB = createChildWindow()

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  syncParentHeadToChild,
+  syncStyleSheetRulesToChild,
+} from './windowStyleSync'
+
+function createChildWindow() {
+  const childDocument = document.implementation.createHTMLDocument()
+  return {
+    document: childDocument,
+    Event,
+  } as unknown as WindowProxy
+}
+
+function clearParentHead() {
+  document.head
+    .querySelectorAll('style, link[rel="stylesheet"]')
+    .forEach(node => node.remove())
+}
+
+describe('windowStyleSync', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    clearParentHead()
+  })
+
+  it('updates synced style nodes in place without retaining stale attributes', async () => {
+    const childWindow = createChildWindow()
+    const parentStyle = document.createElement('style')
+    parentStyle.setAttribute('media', 'screen')
+    parentStyle.textContent = '.a { color: red; }'
+    document.head.appendChild(parentStyle)
+
+    await syncParentHeadToChild(childWindow)
+    const firstSyncedStyle = childWindow.document.head.querySelector(
+      'style[data-webspatial-sync="1"]',
+    ) as HTMLStyleElement
+    expect(firstSyncedStyle).not.toBeNull()
+    expect(firstSyncedStyle.getAttribute('media')).toBe('screen')
+    expect(firstSyncedStyle.textContent).toContain('color: red')
+
+    parentStyle.removeAttribute('media')
+    parentStyle.setAttribute('nonce', 'next')
+    parentStyle.textContent = '.a { color: blue; }'
+
+    await syncParentHeadToChild(childWindow)
+    const secondSyncedStyle = childWindow.document.head.querySelector(
+      'style[data-webspatial-sync="1"]',
+    ) as HTMLStyleElement
+
+    expect(secondSyncedStyle).toBe(firstSyncedStyle)
+    expect(secondSyncedStyle.getAttribute('media')).toBeNull()
+    expect(secondSyncedStyle.getAttribute('nonce')).toBe('next')
+    expect(secondSyncedStyle.textContent).toContain('color: blue')
+    expect(
+      childWindow.document.head.querySelectorAll(
+        'style[data-webspatial-sync="1"]',
+      ),
+    ).toHaveLength(1)
+  })
+
+  it('forces full text fallback after clearing target CSSOM rules', () => {
+    const source = document.createElement('style')
+    source.textContent = '.a { color: red; }'
+    Object.defineProperty(source, 'sheet', {
+      configurable: true,
+      value: {
+        get cssRules() {
+          throw new Error('inaccessible')
+        },
+      },
+    })
+
+    const target = document.createElement('style')
+    let textContent = '.a { color: red; }'
+    let textAssignments = 0
+    Object.defineProperty(target, 'textContent', {
+      configurable: true,
+      get: () => textContent,
+      set: value => {
+        textAssignments++
+        textContent = value ?? ''
+      },
+    })
+    Object.defineProperty(target, 'sheet', {
+      configurable: true,
+      value: {
+        cssRules: { length: 1 },
+        deleteRule() {
+          this.cssRules.length -= 1
+        },
+      },
+    })
+
+    syncStyleSheetRulesToChild(target, source)
+
+    expect(textAssignments).toBe(1)
+    expect(textContent).toBe('.a { color: red; }')
+  })
+
+  it('does not let an older async stylesheet sync append after a newer sync starts', async () => {
+    vi.useFakeTimers()
+    const childWindow = createChildWindow()
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = 'https://example.com/a.css'
+    document.head.appendChild(link)
+
+    const firstSync = syncParentHeadToChild(childWindow)
+    const secondSync = syncParentHeadToChild(childWindow)
+
+    await vi.advanceTimersByTimeAsync(51)
+    const childLinks = childWindow.document.head.querySelectorAll(
+      'link[data-webspatial-sync="1"]',
+    )
+    expect(childLinks).toHaveLength(1)
+    childLinks[0]!.dispatchEvent(new Event('load'))
+
+    await Promise.all([firstSync, secondSync])
+  })
+})

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -381,7 +381,6 @@ describe('windowStyleSync', () => {
   })
 
   it('keeps afterHostLayout sync scoped to the requested target', async () => {
-    vi.useFakeTimers()
     const childWindowA = createChildWindow()
     const childWindowB = createChildWindow()
     registerParentHeadSyncTarget(childWindowA, { immediate: false })
@@ -390,14 +389,10 @@ describe('windowStyleSync', () => {
     const parentStyle = document.createElement('style')
     parentStyle.textContent = '.targeted { color: blue; }'
     document.head.appendChild(parentStyle)
-    const querySpy = vi.spyOn(document.head, 'querySelectorAll')
     const onComplete = vi.fn()
 
     scheduleSyncParentHeadToChild(childWindowB, 'afterHostLayout', onComplete)
-
-    await vi.runAllTicks()
-    await vi.advanceTimersByTimeAsync(20)
-    await Promise.resolve()
+    await __parentHeadSyncRegistryTest__.flushPendingWaveForTest()
 
     expect(
       childWindowA.document.head.querySelector(
@@ -410,8 +405,5 @@ describe('windowStyleSync', () => {
       )?.textContent,
     ).toContain('color: blue')
     expect(onComplete).toHaveBeenCalledTimes(1)
-    expect(
-      querySpy.mock.calls.filter(([selector]) => selector === 'style'),
-    ).toHaveLength(1)
   })
 })

--- a/packages/react/src/utils/windowStyleSync.test.ts
+++ b/packages/react/src/utils/windowStyleSync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  scheduleSyncParentHeadToChild,
   syncParentHeadToChild,
   syncStyleSheetRulesToChild,
 } from './windowStyleSync'
@@ -117,5 +118,30 @@ describe('windowStyleSync', () => {
     childLinks[0]!.dispatchEvent(new Event('load'))
 
     await Promise.all([firstSync, secondSync])
+  })
+
+  it('cancels a pending delayed sync when an immediate sync is scheduled', async () => {
+    vi.useFakeTimers()
+    const childWindow = createChildWindow()
+    const parentStyle = document.createElement('style')
+    parentStyle.textContent = '.a { color: red; }'
+    document.head.appendChild(parentStyle)
+
+    scheduleSyncParentHeadToChild(childWindow, 'delayed')
+    scheduleSyncParentHeadToChild(childWindow, 'immediate')
+
+    await vi.runAllTicks()
+    await Promise.resolve()
+
+    const syncedStyle = childWindow.document.head.querySelector(
+      'style[data-webspatial-sync="1"]',
+    ) as HTMLStyleElement
+    expect(syncedStyle.textContent).toContain('color: red')
+
+    parentStyle.textContent = '.a { color: blue; }'
+    await vi.advanceTimersByTimeAsync(101)
+
+    expect(syncedStyle.textContent).toContain('color: red')
+    expect(syncedStyle.textContent).not.toContain('color: blue')
   })
 })

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -647,18 +647,11 @@ function enqueueParentHeadSync(
   queuePendingWaveFlush(wave.timing)
 }
 
-export function registerParentHeadSyncTarget(
-  childWindow: WindowProxy,
-  options?: { immediate?: boolean },
-) {
+function addParentHeadSyncTarget(childWindow: WindowProxy) {
   const scheduler = getHeadSyncScheduler(childWindow)
   scheduler.disposed = false
   activeTargets.add(childWindow)
   installParentHeadSyncRegistry()
-
-  if (options?.immediate ?? true) {
-    scheduleSyncParentHeadToChild(childWindow)
-  }
 
   let unregistered = false
   return () => {
@@ -667,6 +660,12 @@ export function registerParentHeadSyncTarget(
     activeTargets.delete(childWindow)
     teardownParentHeadSyncRegistryIfEmpty()
   }
+}
+
+export function registerParentHeadSyncTarget(childWindow: WindowProxy) {
+  const unregister = addParentHeadSyncTarget(childWindow)
+  scheduleSyncParentHeadToChild(childWindow)
+  return unregister
 }
 
 /**
@@ -698,6 +697,13 @@ export const __parentHeadSyncRegistryTest__ = {
   getActiveTargetCount: () => activeTargets.size,
   getObserverInstalled: () => headObserver != null,
   flushPendingWaveForTest: flushHeadSyncWave,
+  registerTarget(childWindow: WindowProxy, options?: { immediate?: boolean }) {
+    const unregister = addParentHeadSyncTarget(childWindow)
+    if (options?.immediate ?? true) {
+      scheduleSyncParentHeadToChild(childWindow)
+    }
+    return unregister
+  },
   reset: () => {
     activeTargets.clear()
     teardownParentHeadSyncRegistry()

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -42,6 +42,168 @@ export function asyncLoadStyleToChildWindow(
 const WEBSPATIAL_SYNC_ATTR = 'data-webspatial-sync'
 const WEBSPATIAL_SYNC_KEY_ATTR = 'data-webspatial-sync-key'
 
+/**
+ * styled-components (and similar runtimes) often update CSS via CSSStyleSheet
+ * insertRule/deleteRule without mutating the <style> node's text children.
+ * cloneNode(true) would miss those live rules — serialize sheet.cssRules instead.
+ */
+export function getStyleElementTextForSync(styleEl: HTMLStyleElement): string {
+  const sheet = styleEl.sheet
+  if (sheet) {
+    try {
+      const parts: string[] = []
+      for (let i = 0; i < sheet.cssRules.length; i++) {
+        parts.push(sheet.cssRules[i]!.cssText)
+      }
+      if (parts.length > 0) return parts.join('\n')
+    } catch {
+      // Inaccessible stylesheet (e.g. cross-origin) — fall back to DOM text.
+    }
+  }
+  return styleEl.textContent ?? ''
+}
+
+function copyParentStyleAttributes(
+  source: HTMLStyleElement,
+  target: HTMLStyleElement,
+) {
+  for (const attr of Array.from(source.attributes)) {
+    if (attr.name === WEBSPATIAL_SYNC_ATTR) continue
+    target.setAttribute(attr.name, attr.value)
+  }
+}
+
+export function cloneParentStyleElementForSync(
+  styleEl: HTMLStyleElement,
+): HTMLStyleElement {
+  const node = document.createElement('style')
+  copyParentStyleAttributes(styleEl, node)
+  node.setAttribute(WEBSPATIAL_SYNC_ATTR, '1')
+  return node
+}
+
+function getStyleSheetRuleTexts(styleEl: HTMLStyleElement): string[] | null {
+  const sheet = styleEl.sheet
+  if (!sheet) return null
+  try {
+    const texts: string[] = []
+    for (let i = 0; i < sheet.cssRules.length; i++) {
+      texts.push(sheet.cssRules[i]!.cssText)
+    }
+    return texts
+  } catch {
+    return null
+  }
+}
+
+function clearStyleSheetRules(sheet: CSSStyleSheet) {
+  while (sheet.cssRules.length > 0) {
+    sheet.deleteRule(sheet.cssRules.length - 1)
+  }
+}
+
+function applyFullTextStyleSync(
+  target: HTMLStyleElement,
+  source: HTMLStyleElement,
+) {
+  const text = getStyleElementTextForSync(source)
+  const sheet = target.sheet
+  if (sheet) {
+    try {
+      clearStyleSheetRules(sheet)
+    } catch {
+      // Fall through to textContent assignment.
+    }
+  }
+  if (target.textContent !== text) {
+    target.textContent = text
+  }
+}
+
+/**
+ * Mirror parent CSSOM into an existing portal <style> via insertRule/deleteRule
+ * so append-only CSS-in-JS updates do not replace the whole stylesheet text.
+ */
+export function syncStyleSheetRulesToChild(
+  target: HTMLStyleElement,
+  source: HTMLStyleElement,
+) {
+  const parentRules = getStyleSheetRuleTexts(source)
+  if (parentRules === null) {
+    applyFullTextStyleSync(target, source)
+    return
+  }
+
+  if (parentRules.length === 0) {
+    const sheet = target.sheet
+    if (sheet) {
+      try {
+        clearStyleSheetRules(sheet)
+      } catch {
+        applyFullTextStyleSync(target, source)
+        return
+      }
+    }
+    const text = source.textContent ?? ''
+    if (target.textContent !== text) target.textContent = text
+    return
+  }
+
+  const sheet = target.sheet
+  if (!sheet) {
+    applyFullTextStyleSync(target, source)
+    return
+  }
+
+  try {
+    let commonPrefix = 0
+    const maxPrefix = Math.min(sheet.cssRules.length, parentRules.length)
+    while (commonPrefix < maxPrefix) {
+      if (sheet.cssRules[commonPrefix]!.cssText !== parentRules[commonPrefix]) {
+        break
+      }
+      commonPrefix++
+    }
+
+    while (sheet.cssRules.length > commonPrefix) {
+      sheet.deleteRule(sheet.cssRules.length - 1)
+    }
+
+    for (let i = commonPrefix; i < parentRules.length; i++) {
+      sheet.insertRule(parentRules[i]!, i)
+    }
+  } catch {
+    applyFullTextStyleSync(target, source)
+  }
+}
+
+/** Update portal <style> nodes in place; prefer CSSOM rule deltas over full text replace. */
+function syncInlineStylesToChild(
+  childHead: HTMLHeadElement,
+  parentStyles: HTMLStyleElement[],
+) {
+  const existing = Array.from(
+    childHead.querySelectorAll(`style[${WEBSPATIAL_SYNC_ATTR}="1"]`),
+  ) as HTMLStyleElement[]
+
+  for (let i = 0; i < parentStyles.length; i++) {
+    const source = parentStyles[i]!
+    const target = existing[i]
+    if (target) {
+      copyParentStyleAttributes(source, target)
+      syncStyleSheetRulesToChild(target, source)
+    } else {
+      const node = cloneParentStyleElementForSync(source)
+      childHead.appendChild(node)
+      syncStyleSheetRulesToChild(node, source)
+    }
+  }
+
+  for (let i = parentStyles.length; i < existing.length; i++) {
+    existing[i]!.parentNode?.removeChild(existing[i]!)
+  }
+}
+
 export function setOpenWindowStyle(openedWindow: WindowProxy) {
   openedWindow.document.documentElement.style.cssText +=
     document.documentElement.style.cssText
@@ -99,16 +261,7 @@ export async function syncParentHeadToChild(childWindow: WindowProxy) {
     if (!desiredStylesheetKeys.has(key)) link.parentNode?.removeChild(link)
   }
 
-  const prevSyncedStyles = head.querySelectorAll(
-    `style[${WEBSPATIAL_SYNC_ATTR}="1"]`,
-  )
-  prevSyncedStyles.forEach(n => n.parentNode?.removeChild(n))
-
-  for (const styleEl of parentStyles) {
-    const node = styleEl.cloneNode(true) as HTMLStyleElement
-    node.setAttribute(WEBSPATIAL_SYNC_ATTR, '1')
-    head.appendChild(node)
-  }
+  syncInlineStylesToChild(head, parentStyles)
 
   const currentKeys = new Set<string>()
   const currentSyncedLinks = Array.from(
@@ -136,4 +289,93 @@ export async function syncParentHeadToChild(childWindow: WindowProxy) {
     document.documentElement.className
 
   return Promise.all(styleLoadedPromises)
+}
+
+type SyncScheduleTiming = 'immediate' | 'delayed' | 'afterHostLayout'
+
+type HeadSyncScheduler = {
+  delayTimer?: number
+  immediateQueued: boolean
+  afterHostLayoutRaf?: number
+  afterHostLayoutComplete?: () => void
+  disposed: boolean
+}
+
+const headSyncSchedulers = new WeakMap<WindowProxy, HeadSyncScheduler>()
+
+function getHeadSyncScheduler(childWindow: WindowProxy): HeadSyncScheduler {
+  const prev = headSyncSchedulers.get(childWindow)
+  if (prev) return prev
+  const next: HeadSyncScheduler = {
+    immediateQueued: false,
+    disposed: false,
+  }
+  headSyncSchedulers.set(childWindow, next)
+  return next
+}
+
+/**
+ * Coalesced head sync for a portal window. `afterHostLayout` runs after the next
+ * animation frame so CSS-in-JS (e.g. styled-components) can commit head rules
+ * that follow a spatial host class/style update.
+ */
+export function scheduleSyncParentHeadToChild(
+  childWindow: WindowProxy,
+  timing: SyncScheduleTiming = 'immediate',
+  onComplete?: () => void,
+) {
+  const scheduler = getHeadSyncScheduler(childWindow)
+  if (scheduler.disposed) return
+
+  const run = () => {
+    if (scheduler.disposed) return
+    void syncParentHeadToChild(childWindow).then(() => {
+      if (timing === 'afterHostLayout') {
+        const complete = scheduler.afterHostLayoutComplete
+        scheduler.afterHostLayoutComplete = undefined
+        complete?.()
+      }
+    })
+  }
+
+  if (timing === 'delayed') {
+    if (scheduler.delayTimer) window.clearTimeout(scheduler.delayTimer)
+    scheduler.delayTimer = window.setTimeout(run, 100)
+    return
+  }
+
+  if (timing === 'afterHostLayout') {
+    if (onComplete) {
+      scheduler.afterHostLayoutComplete = onComplete
+    }
+    if (scheduler.afterHostLayoutRaf != null) {
+      return
+    }
+    queueMicrotask(() => {
+      if (scheduler.disposed || scheduler.afterHostLayoutRaf != null) return
+      scheduler.afterHostLayoutRaf = window.requestAnimationFrame(() => {
+        scheduler.afterHostLayoutRaf = undefined
+        run()
+      })
+    })
+    return
+  }
+
+  if (scheduler.immediateQueued) return
+  scheduler.immediateQueued = true
+  queueMicrotask(() => {
+    scheduler.immediateQueued = false
+    run()
+  })
+}
+
+export function disposeSyncParentHeadToChild(childWindow: WindowProxy) {
+  const scheduler = headSyncSchedulers.get(childWindow)
+  if (!scheduler) return
+  scheduler.disposed = true
+  if (scheduler.delayTimer) window.clearTimeout(scheduler.delayTimer)
+  if (scheduler.afterHostLayoutRaf) {
+    window.cancelAnimationFrame(scheduler.afterHostLayoutRaf)
+  }
+  headSyncSchedulers.delete(childWindow)
 }

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -1,3 +1,5 @@
+import { SpatialStyleInfoUpdateEvent } from '../notifyUpdateStandInstanceLayout'
+
 export function asyncLoadStyleToChildWindow(
   childWindow: WindowProxy,
   link: HTMLLinkElement,
@@ -110,11 +112,19 @@ function clearStyleSheetRules(sheet: CSSStyleSheet) {
   }
 }
 
+function getStyleTextForRules(
+  source: HTMLStyleElement,
+  parentRules?: string[] | null,
+) {
+  if (parentRules && parentRules.length > 0) return parentRules.join('\n')
+  return source.textContent ?? ''
+}
+
 function applyFullTextStyleSync(
   target: HTMLStyleElement,
   source: HTMLStyleElement,
+  text = getStyleElementTextForSync(source),
 ) {
-  const text = getStyleElementTextForSync(source)
   const sheet = target.sheet
   if (sheet) {
     try {
@@ -133,10 +143,17 @@ function applyFullTextStyleSync(
 export function syncStyleSheetRulesToChild(
   target: HTMLStyleElement,
   source: HTMLStyleElement,
+  precomputedParentRules?: string[] | null,
+  precomputedText?: string,
 ) {
-  const parentRules = getStyleSheetRuleTexts(source)
+  const parentRules =
+    precomputedParentRules === undefined
+      ? getStyleSheetRuleTexts(source)
+      : precomputedParentRules
+  const parentText =
+    precomputedText ?? getStyleTextForRules(source, parentRules)
   if (parentRules === null) {
-    applyFullTextStyleSync(target, source)
+    applyFullTextStyleSync(target, source, parentText)
     return
   }
 
@@ -150,14 +167,13 @@ export function syncStyleSheetRulesToChild(
         return
       }
     }
-    const text = source.textContent ?? ''
-    if (target.textContent !== text) target.textContent = text
+    if (target.textContent !== parentText) target.textContent = parentText
     return
   }
 
   const sheet = target.sheet
   if (!sheet) {
-    applyFullTextStyleSync(target, source)
+    applyFullTextStyleSync(target, source, parentText)
     return
   }
 
@@ -179,15 +195,45 @@ export function syncStyleSheetRulesToChild(
       sheet.insertRule(parentRules[i]!, i)
     }
   } catch {
-    applyFullTextStyleSync(target, source)
+    applyFullTextStyleSync(target, source, parentText)
+  }
+}
+
+export type ParentHeadSnapshot = {
+  parentStyles: HTMLStyleElement[]
+  parentStylesheets: HTMLLinkElement[]
+  documentElementClassName: string
+  styleRuleTexts: Array<string[] | null>
+  styleTextContents: string[]
+}
+
+export function captureParentHeadSnapshot(): ParentHeadSnapshot {
+  const parentStyles = Array.from(
+    document.head.querySelectorAll('style'),
+  ) as HTMLStyleElement[]
+  const styleRuleTexts = parentStyles.map(getStyleSheetRuleTexts)
+  const styleTextContents = parentStyles.map((style, index) =>
+    getStyleTextForRules(style, styleRuleTexts[index]),
+  )
+  const parentStylesheets = Array.from(
+    document.head.querySelectorAll('link[rel="stylesheet"][href]'),
+  ) as HTMLLinkElement[]
+
+  return {
+    parentStyles,
+    parentStylesheets,
+    documentElementClassName: document.documentElement.className,
+    styleRuleTexts,
+    styleTextContents,
   }
 }
 
 /** Update portal <style> nodes in place; prefer CSSOM rule deltas over full text replace. */
 function syncInlineStylesToChild(
   childHead: HTMLHeadElement,
-  parentStyles: HTMLStyleElement[],
+  snapshot: ParentHeadSnapshot,
 ) {
+  const { parentStyles, styleRuleTexts, styleTextContents } = snapshot
   const existing = Array.from(
     childHead.querySelectorAll(`style[${WEBSPATIAL_SYNC_ATTR}="1"]`),
   ) as HTMLStyleElement[]
@@ -197,11 +243,21 @@ function syncInlineStylesToChild(
     const target = existing[i]
     if (target) {
       copyParentStyleAttributes(source, target)
-      syncStyleSheetRulesToChild(target, source)
+      syncStyleSheetRulesToChild(
+        target,
+        source,
+        styleRuleTexts[i],
+        styleTextContents[i],
+      )
     } else {
       const node = cloneParentStyleElementForSync(source)
       childHead.appendChild(node)
-      syncStyleSheetRulesToChild(node, source)
+      syncStyleSheetRulesToChild(
+        node,
+        source,
+        styleRuleTexts[i],
+        styleTextContents[i],
+      )
     }
   }
 
@@ -239,18 +295,17 @@ function getController(childWindow: WindowProxy): SyncController {
   return next
 }
 
-export async function syncParentHeadToChild(childWindow: WindowProxy) {
+export async function syncParentHeadToChild(
+  childWindow: WindowProxy,
+  snapshot = captureParentHeadSnapshot(),
+) {
   const controller = getController(childWindow)
   const version = ++controller.version
   const styleLoadedPromises: Promise<boolean>[] = []
   const { head } = childWindow.document
 
   const isCurrent = () => controller.version === version
-
-  const parentStyles = Array.from(document.head.querySelectorAll('style'))
-  const parentStylesheets = Array.from(
-    document.head.querySelectorAll('link[rel="stylesheet"][href]'),
-  ) as HTMLLinkElement[]
+  const { parentStylesheets } = snapshot
 
   const desiredStylesheetKeys = new Set<string>()
   for (const link of parentStylesheets) {
@@ -267,7 +322,7 @@ export async function syncParentHeadToChild(childWindow: WindowProxy) {
     if (!desiredStylesheetKeys.has(key)) link.parentNode?.removeChild(link)
   }
 
-  syncInlineStylesToChild(head, parentStyles)
+  syncInlineStylesToChild(head, snapshot)
 
   const currentKeys = new Set<string>()
   const currentSyncedLinks = Array.from(
@@ -292,7 +347,7 @@ export async function syncParentHeadToChild(childWindow: WindowProxy) {
 
   // sync className
   childWindow.document.documentElement.className =
-    document.documentElement.className
+    snapshot.documentElementClassName
 
   return Promise.all(styleLoadedPromises)
 }
@@ -300,10 +355,6 @@ export async function syncParentHeadToChild(childWindow: WindowProxy) {
 type SyncScheduleTiming = 'immediate' | 'delayed' | 'afterHostLayout'
 
 type HeadSyncScheduler = {
-  delayTimer?: number
-  immediateQueued: boolean
-  afterHostLayoutRaf?: number
-  afterHostLayoutComplete?: () => void
   disposed: boolean
 }
 
@@ -313,11 +364,309 @@ function getHeadSyncScheduler(childWindow: WindowProxy): HeadSyncScheduler {
   const prev = headSyncSchedulers.get(childWindow)
   if (prev) return prev
   const next: HeadSyncScheduler = {
-    immediateQueued: false,
     disposed: false,
   }
   headSyncSchedulers.set(childWindow, next)
   return next
+}
+
+type SyncTimingFromMutation = 'immediate' | 'delayed'
+
+type PendingWave = {
+  timing: SyncScheduleTiming
+  broadcast: boolean
+  targets: Set<WindowProxy>
+  onComplete: Map<WindowProxy, () => void>
+}
+
+const activeTargets = new Set<WindowProxy>()
+
+let headObserver: MutationObserver | null = null
+let domUpdatedHandler: (() => void) | null = null
+let originalInsertRule: CSSStyleSheet['insertRule'] | undefined
+let originalDeleteRule: CSSStyleSheet['deleteRule'] | undefined
+let pendingWave: PendingWave | null = null
+let flushQueued: SyncScheduleTiming | null = null
+let delayTimer: number | undefined
+let afterHostLayoutRaf: number | undefined
+
+const timingPriority: Record<SyncScheduleTiming, number> = {
+  delayed: 1,
+  afterHostLayout: 2,
+  immediate: 3,
+}
+
+function isParentHeadStyleSheet(sheet: CSSStyleSheet) {
+  const ownerNode = (sheet as CSSStyleSheet & { ownerNode?: Node }).ownerNode
+  if (
+    ownerNode instanceof HTMLStyleElement &&
+    ownerNode.ownerDocument === document &&
+    document.head.contains(ownerNode)
+  ) {
+    return true
+  }
+
+  return Array.from(document.head.querySelectorAll('style')).some(
+    style => style.sheet === sheet,
+  )
+}
+
+function getSyncTiming(
+  mutations?: MutationRecord[] | null,
+): SyncTimingFromMutation | null {
+  if (!Array.isArray(mutations) || mutations.length === 0) return null
+  let hasDelayed = false
+  for (const mutation of mutations) {
+    if (mutation.type === 'characterData') {
+      const parent = mutation.target.parentElement
+      if (parent?.tagName === 'STYLE') return 'immediate'
+    }
+
+    const nodes: Node[] = [
+      mutation.target,
+      ...Array.from(mutation.addedNodes),
+      ...Array.from(mutation.removedNodes),
+    ]
+    for (const node of nodes) {
+      if (!(node instanceof Element)) continue
+      const tag = node.tagName
+      if (tag === 'STYLE') return 'immediate'
+      if (tag === 'LINK') {
+        const { rel } = node as HTMLLinkElement
+        if (rel && rel.toLowerCase() === 'stylesheet') hasDelayed = true
+      }
+    }
+  }
+  return hasDelayed ? 'delayed' : null
+}
+
+function installCssomRuleObserver() {
+  if (typeof CSSStyleSheet === 'undefined' || originalInsertRule) return
+
+  originalInsertRule = CSSStyleSheet.prototype.insertRule
+  originalDeleteRule = CSSStyleSheet.prototype.deleteRule
+
+  CSSStyleSheet.prototype.insertRule = function patchedInsertRule(
+    rule: string,
+    index?: number,
+  ) {
+    const result = originalInsertRule!.call(this, rule, index)
+    if (isParentHeadStyleSheet(this)) {
+      enqueueParentHeadSync('immediate', { broadcast: true })
+    }
+    return result
+  }
+
+  CSSStyleSheet.prototype.deleteRule = function patchedDeleteRule(
+    index: number,
+  ) {
+    originalDeleteRule!.call(this, index)
+    if (isParentHeadStyleSheet(this)) {
+      enqueueParentHeadSync('immediate', { broadcast: true })
+    }
+  }
+}
+
+function uninstallCssomRuleObserver() {
+  if (originalInsertRule) {
+    CSSStyleSheet.prototype.insertRule = originalInsertRule
+  }
+  if (originalDeleteRule) {
+    CSSStyleSheet.prototype.deleteRule = originalDeleteRule
+  }
+  originalInsertRule = undefined
+  originalDeleteRule = undefined
+}
+
+function installParentHeadSyncRegistry() {
+  if (!headObserver) {
+    headObserver = new MutationObserver(mutations => {
+      const timing = getSyncTiming(mutations)
+      if (!timing) return
+      enqueueParentHeadSync(timing, { broadcast: true })
+    })
+    headObserver.observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    })
+  }
+
+  if (!domUpdatedHandler) {
+    domUpdatedHandler = () =>
+      enqueueParentHeadSync('afterHostLayout', { broadcast: true })
+    document.addEventListener(
+      SpatialStyleInfoUpdateEvent.domUpdated,
+      domUpdatedHandler,
+    )
+  }
+
+  installCssomRuleObserver()
+}
+
+function clearQueuedFlush() {
+  if (delayTimer) {
+    window.clearTimeout(delayTimer)
+    delayTimer = undefined
+  }
+  if (afterHostLayoutRaf) {
+    window.cancelAnimationFrame(afterHostLayoutRaf)
+    afterHostLayoutRaf = undefined
+  }
+  flushQueued = null
+}
+
+function teardownParentHeadSyncRegistry() {
+  headObserver?.disconnect()
+  headObserver = null
+
+  if (domUpdatedHandler) {
+    document.removeEventListener(
+      SpatialStyleInfoUpdateEvent.domUpdated,
+      domUpdatedHandler,
+    )
+    domUpdatedHandler = null
+  }
+
+  uninstallCssomRuleObserver()
+  clearQueuedFlush()
+  pendingWave = null
+}
+
+function teardownParentHeadSyncRegistryIfEmpty() {
+  if (activeTargets.size > 0) return
+  teardownParentHeadSyncRegistry()
+}
+
+function isWindowDisposed(childWindow: WindowProxy) {
+  return headSyncSchedulers.get(childWindow)?.disposed === true
+}
+
+function getOrCreatePendingWave(timing: SyncScheduleTiming) {
+  if (!pendingWave) {
+    pendingWave = {
+      timing,
+      broadcast: false,
+      targets: new Set(),
+      onComplete: new Map(),
+    }
+    return pendingWave
+  }
+
+  if (timingPriority[timing] > timingPriority[pendingWave.timing]) {
+    pendingWave.timing = timing
+  }
+  return pendingWave
+}
+
+async function flushHeadSyncWave() {
+  const wave = pendingWave
+  pendingWave = null
+  flushQueued = null
+  delayTimer = undefined
+  afterHostLayoutRaf = undefined
+  if (!wave) return
+
+  const targets = (
+    wave.broadcast ? Array.from(activeTargets) : Array.from(wave.targets)
+  ).filter(childWindow => !isWindowDisposed(childWindow))
+
+  if (targets.length === 0) return
+
+  const snapshot = captureParentHeadSnapshot()
+  await Promise.all(
+    targets.map(async childWindow => {
+      await syncParentHeadToChild(childWindow, snapshot)
+      wave.onComplete.get(childWindow)?.()
+    }),
+  )
+}
+
+function queuePendingWaveFlush(timing: SyncScheduleTiming) {
+  if (timing === 'delayed') {
+    if (flushQueued) return
+    flushQueued = 'delayed'
+    delayTimer = window.setTimeout(() => {
+      void flushHeadSyncWave()
+    }, 100)
+    return
+  }
+
+  if (delayTimer) {
+    window.clearTimeout(delayTimer)
+    delayTimer = undefined
+  }
+
+  if (timing === 'immediate') {
+    if (afterHostLayoutRaf) {
+      window.cancelAnimationFrame(afterHostLayoutRaf)
+      afterHostLayoutRaf = undefined
+    }
+    if (flushQueued === 'immediate') return
+    flushQueued = 'immediate'
+    queueMicrotask(() => {
+      if (flushQueued !== 'immediate') return
+      void flushHeadSyncWave()
+    })
+    return
+  }
+
+  if (flushQueued === 'immediate' || flushQueued === 'afterHostLayout') return
+
+  flushQueued = 'afterHostLayout'
+  queueMicrotask(() => {
+    if (flushQueued !== 'afterHostLayout') return
+    afterHostLayoutRaf = window.requestAnimationFrame(() => {
+      if (flushQueued !== 'afterHostLayout') return
+      void flushHeadSyncWave()
+    })
+  })
+}
+
+function enqueueParentHeadSync(
+  timing: SyncScheduleTiming,
+  options:
+    | { broadcast: true; onComplete?: never }
+    | {
+        broadcast?: false
+        childWindow: WindowProxy
+        onComplete?: () => void
+      },
+) {
+  const wave = getOrCreatePendingWave(timing)
+  if (options.broadcast) {
+    wave.broadcast = true
+  } else {
+    const scheduler = getHeadSyncScheduler(options.childWindow)
+    if (scheduler.disposed) return
+    wave.targets.add(options.childWindow)
+    if (options.onComplete) {
+      wave.onComplete.set(options.childWindow, options.onComplete)
+    }
+  }
+  queuePendingWaveFlush(wave.timing)
+}
+
+export function registerParentHeadSyncTarget(
+  childWindow: WindowProxy,
+  options?: { immediate?: boolean },
+) {
+  const scheduler = getHeadSyncScheduler(childWindow)
+  scheduler.disposed = false
+  activeTargets.add(childWindow)
+  installParentHeadSyncRegistry()
+
+  if (options?.immediate ?? true) {
+    scheduleSyncParentHeadToChild(childWindow)
+  }
+
+  let unregistered = false
+  return () => {
+    if (unregistered) return
+    unregistered = true
+    activeTargets.delete(childWindow)
+    teardownParentHeadSyncRegistryIfEmpty()
+  }
 }
 
 /**
@@ -330,63 +679,27 @@ export function scheduleSyncParentHeadToChild(
   timing: SyncScheduleTiming = 'immediate',
   onComplete?: () => void,
 ) {
-  const scheduler = getHeadSyncScheduler(childWindow)
-  if (scheduler.disposed) return
-
-  const run = () => {
-    if (scheduler.disposed) return
-    void syncParentHeadToChild(childWindow).then(() => {
-      if (timing === 'afterHostLayout') {
-        const complete = scheduler.afterHostLayoutComplete
-        scheduler.afterHostLayoutComplete = undefined
-        complete?.()
-      }
-    })
-  }
-
-  if (timing === 'delayed') {
-    if (scheduler.delayTimer) window.clearTimeout(scheduler.delayTimer)
-    scheduler.delayTimer = window.setTimeout(run, 100)
-    return
-  }
-
-  if (scheduler.delayTimer) {
-    window.clearTimeout(scheduler.delayTimer)
-    scheduler.delayTimer = undefined
-  }
-
-  if (timing === 'afterHostLayout') {
-    if (onComplete) {
-      scheduler.afterHostLayoutComplete = onComplete
-    }
-    if (scheduler.afterHostLayoutRaf != null) {
-      return
-    }
-    queueMicrotask(() => {
-      if (scheduler.disposed || scheduler.afterHostLayoutRaf != null) return
-      scheduler.afterHostLayoutRaf = window.requestAnimationFrame(() => {
-        scheduler.afterHostLayoutRaf = undefined
-        run()
-      })
-    })
-    return
-  }
-
-  if (scheduler.immediateQueued) return
-  scheduler.immediateQueued = true
-  queueMicrotask(() => {
-    scheduler.immediateQueued = false
-    run()
+  enqueueParentHeadSync(timing, {
+    broadcast: false,
+    childWindow,
+    onComplete: timing === 'afterHostLayout' ? onComplete : undefined,
   })
 }
 
 export function disposeSyncParentHeadToChild(childWindow: WindowProxy) {
   const scheduler = headSyncSchedulers.get(childWindow)
-  if (!scheduler) return
-  scheduler.disposed = true
-  if (scheduler.delayTimer) window.clearTimeout(scheduler.delayTimer)
-  if (scheduler.afterHostLayoutRaf) {
-    window.cancelAnimationFrame(scheduler.afterHostLayoutRaf)
-  }
+  if (scheduler) scheduler.disposed = true
+  activeTargets.delete(childWindow)
+  teardownParentHeadSyncRegistryIfEmpty()
   headSyncSchedulers.delete(childWindow)
+}
+
+export const __parentHeadSyncRegistryTest__ = {
+  getActiveTargetCount: () => activeTargets.size,
+  getObserverInstalled: () => headObserver != null,
+  flushPendingWaveForTest: flushHeadSyncWave,
+  reset: () => {
+    activeTargets.clear()
+    teardownParentHeadSyncRegistry()
+  },
 }

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -67,6 +67,14 @@ function copyParentStyleAttributes(
   source: HTMLStyleElement,
   target: HTMLStyleElement,
 ) {
+  const sourceAttrNames = new Set(
+    Array.from(source.attributes, attr => attr.name),
+  )
+  for (const attr of Array.from(target.attributes)) {
+    if (attr.name === WEBSPATIAL_SYNC_ATTR) continue
+    if (!sourceAttrNames.has(attr.name)) target.removeAttribute(attr.name)
+  }
+
   for (const attr of Array.from(source.attributes)) {
     if (attr.name === WEBSPATIAL_SYNC_ATTR) continue
     target.setAttribute(attr.name, attr.value)
@@ -115,9 +123,7 @@ function applyFullTextStyleSync(
       // Fall through to textContent assignment.
     }
   }
-  if (target.textContent !== text) {
-    target.textContent = text
-  }
+  target.textContent = text
 }
 
 /**

--- a/packages/react/src/utils/windowStyleSync.ts
+++ b/packages/react/src/utils/windowStyleSync.ts
@@ -350,6 +350,11 @@ export function scheduleSyncParentHeadToChild(
     return
   }
 
+  if (scheduler.delayTimer) {
+    window.clearTimeout(scheduler.delayTimer)
+    scheduler.delayTimer = undefined
+  }
+
   if (timing === 'afterHostLayout') {
     if (onComplete) {
       scheduler.afterHostLayoutComplete = onComplete


### PR DESCRIPTION
## Summary

Fixes #1265.

Fixes SpatialDiv portal head synchronization for CSS-in-JS runtimes (styled-components and similar). The branch removes the flicker where a portal element receives a new styled-components class before the matching parent `<style>` rule has been mirrored into the child portal webview.

This PR also coalesces head sync across multiple active portals so nested SpatialDivs and pages with many SpatialDivs do not multiply observer and parent-head read costs linearly.

## Problem

On `main`, prop-driven styled-components updates inside a SpatialDiv can briefly render with the new class but without the matching CSS rule in the portal child window. Dragging an opacity slider on visionOS/PICO is the most visible repro.

Contributing gaps on `main`:

- `syncParentHeadToChild` cloned `<style>` nodes and missed CSSOM-only updates (`insertRule` / `deleteRule`).
- `useSyncHeadStyles(..., { subtree: false })` skipped `characterData` updates inside existing `<style>` nodes.
- `MutationObserver` cannot see CSSOM-only styled-components updates.
- `useSync2DFrame` could refresh portal content before the child head was re-synced.
- Each active portal installed its own head observer and re-read the full parent head on every change (O(N) cost for N portals).

## Solution

### Correctness (styled-components / CSS-in-JS)

- Serialize parent rules from `style.sheet.cssRules` when available.
- Reuse synced portal `<style>` nodes in place and incrementally mirror rules via `insertRule` / `deleteRule`.
- Remove stale attributes when updating reused portal `<style>` nodes.
- Force full-text fallback after clearing target CSSOM rules so fallback cannot leave an empty stylesheet.
- Use a singleton parent-head registry that always observes `document.head` with `subtree: true` (caller `subtree: false` is ignored).
- Patch parent `CSSStyleSheet.insertRule` / `deleteRule` while sync targets are active and broadcast immediate sync to all active portals.
- Restore patched CSSOM methods only after the final active target unregisters.
- Run portal head sync on `afterHostLayout` before completing 2D-frame-triggered portal refreshes.
- Cancel pending delayed sync when immediate / after-host-layout sync supersedes it.

### Performance (many portals / nested SpatialDiv)

- Replace per-portal `MutationObserver` and `domUpdated` listeners with one global registry.
- Coalesce sync into waves:
  - **broadcast** waves (head mutation, CSSOM change, `domUpdated`) sync all active portals.
  - **single-target** waves (`scheduleSyncParentHeadToChild`, especially `afterHostLayout` from `useSync2DFrame`) sync only the requested portal.
- Capture one `ParentHeadSnapshot` per wave and fan it out to all target portal windows.

Portal head writes remain O(N) because each portal is a separate webview; this PR removes the redundant O(N) observer and parent-head read overhead.

## Demo / manual validation

New test-server route: `#/styledComponentsSpatialTest`

| Tab | What it exercises |
|-----|-------------------|
| Styled host | styled-components on the `enable-xr` host itself |
| Styled child | styled child inside a plain spatial shell |
| Styled title | title-related styled case |
| Nested | outer + inner nested SpatialDiv with styled-components |

Inspector helpers on the host tab:

- `window.__setStyledComponentsSpatialOpacity(value)`
- `window.__probeStyledComponentsSpatialHeadSync()`
- `window.__runStyledComponentsSpatialOpacitySweep(values?)`

Suggested device check (visionOS or PICO):

1. Open `#/styledComponentsSpatialTest`.
2. Drag opacity on **Styled host** and **Nested** tabs.
3. Expect no visible flash/flicker while class and synced head rules stay aligned.
4. Run `__runStyledComponentsSpatialOpacitySweep()` and confirm `mismatchFrames === 0`.

Related existing page: `#/head-style-sync` (link dedupe / stress for `<link rel=stylesheet>` sync).

## Regression coverage

`packages/react/src/utils/windowStyleSync.test.ts` (11 tests) and `useSyncHeadStyles.test.tsx` (3 tests) cover:

- mixed `<link>` + `<style>` mutation batches prefer immediate timing
- delayed sync cancelled when immediate supersedes it
- CSSOM `insertRule` broadcast to every active portal
- singleton global head observer (1 observer for N targets)
- one parent-head snapshot read per broadcast wave
- `afterHostLayout` scoped to requested portal + `onComplete`
- CSSOM prototype patch restored after final unregister
- synced `<style>` nodes reused in place (no duplicates)
- stale attributes removed from reused style nodes
- full-text fallback after inaccessible / cleared CSSOM
- stale async stylesheet loads cannot append after a newer sync

## Known limitations

- Portal head writes are still O(N) for N active portals (expected lower bound).
- `domUpdated` now triggers a broadcast `afterHostLayout` wave for all active portals (correctness-first; slightly more sync work on frequent DOM updates).
- Synced inline `<style>` nodes are paired by order, not by stable key. This is intentional for styled-components append/update flows, but devtools/HMR that reorder parent `<style>` nodes may need future keying.
- Custom `StyleSheetManager` targets outside the host `document.head` are not supported.

## Validation

```sh
pnpm install --frozen-lockfile
pnpm --filter @webspatial/react-sdk test          # 126 tests
pnpm --filter @webspatial/react-sdk build
pnpm --filter @webspatial/core-sdk build
```

Focused head-sync tests:

```sh
cd packages/react
pnpm exec vitest run src/utils/windowStyleSync.test.ts src/utils/useSyncHeadStyles.test.tsx
```

## Files of note

- `packages/react/src/utils/windowStyleSync.ts` — snapshot sync, registry, wave scheduler
- `packages/react/src/utils/useSyncHeadStyles.ts` — thin register/unregister wrapper
- `packages/react/src/spatialized-container/hooks/useSync2DFrame.ts` — sync before portal refresh
- `apps/test-server/src/pages/styledComponentsSpatialTest/` — manual matrix + nested case
- `.changeset/fix-head-style-cssom-sync.md` — `@webspatial/react-sdk` patch

Before Fix

https://github.com/user-attachments/assets/6e96f108-a30e-42bf-a2a5-f54dec8cb4de

After Fix 

https://github.com/user-attachments/assets/1d2a2bf4-3653-43e8-b2a3-25ae656eddfc

