### PR TITLE
fix(visionos): recreate scene when WindowGroup data is stale

### DIFF
--- a/.changeset/visionos-windowgroup-scene-recreate.md
+++ b/.changeset/visionos-windowgroup-scene-recreate.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Recreate the spatial scene when visionOS `WindowGroup` window data references a missing scene ID, instead of force-unwrapping nil. Read volume resize limits from the active scene config after recreation.
+
+---

--- a/packages/visionOS/web-spatial/WebSpatialApp.swift
+++ b/packages/visionOS/web-spatial/WebSpatialApp.swift
@@ -40,13 +40,31 @@ struct WebSpatialApp: App {
         )
     }
 
+    func getSceneOrCreate(_ sceneID: String?, _ style: SpatialScene.WindowStyle) -> SpatialScene {
+        if let sceneID, let spatialScene = SpatialApp.Instance.getScene(sceneID) {
+            return spatialScene
+        }
+
+        logger.debug("Missing scene for WindowGroup data. Recreating scene.")
+        return SpatialApp.Instance.createScene(
+            startURL,
+            style,
+            .visible,
+            app.getSceneOptions()
+        )
+    }
+
+    func getSceneOrCreate(_ sceneID: String, _ style: SpatialScene.WindowStyle) -> SpatialScene {
+        return getSceneOrCreate(Optional(sceneID), style)
+    }
+
     var body: some Scene {
         WindowGroup(
             id: SpatialScene.WindowStyle.window.rawValue,
             for: String.self
         ) { $windowData in
-            let spatialScene = SpatialApp.Instance.getScene(windowData)
-            SpatialSceneView(spatialScene: spatialScene!)
+            let spatialScene = getSceneOrCreate(windowData, .window)
+            SpatialSceneView(spatialScene: spatialScene)
         }
         defaultValue: {
             let scene = SpatialApp.Instance.createScene(
@@ -66,20 +84,20 @@ struct WebSpatialApp: App {
         )
 
         WindowGroup(id: SpatialScene.WindowStyle.volume.rawValue, for: String.self) { $windowData in
-            let spatialScene = SpatialApp.Instance.getScene(windowData)
-            SpatialSceneView(spatialScene: spatialScene!)
+            let spatialScene = getSceneOrCreate(windowData, .volume)
+            SpatialSceneView(spatialScene: spatialScene)
                 .frame(
                     minWidth: getCGFloat(
-                        app.getSceneOptions(windowData)?.resizeRange?.minWidth
+                        spatialScene.sceneConfig?.resizeRange?.minWidth
                     ),
                     maxWidth: getCGFloat(
-                        app.getSceneOptions(windowData)?.resizeRange?.maxWidth
+                        spatialScene.sceneConfig?.resizeRange?.maxWidth
                     ),
                     minHeight: getCGFloat(
-                        app.getSceneOptions(windowData)?.resizeRange?.minHeight
+                        spatialScene.sceneConfig?.resizeRange?.minHeight
                     ),
                     maxHeight: getCGFloat(
-                        app.getSceneOptions(windowData)?.resizeRange?.maxHeight
+                        spatialScene.sceneConfig?.resizeRange?.maxHeight
                     )
                 )
         }


### PR DESCRIPTION
## Summary

- Add `getSceneOrCreate()` in `WebSpatialApp` so window/volume `WindowGroup` entries recreate a spatial scene when the stored scene ID is missing or stale, instead of force-unwrapping nil.
- Read volume resize limits from `spatialScene.sceneConfig` so recreated scenes use the active scene configuration.

## Context

This is a visionOS shell **defensive** fix, independent of Radix / SpatialDiv portal work (#1231).

Today `WebSpatialApp` does:

```swift
let spatialScene = SpatialApp.Instance.getScene(windowData)
SpatialSceneView(spatialScene: spatialScene!)
```

If SwiftUI `WindowGroup(for: String.self)` re-renders with a scene ID that is no longer in `SpatialApp.scenes` (for example after `SceneHandlerUIView.onDisappear` calls `spatialScene.destroy()`), the force-unwrap crashes the app.

This change removes the crash by recreating a scene when lookup fails. It was originally bundled into #1231 and split out here to keep that PR focused on `useSpatialPortalContainer()`.

## Repro status

**No stable manual repro is documented in the repo.** Candidate paths below are plausible from code review but are **not guaranteed** to crash on `main`:

**Path A — `#/scene` → `window.open` → close child window**

Normal close order is usually `dismissWindow` while the scene still exists, then `destroy()` on disappear. Manual testing has **not** reliably reproduced a crash on `main`.

**Path B — Xcode Stop/Run without resetting Simulator**

Process memory is cleared while WindowGroup state may restore a stale scene ID. Worth trying, but also not confirmed as a stable repro.

**Not related:** SPA back/forward/reload via `resetForNavigation()` destroys page spatial objects, not entries in `SpatialApp.scenes`.

## Verify fix

- [ ] Build `web-spatial` for visionOS Simulator
- [ ] Smoke-test cold start, `#/scene`, and child `window.open` / close on this branch
- [ ] Optional: try Path A/B on `main` vs this branch; a successful fix may only show as Console log `Missing scene for WindowGroup data. Recreating scene.` rather than a visible crash
- [ ] Confirm normal navigation still works after merge

## Review note

Treat this as hardening against a rare WindowGroup/scene lifecycle race, not as a fix for a confirmed always-repro user bug. Merging is reasonable if the nil-safe behavior and smoke tests look good, even without a deterministic repro.