### PR TITLE
docs: document agent skill mirrors

### DIFF
--- a/.coco/skills/README.md
+++ b/.coco/skills/README.md
@@ -1,3 +1,5 @@
 # Coco / OpenSpec skills
 
-OpenSpec **SKILL.md** workflows live here for tooling that resolves skills under `.coco/skills/`. They match the content under `.github/skills/` (see that README for the skill table and `openspec` CLI requirements).
+OpenSpec **SKILL.md** workflows live here for tooling that resolves skills under `.coco/skills/`. They are compatibility mirrors of the canonical OpenSpec skills under `.github/skills/`; keep mirrored `SKILL.md` files byte-for-byte identical unless Coco requires wrapper metadata.
+
+See `.github/skills/README.md` for the skill table, mirror policy, and `openspec` CLI requirements.

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -1,5 +1,5 @@
 # Cursor: OpenSpec skills
 
-Same OpenSpec **SKILL.md** workflows as `.github/skills/`, installed here so Cursor can load them as project skills without extra path configuration.
+Same OpenSpec **SKILL.md** workflows as `.github/skills/`, installed here so Cursor can load them as project skills without extra path configuration. These files are compatibility mirrors; keep mirrored `SKILL.md` files byte-for-byte identical unless Cursor requires wrapper metadata.
 
-See `.github/skills/README.md` for the table of skills and CLI requirements (`openspec`).
+See `.github/skills/README.md` for the table of skills, mirror policy, and CLI requirements (`openspec`).

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -2,6 +2,10 @@
 
 These directories contain **SKILL.md** instructions for AI coding agents working with [OpenSpec](https://github.com/Fission-AI/OpenSpec) in this repository (`openspec/` change proposals, tasks, and archives).
 
+This `.github/skills/` tree is the canonical checked-in copy for the OpenSpec skill text. The same OpenSpec skills are mirrored under `.coco/skills/`, `.codex/skills/`, `.cursor/skills/`, and `.trae/skills/` only so each tool can discover skills from its preferred path. Keep mirrored `SKILL.md` files byte-for-byte identical unless a specific tool requires wrapper metadata.
+
+Trae command files under `.trae/commands/opsx-*.md` are intentionally thin wrappers around the matching `.trae/skills/openspec-*/SKILL.md` files; put workflow behavior in the skill, not the command wrapper.
+
 | Skill | Purpose |
 | ----- | ------- |
 | `openspec-apply-change` | Implement tasks from an active OpenSpec change |

--- a/openspec/changes/archive/2026-04-21-runtime-feature-detection/capability-matrix.template.md
+++ b/openspec/changes/archive/2026-04-21-runtime-feature-detection/capability-matrix.template.md
@@ -62,7 +62,7 @@ Paste into row 1 of a spreadsheet:
 shellVersion	Model	Reality	Entity	BoxEntity	SphereEntity	ConeEntity	CylinderEntity	PlaneEntity	SceneGraph	ModelAsset	ModelEntity	UnlitMaterial	Material	AttachmentAsset	AttachmentEntity	'-xr-background-material'	'-xr-back'	'-xr-depth'	'-xr-transform'	SpatialTapEvent	SpatialDragStartEvent	SpatialDragEvent	SpatialDragEndEvent	SpatialRotateEvent	SpatialRotateEndEvent	SpatialMagnifyEvent	SpatialMagnifyEndEvent	useMetrics	convertCoordinate	initScene	WindowScene	VolumeScene	xrClientDepth	xrOffsetBack	xrInnerDepth	xrOuterDepth	Notes
 ```
 
-**CSV starters (open in Excel / Sheets):** [`capability-matrix/visionos-main.csv`](./capability-matrix/visionos-main.csv), [`capability-matrix/picoos-main.csv`](./capability-matrix/picoos-main.csv) — see [`capability-matrix/README.md`](./capability-matrix/README.md).
+CSV starter files are not committed in this archive. Use the tab-separated header row above to create a local spreadsheet if needed.
 
 ### 2.8 Optional — sub-token columns (same `shellVersion` rows)
 
@@ -82,7 +82,7 @@ Copy-paste header row for optional sub-tokens only:
 shellVersion	WindowScene:defaultSize	WindowScene:resizability	VolumeScene:defaultSize	VolumeScene:resizability	VolumeScene:worldScaling	VolumeScene:worldAlignment	VolumeScene:baseplateVisibility	Material:unlit	Model:autoplay	Model:loop	Model:stagemode	Model:poster	Model:loading	Model:source	Model:ready	Model:currentSrc	Model:entityTransform	Model:paused	Model:duration	Model:playbackRate	Model:play	Model:pause	Model:currentTime	SpatialRotateEvent:constrainedToAxis	Notes
 ```
 
-**CSV starters:** [`capability-matrix/visionos-subtokens.csv`](./capability-matrix/visionos-subtokens.csv), [`capability-matrix/picoos-subtokens.csv`](./capability-matrix/picoos-subtokens.csv).
+CSV starter files are not committed in this archive. Use the optional sub-token header row above to create a local spreadsheet if needed.
 
 ---
 


### PR DESCRIPTION
## Summary
- Document the canonical OpenSpec skill mirror policy in `.github/skills/README.md` and mirror README files.
- Keep Codex, Cursor, Trae, and Coco `SKILL.md` entry points unchanged; this PR does not change agent workflow behavior.
- Replace missing archived capability-matrix CSV starter links with instructions to use the committed tab-separated header rows.

## Verification
- `node tools/scripts/check-valid-characters.js` on all changed docs.
- `node tools/scripts/check-filesize.js` on all changed docs.
- Confirmed OpenSpec skill mirrors match `.github/skills` with `cmp` across `.coco`, `.codex`, `.cursor`, and `.trae`.
- Confirmed `.trae/commands/opsx-*` files match `origin/main` and are no longer part of the PR diff.
- `git diff --check`