### PR TITLE
spatialweb-event support multi-receivers

### DIFF
--- a/.changeset/fifty-geckos-hear.md
+++ b/.changeset/fifty-geckos-hear.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+`SpatialWebEvent` now supports multiple receivers per id

--- a/openspec/changes/spatial-web-event-multi-receivers/.openspec.yaml
+++ b/openspec/changes/spatial-web-event-multi-receivers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/spatial-web-event-multi-receivers/design.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`SpatialWebEvent` is the SDK's shared bridge for routing native-originated event payloads back into JavaScript. Multiple parts of the SDK register listeners under shared ids such as scene objects, window-level metric listeners, and one-shot platform adapter callbacks. This branch changes the internal storage from one callback per id to many callbacks per id, so the OpenSpec design needs to define registration, dispatch, and cleanup semantics explicitly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow one event id to fan out a payload to multiple registered receivers.
+- Support both full-id cleanup and single-callback removal.
+- Ensure internal storage is cleaned up after the last receiver is removed.
+- Preserve compatibility for existing single-receiver call sites.
+
+**Non-Goals:**
+- Changing the payload shape delivered to callbacks.
+- Introducing receiver ordering guarantees beyond the underlying collection semantics.
+- Adding receiver priorities, once-only listeners, or wildcard subscriptions.
+- Changing consumer-side event bubbling behavior in higher-level classes.
+
+## Decisions
+
+### Decision: Store receivers as Map of Sets
+
+Each event id maps to a `Set` of callbacks instead of a single callback value.
+
+```mermaid
+flowchart LR
+    A[event id] --> B[Map lookup]
+    B --> C[Set of receivers]
+    C --> D[receiver 1]
+    C --> E[receiver 2]
+    C --> F[receiver n]
+```
+
+Rationale:
+- `Map<string, Set<fn>>` keeps id lookup cheap and makes duplicate callback registration idempotent for the same function reference.
+- It matches the branch implementation and avoids overwriting earlier listeners.
+
+Alternative considered:
+- `Map<string, fn[]>`. Rejected because callback removal is less direct and duplicate entries are easier to accumulate accidentally.
+
+### Decision: Dispatch fans out to every receiver currently registered for the id
+
+When `window.__SpatialWebEvent` receives an `{ id, data }` payload, it loads the current receiver set for that id and invokes each callback with the same payload data. The dispatch loop must isolate per-receiver failures so one throwing callback does not prevent the remaining receivers from running.
+
+```mermaid
+sequenceDiagram
+    participant Native
+    participant Bridge as __SpatialWebEvent
+    participant Store as eventReceiver Map
+    participant R1 as receiver 1
+    participant R2 as receiver 2
+
+    Native->>Bridge: id and data
+    Bridge->>Store: get receivers by id
+    Store-->>Bridge: receiver set
+    Bridge->>R1: callback data
+    Bridge->>R2: callback data
+```
+
+Rationale:
+- This is the smallest change that fixes overwrite behavior while preserving the external API.
+- Shared ids such as `window` can now support more than one concurrent subscriber.
+- It keeps fan-out semantics reliable for shared ids where one subscriber should not be able to starve unrelated subscribers.
+
+Alternative considered:
+- Stop after the first callback that handles the event. Rejected because the branch behavior is explicit fan-out, not exclusive ownership.
+
+### Decision: Preserve two cleanup paths
+
+`removeEventReceiver(id, callback)` removes only the specified callback from the set. `removeEventReceiver(id)` removes the entire id entry and all registered callbacks.
+
+Rationale:
+- Existing call sites already rely on whole-id cleanup during destroy flows and one-shot request lifecycles.
+- The optional callback form supports precise removal for shared ids without breaking existing callers.
+
+Alternative considered:
+- Require a callback argument in all cases. Rejected because it would break existing destroy paths in this repository.
+
+### Decision: Delete empty sets immediately
+
+After a targeted removal, if the receiver set becomes empty, the id entry is removed from the `Map`.
+
+Rationale:
+- This keeps the registry aligned with active subscriptions only.
+- It avoids retaining empty containers after transient request ids or destroyed objects are cleaned up.
+
+## Risks / Trade-offs
+
+- Risk: shared ids may now trigger more callbacks than before. Mitigation: this is the intended contract, and the public API remains opt-in through explicit registration.
+- Risk: there is no explicit callback ordering guarantee. Mitigation: the spec defines fan-out and cleanup semantics only, not ordering semantics.
+- Risk: destroy paths that call full-id cleanup can still remove unrelated listeners if ids are shared carelessly. Mitigation: document the difference between targeted removal and whole-id removal, and keep whole-id cleanup for ids that are lifecycle-owned by a single object.
+
+## Migration Plan
+
+No migration is required for SDK consumers. Existing single-listener usage continues to work unchanged, while shared-id consumers can now register independently. Rollback is limited to restoring the previous single-callback storage and the older tests.
+
+## Open Questions
+
+None for this branch. The API surface remains the same, and the branch implementation already establishes the intended cleanup behavior.

