### PR TITLE
fix: Model duration unavailable before playback

### DIFF
--- a/.changeset/tall-banks-attend.md
+++ b/.changeset/tall-banks-attend.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/platform-visionos': patch
+'web-content': patch
+'@webspatial/react-sdk': patch
+---
+
+fix: Model duration unavailable before playback

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -35,7 +35,7 @@ function App() {
         // src="/modelasset/cone.usdz"
         poster="/img/toy_drummer.png"
         enable-xr
-        autoPlay
+        autoPlay={false}
         loop={loop}
         style={{
           height: '200px',
@@ -91,7 +91,7 @@ function App() {
         <button
           className="btn m-1"
           onClick={() => {
-            if (modelRef.current?.currentTime) {
+            if (modelRef.current?.currentTime != undefined) {
               modelRef.current.currentTime -= 10
             }
           }}
@@ -113,7 +113,7 @@ function App() {
         <button
           className="btn m-1"
           onClick={() => {
-            if (modelRef.current?.currentTime) {
+            if (modelRef.current?.currentTime != undefined) {
               modelRef.current.currentTime += 10
             }
           }}

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -80,7 +80,9 @@ struct SpatializedStatic3DView: View {
                 }
             }
             .onChange(of: spatializedStatic3DElement.animationPaused) { onPlayback(isPaused: $1) }
-            .onChange(of: spatializedStatic3DElement.playbackRate) { asset?.animationPlaybackController?.speed = Float($1) }
+            .onChange(of: spatializedStatic3DElement.playbackRate) {
+                asset?.animationPlaybackController?.speed = spatializedStatic3DElement.animationPaused ? 0 : Float($1)
+            }
             .onChange(of: spatializedStatic3DElement.pendingSeekTime) { _, time in onSeek(time: time) }
             .task(id: spatializedStatic3DElement.allSources) { await loadSources() }
         } else {
@@ -122,7 +124,7 @@ struct SpatializedStatic3DView: View {
             asset.selectedAnimation = asset.availableAnimations.first
         }
         let controller = asset.animationPlaybackController
-        controller?.speed = Float(spatializedStatic3DElement.playbackRate)
+        controller?.speed = isPaused ? 0 : Float(spatializedStatic3DElement.playbackRate)
         if let time = spatializedStatic3DElement.pendingSeekTime, let controller {
             controller.time = time
             spatializedStatic3DElement.pendingSeekTime = nil
@@ -183,13 +185,11 @@ struct SpatializedStatic3DView: View {
         if let result {
             loadState = .loaded(result.asset, result.url.absoluteString)
             onLoadSuccess(src: result.url.absoluteString)
-            if spatializedStatic3DElement.autoplay {
-                // If animationPaused didn't change then SwiftUI will not trigger onChange so manually trigger playback
-                // This happens when play is called before load and autoplay is enabled
-                if spatializedStatic3DElement.animationPaused {
-                    spatializedStatic3DElement.animationPaused = false
-                } else { onPlayback(isPaused: false) }
-            }
+            // If animationPaused didn't change then SwiftUI will not trigger onChange so manually trigger playback
+            // This happens when play is called before load and autoplay is enabled
+            if spatializedStatic3DElement.autoplay, spatializedStatic3DElement.animationPaused {
+                spatializedStatic3DElement.animationPaused = false
+            } else { onPlayback(isPaused: !spatializedStatic3DElement.autoplay) }
         } else {
             loadState = .failed
             onLoadFailure()


### PR DESCRIPTION
On visionOS AnimationPlaybackController plays the animation when `speed` is non zero even if `pause()` is called. So always set `speed` to 0 when the animation should be paused.

Fixes #1142

<img width="1385" height="880" alt="Screenshot 2026-06-04 at 14 33 10" src="https://github.com/user-attachments/assets/82c8fcff-61e9-4a5a-8046-c4222c452609" />
