### PR TITLE
docs: align docs with current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ From repo root:
 
 - Package manager is `pnpm` (enforced by `preinstall`).
 - Pre-commit runs `lint-staged`; it rejects files >= 1MB and non-English (CJK) characters.
-- Keep PRs focused: avoid committing local artifacts (`.trae/`, `node_modules/`, build outputs).
+- Keep PRs focused: avoid committing untracked local artifacts (`node_modules/`, build outputs, temp tool scratch dirs). Tracked agent helper docs under `.trae/` are part of the repo.
 - **AI Agent Rule:** When refactoring, moving, or modifying existing code, DO NOT strip, delete, or rewrite existing inline comments unless explicitly instructed to do so. Retain all original developer context.
 - **AI Agent Rule:** Keep refactors (like moving files or renaming variables) strictly separate from logic changes to make PRs easier to review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to WebSpatial! This document provide
 ### Required Tools
 
 - [Node.js 22+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
-- [XCode >= 15.4](https://apps.apple.com/us/app/xcode/id497799835?mt=12) (If building for VisionOS)
+- [Xcode 26.x](https://apps.apple.com/us/app/xcode/id497799835?mt=12) with the Apple Vision Pro simulator (current CI selects Xcode 26.3 for visionOS builds)
 - [VSCode](https://code.visualstudio.com/) Text editor (recommended)
 
 ### Recommended Knowledge

--- a/docs/convertCoordinate.md
+++ b/docs/convertCoordinate.md
@@ -553,10 +553,10 @@ This two-step approach via the window coordinate system ensures cross-Reality co
 
 ## References
 
-- [`Vec3`](./Vec3.md) — 3D vector type used for positions
-- [`<Reality>`](./Reality.md) — Reality volume component
-- [`<Entity>`](./Entity.md) — Entity component and `EntityRef`
+- [`Vec3`](../packages/core/src/types/types.ts) — 3D vector type used for positions
+- [`<Reality>`](./dynamic-3d-api-prd.md#5-reality) — Reality volume component
+- [`<Entity>`](./dynamic-3d-api-prd.md#6-entity-group-container) — Entity component and `EntityRef`
 - [`<Model>`](./Model.md) — Model component and `ModelRef`
-- [`SpatializedElementRef`](./SpatializedContainer.md) — Spatialized container ref type
+- [`SpatializedElementRef`](../packages/react/src/spatialized-container/types.ts) — Spatialized container ref type
 - [RealityKit — Entity coordinate conversion](https://developer.apple.com/documentation/realitykit/entity/convert(position:from:))
 - [RealityKit — RealityViewContent](https://developer.apple.com/documentation/realitykit/realityviewcontent)

--- a/docs/dynamic-3d-api-prd.md
+++ b/docs/dynamic-3d-api-prd.md
@@ -168,7 +168,7 @@ For a **standalone** `<Model>` (single file, no `<Reality>` / scene graph), see 
 ```
 
 - **ModelAsset:** `id`, `src`, `onLoad?`, `onError?`. Relative `src` are resolved to absolute URLs. Formats (e.g. USDZ) follow platform support; see [Apple Quick Look](https://developer.apple.com/augmented-reality/quick-look/) and **`docs/Model.md`**.
-- **ModelEntity:** `model` (asset id), optional `materials?` (material override), `position?`, `rotation?`, `scale?`, and entity event handlers. Changing **`model`** after mount recreates that instance with the new asset. Changing **`materials`** reapplies overrides on the loaded model.
+- **ModelEntity:** `model` (asset id), optional `materials?` (material override), `position?`, `rotation?`, `scale?`, and entity event handlers. Changing **`model`** after mount recreates that instance with the new asset. Changing **`materials`** reapplies overrides on the loaded model. Avoid driving material overrides from high-frequency state: overlapping async updates can still apply out of order, and clearing `materials` does not currently restore the model asset's authored material set on visionOS.
 
 ---
 

--- a/packages/visionOS/CHANGELOG.md
+++ b/packages/visionOS/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @webspatial/platform-avp
+# @webspatial/platform-visionos
 
 ## 1.7.0
 


### PR DESCRIPTION
## Summary
- Clarify current `ModelEntity.materials` runtime caveats in the Dynamic 3D PRD.
- Update the visionOS package changelog heading and refresh the contributor Xcode prerequisite to match current CI.
- Replace `convertCoordinate` references to missing docs with existing docs/source paths, and clarify that tracked `.trae/` helper docs are part of the repo.
- Leave `docs/Model.md` unchanged so Model API documentation can be handled in a separate PR.

## Verification
- `node tools/scripts/check-valid-characters.js AGENTS.md CONTRIBUTING.md docs/Model.md docs/dynamic-3d-api-prd.md docs/convertCoordinate.md packages/visionOS/CHANGELOG.md`
- `node tools/scripts/check-filesize.js AGENTS.md CONTRIBUTING.md docs/Model.md docs/dynamic-3d-api-prd.md docs/convertCoordinate.md packages/visionOS/CHANGELOG.md`
- Confirmed `docs/Model.md` matches `origin/main`.
- `git diff --check`