--- a/openspec/changes/spatial-web-event-multi-receivers/design.zh.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/design.zh.md
@@ -1,0 +1,99 @@
+## Context
+
+`SpatialWebEvent` 是 SDK 中把 native 事件载荷路由回 JavaScript 的共享桥接层。SDK 的多个部分会在共享 id 下注册监听器，例如场景对象 窗口级物理度量监听器以及一次性平台适配回调。当前分支已经把内部存储从每个 id 一个回调改成了每个 id 多个回调，因此需要在 OpenSpec 中明确注册 分发 和清理语义。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 允许同一个事件 id 把一次载荷扇出到多个已注册 receiver。
+- 同时支持整组清理和单个 callback 精确移除。
+- 在最后一个 receiver 被移除后清空内部存储项。
+- 保持现有单 receiver 调用方的兼容性。
+
+**Non-Goals:**
+- 改变传递给 callback 的 payload 结构。
+- 在底层集合语义之外引入额外的 receiver 顺序保证。
+- 引入 receiver 优先级 一次性监听器 或通配订阅。
+- 改变上层类中的事件冒泡行为。
+
+## Decisions
+
+### Decision: 用 Map 和 Set 存储 receiver
+
+每个事件 id 不再映射到单个 callback，而是映射到一个 callback `Set`。
+
+```mermaid
+flowchart LR
+    A[event id] --> B[Map 查询]
+    B --> C[receiver 集合]
+    C --> D[receiver 1]
+    C --> E[receiver 2]
+    C --> F[receiver n]
+```
+
+原因:
+- `Map<string, Set<fn>>` 可以保持按 id 查询高效，同时对同一函数引用的重复注册天然幂等。
+- 这与当前分支实现一致，也能避免后注册监听器覆盖先注册监听器。
+
+备选方案:
+- `Map<string, fn[]>`。否决原因是移除 callback 不够直接，也更容易意外积累重复项。
+
+### Decision: 收到事件时向该 id 下所有 receiver 扇出分发
+
+当 `window.__SpatialWebEvent` 收到 `{ id, data }` 载荷时，系统会读取该 id 当前的 receiver 集合，并把同一份 `data` 传给全部 callback。分发循环必须隔离单个 receiver 的异常，避免某个 callback 抛错后阻止其余 receiver 继续执行。
+
+```mermaid
+sequenceDiagram
+    participant Native
+    participant Bridge as __SpatialWebEvent
+    participant Store as eventReceiver Map
+    participant R1 as receiver 1
+    participant R2 as receiver 2
+
+    Native->>Bridge: id 和 data
+    Bridge->>Store: 按 id 查询 receivers
+    Store-->>Bridge: receiver 集合
+    Bridge->>R1: callback data
+    Bridge->>R2: callback data
+```
+
+原因:
+- 这是修复覆盖问题所需的最小行为变更，同时保持外部 API 不变。
+- 像 `window` 这样的共享 id 现在可以被多个订阅者同时使用。
+- 这样可以保证共享 id 的扇出语义稳定，不会因为某一个订阅者失败而饿死其他无关订阅者。
+
+备选方案:
+- 找到第一个处理方后立即停止。否决原因是当前分支实现明确是 fan-out，而不是独占消费。
+
+### Decision: 保留两种清理路径
+
+`removeEventReceiver(id, callback)` 只移除指定 callback。`removeEventReceiver(id)` 则会删除整个 id 项及其全部 callback。
+
+原因:
+- 仓库内已有调用点依赖整组清理来处理 destroy 流程和一次性请求生命周期。
+- 可选 callback 形式可以为共享 id 提供精确移除能力，同时不破坏现有调用方。
+
+备选方案:
+- 强制所有调用都必须传 callback。否决原因是会破坏本仓库中的既有 destroy 路径。
+
+### Decision: 空集合立即删除
+
+在精确移除某个 callback 后，如果该 id 下的 receiver 集合已经为空，就立即从 `Map` 中删除该 id。
+
+原因:
+- 这样可以让注册表始终只反映活跃订阅。
+- 也能避免在临时请求 id 或已销毁对象清理后残留空容器。
+
+## Risks / Trade-offs
+
+- Risk: 共享 id 现在可能触发比以前更多的 callback。Mitigation: 这是本 change 的目标语义，且公开 API 仍然是显式注册才会生效。
+- Risk: 没有额外定义 callback 执行顺序保证。Mitigation: spec 只定义扇出和清理语义，不额外承诺顺序语义。
+- Risk: 对共享 id 使用整组清理时，仍可能误删其他监听器。Mitigation: 文档中明确区分精确移除和整组清理，并把整组清理保留给生命周期只归属单对象的 id。
+
+## Migration Plan
+
+对 SDK 使用方不需要迁移。已有单监听器用法保持不变，而共享 id 的使用方现在可以独立注册。若回滚，只需恢复旧的单 callback 存储和之前的测试即可。
+
+## Open Questions
+
+当前分支没有剩余开放问题。公开 API 保持不变，而实现已经明确了预期的清理行为。

