### PR TITLE
bugfix: wait for child document readiness before resolving spatial handoff

### DIFF
--- a/.changeset/fix-spatial-child-document-ready.md
+++ b/.changeset/fix-spatial-child-document-ready.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Fix spatial child window creation so platform handoff resolves only after the child document reaches `complete`. This avoids rare caller-side DOM write failures such as `TypeError: Cannot set properties of null (setting 'innerHTML')` when the returned window proxy still has a loading document.

--- a/packages/core/src/platform-adapter/pico-os/PicoOSPlatform.ts
+++ b/packages/core/src/platform-adapter/pico-os/PicoOSPlatform.ts
@@ -103,6 +103,7 @@ export class PicoOSPlatform implements PlatformAbility {
       const createdId = createSpatialRequestId()
       let settled = false
       let timeoutId: ReturnType<typeof setTimeout> | undefined
+      let cleanupDocumentReadyListener: (() => void) | undefined
 
       // Native creation may respond synchronously, asynchronously, or never.
       // Funnel every path through one settle() helper so receiver cleanup is
@@ -113,12 +114,50 @@ export class PicoOSPlatform implements PlatformAbility {
         if (timeoutId !== undefined) {
           clearTimeout(timeoutId)
         }
+        cleanupDocumentReadyListener?.()
+        cleanupDocumentReadyListener = undefined
         SpatialWebEvent.removeEventReceiver(createdId)
         resolve(result)
       }
 
       try {
         let windowProxy: WindowProxy | null = null
+        const settleWhenDocumentComplete = (spatialId: string) => {
+          const successResult = CommandResultSuccess({
+            windowProxy: windowProxy,
+            id: spatialId,
+          })
+          const childDocument = windowProxy?.document
+
+          if (!childDocument) {
+            settle(
+              CommandResultFailure(
+                'E_SPATIAL_DOCUMENT_UNAVAILABLE',
+                `${command} document is unavailable`,
+              ),
+            )
+            return
+          }
+
+          if (childDocument.readyState === 'complete') {
+            settle(successResult)
+            return
+          }
+
+          const onReadyStateChange = () => {
+            if (childDocument.readyState !== 'complete') return
+            settle(successResult)
+          }
+
+          cleanupDocumentReadyListener = () => {
+            childDocument.removeEventListener(
+              'readystatechange',
+              onReadyStateChange,
+            )
+          }
+          childDocument.addEventListener('readystatechange', onReadyStateChange)
+        }
+
         timeoutId = setTimeout(() => {
           settle(
             CommandResultFailure(
@@ -131,12 +170,7 @@ export class PicoOSPlatform implements PlatformAbility {
         SpatialWebEvent.addEventReceiver(
           createdId,
           (result: { spatialId: string }) => {
-            settle(
-              CommandResultSuccess({
-                windowProxy: windowProxy,
-                id: result.spatialId,
-              }),
-            )
+            settleWhenDocumentComplete(result.spatialId)
           },
         )
         windowProxy = this.openWindow(

--- a/packages/core/src/platform-adapter/spatialRequestMetadata.test.ts
+++ b/packages/core/src/platform-adapter/spatialRequestMetadata.test.ts
@@ -76,7 +76,16 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
     window.__webspatialsdk__ = { pageEpoch: '3' }
     const { SpatialWebEvent } = await import('../SpatialWebEvent')
     SpatialWebEvent.init()
-    const open = vi.fn(() => null)
+    const open = vi.fn(
+      () =>
+        ({
+          document: {
+            readyState: 'complete',
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          },
+        }) as unknown as Window,
+    )
     vi.spyOn(window, 'open').mockImplementation(open)
 
     const { PicoOSPlatform } = await import('./pico-os/PicoOSPlatform')
@@ -107,7 +116,16 @@ describe('PicoOSPlatform SpatialDiv request correlation', () => {
     window.__webspatialsdk__ = { pageEpoch: '4' }
     const { SpatialWebEvent } = await import('../SpatialWebEvent')
     SpatialWebEvent.init()
-    const open = vi.fn(() => null)
+    const open = vi.fn(
+      () =>
+        ({
+          document: {
+            readyState: 'complete',
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          },
+        }) as unknown as Window,
+    )
     vi.spyOn(window, 'open').mockImplementation(open)
 
     const { PicoOSPlatform } = await import('./pico-os/PicoOSPlatform')


### PR DESCRIPTION
bugfix: wait for child document readiness before resolving spatial handoff

rootcause: the native creation handoff can be resolved before the child window document reaches complete, so callers may receive a window proxy whose document is still loading.

symptom: in rare cases, DOM writes in the caller fail with `TypeError: Cannot set properties of null (setting 'innerHTML')` because document.head is not available yet.

solution: defer resolving the platform creation result until the child document readyState is complete, and fail early when no child document is available.