--- a/openspec/changes/spatial-web-event-multi-receivers/proposal.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`SpatialWebEvent` previously treated each event id as a single callback slot, which caused later registrations to overwrite earlier ones. This change defines fan-out delivery for a shared id so multiple SDK subsystems can subscribe to the same native event stream without breaking each other.
+
+## What Changes
+
+- Allow a single `SpatialWebEvent` id to register multiple receivers at the same time.
+- Dispatch each inbound event payload to every receiver currently registered for that id.
+- Keep fan-out delivery running even if one receiver throws during dispatch.
+- Support removing one specific receiver without affecting the remaining receivers on the same id.
+- Keep `removeEventReceiver(id)` as the full-cleanup path that clears all receivers for that id.
+- Remove the id entry entirely after the last receiver is removed so internal state does not retain empty containers.
+- Preserve compatibility for single-receiver callers by keeping the public method names unchanged.
+
+## Capabilities
+
+### New Capabilities
+- `spatial-web-event-receivers`: Manage registration, dispatch, and cleanup semantics for one or more receivers attached to the same `SpatialWebEvent` id.
+
+### Modified Capabilities
+
+## Impact
+
+- Affects event routing in `packages/core/src/SpatialWebEvent.ts`.
+- Affects SDK consumers that share ids, including `SpatializedElement`, `SpatialEntity`, `SpatialComponent`, and platform adapter callbacks.
+- Affects behavior coverage in `packages/core/src/jsbcommand.coverage.test.ts`, `packages/core/src/physicalMetrics.test.ts`, and `packages/core/src/coverage-boost.test.ts`.

--- a/openspec/changes/spatial-web-event-multi-receivers/proposal.zh.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/proposal.zh.md
@@ -1,0 +1,26 @@
+## Why
+
+`SpatialWebEvent` 之前把每个事件 id 当成单一回调槽位，后注册的回调会覆盖先注册的回调。这个 change 为共享 id 定义扇出分发语义，让多个 SDK 子系统可以同时订阅同一个 native 事件流而不会互相破坏。
+
+## What Changes
+
+- 允许同一个 `SpatialWebEvent` id 同时注册多个 receiver。
+- 规定每次收到该 id 的事件载荷时，必须分发给当前注册的全部 receiver。
+- 即使某个 receiver 在分发过程中抛出异常，也要继续完成对其他 receiver 的扇出分发。
+- 支持移除某一个指定 receiver，而不影响同一 id 下的其他 receiver。
+- 保留 `removeEventReceiver(id)` 作为整组清理路径，用于清除该 id 下的全部 receiver。
+- 当最后一个 receiver 被移除后，删除对应 id 项，避免内部状态保留空容器。
+- 保持现有公开方法名不变，以兼容单 receiver 调用方。
+
+## Capabilities
+
+### New Capabilities
+- `spatial-web-event-receivers`: 管理同一个 `SpatialWebEvent` id 下一个或多个 receiver 的注册 分发 与清理语义。
+
+### Modified Capabilities
+
+## Impact
+
+- 影响 `packages/core/src/SpatialWebEvent.ts` 中的事件路由逻辑。
+- 影响共享 id 的 SDK 使用方，包括 `SpatializedElement` `SpatialEntity` `SpatialComponent` 和平台适配层回调。
+- 影响 `packages/core/src/jsbcommand.coverage.test.ts` `packages/core/src/physicalMetrics.test.ts` 和 `packages/core/src/coverage-boost.test.ts` 中的行为覆盖。

--- a/openspec/changes/spatial-web-event-multi-receivers/specs/spatial-web-event-receivers/spec.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/specs/spatial-web-event-receivers/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Event id can register multiple receivers
+The system MUST allow multiple receiver callbacks to be registered under the same `SpatialWebEvent` id without overwriting previously registered receivers.
+
+#### Scenario: Second receiver preserves first receiver
+- **WHEN** two different callbacks are registered for the same event id
+- **THEN** both callbacks MUST remain registered for that id
+
+#### Scenario: Duplicate callback registration is idempotent
+- **WHEN** the same callback reference is registered more than once for the same event id
+- **THEN** the system MUST keep only one active registration for that callback reference
+
+### Requirement: Dispatch fans out to all receivers for the id
+The system MUST dispatch each inbound `SpatialWebEvent` payload to every receiver currently registered for the payload id.
+
+#### Scenario: Payload is delivered to every receiver
+- **WHEN** `window.__SpatialWebEvent` receives an event for an id with multiple registered receivers
+- **THEN** every registered receiver for that id MUST be invoked with the event data
+
+#### Scenario: One receiver failure does not stop fan-out
+- **WHEN** one receiver throws while `window.__SpatialWebEvent` is dispatching an event for an id with multiple registered receivers
+- **THEN** the system MUST continue invoking the remaining registered receivers for that id
+
+#### Scenario: Unknown id is ignored
+- **WHEN** `window.__SpatialWebEvent` receives an event for an id with no registered receivers
+- **THEN** the system MUST complete without invoking any receiver
+
+### Requirement: Receiver cleanup supports targeted and full removal
+The system MUST support removing a specific receiver for an id and removing all receivers for an id.
+
+#### Scenario: Targeted removal keeps other receivers
+- **WHEN** a specific callback is removed from an id that still has other callbacks
+- **THEN** the removed callback MUST no longer receive events
+- **AND** the remaining callbacks for that id MUST continue receiving events
+
+#### Scenario: Full removal clears all receivers for id
+- **WHEN** `removeEventReceiver` is called for an id without a callback argument
+- **THEN** all receivers for that id MUST be removed
+
+#### Scenario: Empty receiver set is removed
+- **WHEN** the last receiver for an id is removed
+- **THEN** the internal receiver registry MUST no longer retain an entry for that id

--- a/openspec/changes/spatial-web-event-multi-receivers/specs/spatial-web-event-receivers/spec.zh.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/specs/spatial-web-event-receivers/spec.zh.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Event id can register multiple receivers
+系统 MUST 允许同一个 `SpatialWebEvent` id 注册多个 receiver callback，并且不会覆盖先前已注册的 receiver。
+
+#### Scenario: Second receiver preserves first receiver
+- **WHEN** 两个不同 callback 被注册到同一个事件 id
+- **THEN** 这两个 callback MUST 都保持在该 id 下处于已注册状态
+
+#### Scenario: Duplicate callback registration is idempotent
+- **WHEN** 同一个 callback 引用被多次注册到同一个事件 id
+- **THEN** 系统 MUST 只保留这个 callback 引用的一份有效注册
+
+### Requirement: Dispatch fans out to all receivers for the id
+系统 MUST 把每次收到的 `SpatialWebEvent` 载荷分发给该 id 当前注册的全部 receiver。
+
+#### Scenario: Payload is delivered to every receiver
+- **WHEN** `window.__SpatialWebEvent` 收到一个属于某 id 的事件，且该 id 下注册了多个 receiver
+- **THEN** 该 id 下的每个已注册 receiver MUST 都以该事件数据被调用
+
+#### Scenario: One receiver failure does not stop fan-out
+- **WHEN** `window.__SpatialWebEvent` 在向某个注册了多个 receiver 的 id 分发事件时，其中一个 receiver 抛出异常
+- **THEN** 系统 MUST 继续调用该 id 下其余已注册的 receiver
+
+#### Scenario: Unknown id is ignored
+- **WHEN** `window.__SpatialWebEvent` 收到一个没有任何 receiver 注册的 id 对应事件
+- **THEN** 系统 MUST 正常完成处理，且不调用任何 receiver
+
+### Requirement: Receiver cleanup supports targeted and full removal
+系统 MUST 同时支持移除某个 id 下的指定 receiver，以及移除该 id 下的全部 receiver。
+
+#### Scenario: Targeted removal keeps other receivers
+- **WHEN** 从某个仍然存在其他 callback 的 id 上移除了一个指定 callback
+- **THEN** 被移除的 callback MUST 不再接收事件
+- **AND** 该 id 下剩余的 callback MUST 继续接收事件
+
+#### Scenario: Full removal clears all receivers for id
+- **WHEN** 调用 `removeEventReceiver` 时只传入 id 而不传 callback
+- **THEN** 该 id 下的全部 receiver MUST 被移除
+
+#### Scenario: Empty receiver set is removed
+- **WHEN** 某个 id 的最后一个 receiver 被移除
+- **THEN** 内部 receiver 注册表 MUST 不再保留该 id 的条目

--- a/openspec/changes/spatial-web-event-multi-receivers/tasks.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec and alignment
+
+- [x] 1.1 Add OpenSpec proposal, design, tasks, and spec files for multi-receiver `SpatialWebEvent` behavior.
+- [x] 1.2 Align the documented receiver lifecycle with the branch implementation and existing consumer usage.
+
+## 2. Core event routing
+
+- [x] 2.1 Replace single-callback storage with a per-id multi-receiver registry.
+- [x] 2.2 Dispatch each inbound event payload to all receivers currently registered for the id.
+- [x] 2.3 Support both targeted callback removal and whole-id cleanup, and delete empty registry entries.
+
+## 3. Verification
+
+- [x] 3.1 Add or update tests that verify multiple receivers on the same id are all invoked.
+- [x] 3.2 Add or update tests that verify targeted removal leaves other receivers active.
+- [x] 3.3 Add or update tests that verify full removal clears the id entry for destroy and one-shot callback flows.
+- [x] 3.4 Add or update tests that verify one receiver failure does not stop fan-out to remaining receivers.

--- a/openspec/changes/spatial-web-event-multi-receivers/tasks.zh.md
+++ b/openspec/changes/spatial-web-event-multi-receivers/tasks.zh.md
@@ -1,0 +1,17 @@
+## 1. 规范与对齐
+
+- [x] 1.1 为 `SpatialWebEvent` 多 receiver 行为补充 OpenSpec 的 proposal design tasks 和 spec 文件。
+- [x] 1.2 让文档中的 receiver 生命周期说明与当前分支实现及现有调用方式保持一致。
+
+## 2. 核心事件路由
+
+- [x] 2.1 把单 callback 存储改为按 id 维护多 receiver 注册表。
+- [x] 2.2 将每次收到的事件载荷分发给该 id 当前注册的全部 receiver。
+- [x] 2.3 同时支持指定 callback 移除和整组 id 清理，并在集合为空时删除注册表项。
+
+## 3. 验证
+
+- [x] 3.1 增加或更新测试，验证同一个 id 下的多个 receiver 都会被调用。
+- [x] 3.2 增加或更新测试，验证精确移除某个 callback 后其他 receiver 仍然保持活跃。
+- [x] 3.3 增加或更新测试，验证整组移除会为 destroy 与一次性回调流程清空对应 id 条目。
+- [x] 3.4 增加或更新测试，验证某个 receiver 抛出异常后不会阻止其余 receiver 继续完成扇出分发。

--- a/packages/core/src/SpatialWebEvent.ts
+++ b/packages/core/src/SpatialWebEvent.ts
@@ -4,20 +4,44 @@ interface SpatialWebEventData {
 }
 
 export class SpatialWebEvent {
-  static eventReceiver: Record<string, (data: any) => void> = {}
+  static eventReceiver: Map<string, Set<(data: any) => void>> = new Map()
   static init() {
     // inject __SpatialWebEvent
     window.__SpatialWebEvent = ({ id, data }: SpatialWebEventData) => {
       // console.log('__SpatialWebEvent', id, data)
-      SpatialWebEvent.eventReceiver[id]?.(data)
+      // Snapshot receivers so one callback cannot affect fan-out delivery.
+      const receivers = Array.from(SpatialWebEvent.eventReceiver.get(id) ?? [])
+      receivers.forEach(fn => {
+        try {
+          fn(data)
+        } catch (error) {
+          // Isolate receiver failures so remaining subscribers still run.
+          console.error('SpatialWebEvent receiver failed', id, error)
+        }
+      })
     }
   }
 
   static addEventReceiver(id: string, callback: (data: any) => void) {
-    SpatialWebEvent.eventReceiver[id] = callback
+    // A single `id` can have multiple receivers.
+    if (!SpatialWebEvent.eventReceiver.has(id)) {
+      SpatialWebEvent.eventReceiver.set(id, new Set())
+    }
+    SpatialWebEvent.eventReceiver.get(id)!.add(callback)
   }
 
-  static removeEventReceiver(id: string) {
-    delete SpatialWebEvent.eventReceiver[id]
+  static removeEventReceiver(id: string, callback?: (data: any) => void) {
+    // If callback is omitted, remove all receivers for the id.
+    if (!callback) {
+      SpatialWebEvent.eventReceiver.delete(id)
+      return
+    }
+
+    const receivers = SpatialWebEvent.eventReceiver.get(id)
+    if (!receivers) return
+    receivers.delete(callback)
+    if (receivers.size === 0) {
+      SpatialWebEvent.eventReceiver.delete(id)
+    }
   }
 }

--- a/packages/core/src/SpatialWebEvent.ts
+++ b/packages/core/src/SpatialWebEvent.ts
@@ -4,7 +4,8 @@ interface SpatialWebEventData {
 }
 
 export class SpatialWebEvent {
-  static eventReceiver: Map<string, Set<(data: any) => void>> = new Map()
+  private static readonly eventReceiver: Map<string, Set<(data: any) => void>> =
+    new Map()
   static init() {
     // inject __SpatialWebEvent
     window.__SpatialWebEvent = ({ id, data }: SpatialWebEventData) => {

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -151,6 +151,60 @@ describe('SpatialWebEvent', () => {
     window.__SpatialWebEvent({ id: 'id1', data: { ok: false } })
     expect(cb).toHaveBeenCalledTimes(1)
   })
+
+  it('fans out to all receivers and keeps duplicate registration idempotent', () => {
+    SpatialWebEvent.init()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+
+    SpatialWebEvent.addEventReceiver('shared', cb1)
+    SpatialWebEvent.addEventReceiver('shared', cb1)
+    SpatialWebEvent.addEventReceiver('shared', cb2)
+
+    window.__SpatialWebEvent({ id: 'shared', data: { ok: true } })
+
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+  })
+
+  it('supports targeted removal and deletes empty receiver entries', () => {
+    SpatialWebEvent.init()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+
+    SpatialWebEvent.addEventReceiver('shared-remove', cb1)
+    SpatialWebEvent.addEventReceiver('shared-remove', cb2)
+
+    SpatialWebEvent.removeEventReceiver('shared-remove', cb1)
+    window.__SpatialWebEvent({ id: 'shared-remove', data: { ok: true } })
+
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(SpatialWebEvent.eventReceiver.get('shared-remove')).toBeDefined()
+
+    SpatialWebEvent.removeEventReceiver('shared-remove', cb2)
+    expect(SpatialWebEvent.eventReceiver.get('shared-remove')).toBeUndefined()
+  })
+
+  it('isolates receiver failures so remaining receivers still run', () => {
+    SpatialWebEvent.init()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const bad = vi.fn(() => {
+      throw new Error('boom')
+    })
+    const good = vi.fn()
+
+    SpatialWebEvent.addEventReceiver('shared-error', bad)
+    SpatialWebEvent.addEventReceiver('shared-error', good)
+
+    window.__SpatialWebEvent({ id: 'shared-error', data: { ok: true } })
+
+    expect(bad).toHaveBeenCalledTimes(1)
+    expect(good).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
 })
 
 describe('SpatialWebEventCreator', () => {
@@ -339,9 +393,10 @@ describe('platform adapters', () => {
     const platform = new VisionOSPlatform()
     const r = await platform.createNativeSpatialDiv()
 
-    expect(r.success).toBe(true)
-    expect(r.data?.id).toBe(uuid)
-    expect(r.data?.windowProxy).toBe(windowProxy)
+    expect(r).toMatchObject({
+      success: true,
+      data: { id: uuid, windowProxy },
+    })
   })
 })
 

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -167,7 +167,7 @@ describe('SpatialWebEvent', () => {
     expect(cb2).toHaveBeenCalledTimes(1)
   })
 
-  it('supports targeted removal and deletes empty receiver entries', () => {
+  it('supports targeted removal and stops delivery once all receivers are removed', () => {
     SpatialWebEvent.init()
     const cb1 = vi.fn()
     const cb2 = vi.fn()
@@ -180,10 +180,11 @@ describe('SpatialWebEvent', () => {
 
     expect(cb1).not.toHaveBeenCalled()
     expect(cb2).toHaveBeenCalledTimes(1)
-    expect(SpatialWebEvent.eventReceiver.get('shared-remove')).toBeDefined()
 
     SpatialWebEvent.removeEventReceiver('shared-remove', cb2)
-    expect(SpatialWebEvent.eventReceiver.get('shared-remove')).toBeUndefined()
+    window.__SpatialWebEvent({ id: 'shared-remove', data: { ok: false } })
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledTimes(1)
   })
 
   it('isolates receiver failures so remaining receivers still run', () => {

--- a/packages/core/src/jsbcommand.coverage.test.ts
+++ b/packages/core/src/jsbcommand.coverage.test.ts
@@ -436,6 +436,7 @@ describe('SpatializedElement', () => {
   it('removes event receiver on destroy', async () => {
     const { SpatialWebEvent } = await import('./SpatialWebEvent')
     const { SpatializedElement } = await import('./SpatializedElement')
+    const { SpatialWebMsgType } = await import('./WebMsgCommand')
 
     SpatialWebEvent.init()
 
@@ -449,9 +450,27 @@ describe('SpatializedElement', () => {
     }
 
     const e = new TestElement('el4')
-    expect(SpatialWebEvent.eventReceiver.el4).toBeDefined()
+    const onTap = vi.fn()
+    e.onSpatialTap = onTap
+
+    window.__SpatialWebEvent({
+      id: 'el4',
+      data: {
+        type: SpatialWebMsgType.spatialtap,
+        detail: { location3D: { x: 1, y: 2, z: 3 } },
+      },
+    })
+    expect(onTap).toHaveBeenCalledTimes(1)
+
     await e.destroy()
-    expect(SpatialWebEvent.eventReceiver.el4).toBeUndefined()
+    window.__SpatialWebEvent({
+      id: 'el4',
+      data: {
+        type: SpatialWebMsgType.spatialtap,
+        detail: { location3D: { x: 4, y: 5, z: 6 } },
+      },
+    })
+    expect(onTap).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/core/src/physicalMetrics.test.ts
+++ b/packages/core/src/physicalMetrics.test.ts
@@ -107,4 +107,43 @@ describe('physicalMetrics', () => {
     expect(m.getValue().meterToPtUnscaled).toBe(400)
     ;(window as any).__webspatialsdk__ = undefined
   })
+
+  test('subscribe supports multiple concurrent subscribers', async () => {
+    const m = await loadModule()
+    const { SpatialWebEvent } = await import('./SpatialWebEvent')
+    SpatialWebEvent.init()
+
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+    const unsubscribe1 = m.subscribe(cb1)
+    const unsubscribe2 = m.subscribe(cb2)
+
+    ;(window as any).__webspatialsdk__ = {
+      physicalMetrics: {
+        meterToPtScaled: 900,
+        meterToPtUnscaled: 800,
+      },
+    }
+    window.__SpatialWebEvent({ id: 'window', data: {} })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(m.getValue().meterToPtScaled).toBe(900)
+    expect(m.getValue().meterToPtUnscaled).toBe(800)
+
+    unsubscribe1()
+    ;(window as any).__webspatialsdk__ = {
+      physicalMetrics: {
+        meterToPtScaled: 700,
+        meterToPtUnscaled: 600,
+      },
+    }
+    window.__SpatialWebEvent({ id: 'window', data: {} })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(2)
+    expect(m.getValue().meterToPtScaled).toBe(700)
+    expect(m.getValue().meterToPtUnscaled).toBe(600)
+
+    unsubscribe2()
+    ;(window as any).__webspatialsdk__ = undefined
+  })
 })

--- a/packages/core/src/physicalMetrics.ts
+++ b/packages/core/src/physicalMetrics.ts
@@ -96,6 +96,7 @@ export function subscribe(cb: () => void) {
   // receive metrics update from native via SpatialWebEvent, id: "window"
   SpatialWebEvent.addEventReceiver('window', handler)
   return () => {
-    SpatialWebEvent.removeEventReceiver('window')
+    // Remove only this subscription's handler to avoid breaking other subscribers.
+    SpatialWebEvent.removeEventReceiver('window', handler)
   }
 }

--- a/packages/core/src/platform-adapter/spatialRequestMetadata.test.ts
+++ b/packages/core/src/platform-adapter/spatialRequestMetadata.test.ts
@@ -78,6 +78,7 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
     SpatialWebEvent.init()
     const open = vi.fn(() => null)
     vi.spyOn(window, 'open').mockImplementation(open)
+    const removeReceiverSpy = vi.spyOn(SpatialWebEvent, 'removeEventReceiver')
 
     const { PicoOSPlatform } = await import('./pico-os/PicoOSPlatform')
     const platform = new PicoOSPlatform()
@@ -100,7 +101,7 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
       success: true,
       data: { id: 'spatial-1' },
     })
-    expect(SpatialWebEvent.eventReceiver[requestId!]).toBeUndefined()
+    expect(removeReceiverSpy).toHaveBeenCalledWith(requestId!)
   })
 
   it('opens attachment protocol with rid and wsepoch', async () => {
@@ -109,6 +110,7 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
     SpatialWebEvent.init()
     const open = vi.fn(() => null)
     vi.spyOn(window, 'open').mockImplementation(open)
+    const removeReceiverSpy = vi.spyOn(SpatialWebEvent, 'removeEventReceiver')
 
     const { PicoOSPlatform } = await import('./pico-os/PicoOSPlatform')
     const platform = new PicoOSPlatform()
@@ -131,13 +133,15 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
       success: true,
       data: { id: 'attachment-1' },
     })
-    expect(SpatialWebEvent.eventReceiver[requestId!]).toBeUndefined()
+    expect(removeReceiverSpy).toHaveBeenCalledWith(requestId!)
   })
 
   it('times out pending SpatialDiv requests', async () => {
     vi.useFakeTimers()
     vi.spyOn(window, 'open').mockImplementation(() => null)
     const { SpatialWebEvent } = await import('../SpatialWebEvent')
+    SpatialWebEvent.init()
+    const removeReceiverSpy = vi.spyOn(SpatialWebEvent, 'removeEventReceiver')
 
     const { PicoOSPlatform } = await import('./pico-os/PicoOSPlatform')
     const { DEFAULT_SPATIAL_REQUEST_TIMEOUT_MS } = await import(
@@ -152,6 +156,6 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
       success: false,
       errorCode: 'E_SPATIAL_REQUEST_TIMEOUT',
     })
-    expect(Object.keys(SpatialWebEvent.eventReceiver)).toHaveLength(0)
+    expect(removeReceiverSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

This PR extracts the previously reviewed `SpatialWebEvent` multi-receiver change from #1136 into an independent PR targeting `main`.

The original change was merged into a non-main branch as part of #1136, but that branch has since removed this change. This PR reintroduces the same behavior as a standalone change so it can be reviewed and merged independently.

This branch also includes a follow-up cleanup to keep the new receiver registry encapsulated: `SpatialWebEvent.eventReceiver` is now private, and tests assert observable behavior instead of reading the internal storage directly.

## Background

`SpatialWebEvent` is the shared bridge used to route native-originated event payloads back into JavaScript. Some SDK subsystems register listeners under shared event ids, such as the `"window"` id used by physical metrics updates.

Previously, each event id could only hold one receiver callback. This meant:

* Later registrations overwrote earlier receivers for the same id.
* Removing one subscriber could accidentally remove the shared receiver and break other subscribers.
* Multiple consumers of the same native event stream could interfere with each other.

This was originally addressed in #1136 and reviewed there. Since that PR did not land in `main`, this PR separates the change and brings it back as an independent patch.

## Changes

* Change `SpatialWebEvent` receiver storage from one callback per id to multiple callbacks per id.
* Dispatch each incoming event payload to every receiver currently registered under the event id.
* Support targeted cleanup via `removeEventReceiver(id, callback)`, which removes only the specified receiver.
* Preserve the existing full-cleanup behavior of `removeEventReceiver(id)`, which removes all receivers for that id.
* Remove the id entry after the last receiver is removed to avoid retaining empty receiver sets.
* Keep the public API compatible for existing single-receiver call sites.
* Make the internal receiver registry private so callers and tests do not depend on the backing data structure.
* Replace direct internal-state assertions with behavior-driven coverage for cleanup and unsubscribe semantics.
* Add OpenSpec proposal, design, and requirement docs for the multi-receiver behavior.
* Add/update test coverage for multi-subscriber behavior and cleanup semantics.

## Compatibility

This should be backward compatible for existing callers:

* Existing `addEventReceiver(id, callback)` usage continues to work.
* Existing `removeEventReceiver(id)` usage still removes all receivers for the id.
* Callers that share an id can now use `removeEventReceiver(id, callback)` to unsubscribe without affecting other receivers.

## Testing

This PR includes behavior coverage for:

* Multiple receivers registered under the same `SpatialWebEvent` id.
* Fan-out dispatch to all active receivers.
* Removing one receiver without affecting the others.
* Stopping delivery once the last receiver is removed.
* `SpatializedElement.destroy()` no longer receiving events after cleanup.
* Pico OS request correlation cleanup paths on success and timeout.
* Existing single-receiver cleanup paths.

Validation run for this branch:

* `pnpm --filter @webspatial/core-sdk test`
* `pnpm exec tsc -p apps/test-server/tsconfig.json`
* `npm run test`

## Related PR

* Based on the previously reviewed change in #1136.
