### PR TITLE
feat: Model add stagemode property web changes

### DIFF
--- a/.changeset/model-stagemode-orbit.md
+++ b/.changeset/model-stagemode-orbit.md
@@ -1,0 +1,6 @@
+---
+'@webspatial/core-sdk': minor
+'@webspatial/react-sdk': minor
+---
+
+Add a `stagemode` prop to `<Model>` for built-in orbit interaction. When set to `"orbit"`, the native layer drives the model's rotation via drag gestures, the `onSpatial*` handlers are disabled, and `entityTransform` becomes read-only (updated from native `entitytransformchange` events). The previous `modelTransform` property is renamed to `entityTransform`.

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -13,6 +13,7 @@ function App() {
   const [playbackRate, setPlaybackRate] = useState(1.0)
   const [loop, setLoop] = useState(true)
   const [loading, setLoading] = useState<'eager' | 'lazy'>('eager')
+  const [isOrbit, setIsOrbit] = useState(true)
   useEffect(() => {
     modelRef
       .current!.ready?.then(() => logLine('ref.current.ready success'))
@@ -37,6 +38,7 @@ function App() {
         enable-xr
         autoPlay={false}
         loop={loop}
+        stagemode={isOrbit ? 'orbit' : 'none'}
         style={{
           height: '200px',
           '--xr-depth': '100px',
@@ -138,6 +140,15 @@ function App() {
           />
           <span className="label-text m-1">Eager</span>
         </label>
+        <label className="inline-flex items-center align-middle">
+          <input
+            type="checkbox"
+            className="checkbox"
+            checked={isOrbit}
+            onChange={() => setIsOrbit(!isOrbit)}
+          />
+          <span className="label-text m-1">Orbit</span>
+        </label>
         <select
           className="select m-1"
           value={playbackRate}
@@ -165,6 +176,7 @@ function App() {
         enable-xr
         autoPlay
         loading={loading}
+        stagemode="orbit"
         style={{
           height: '200px',
           '--xr-depth': '100px',

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -4,6 +4,7 @@ import {
   ModelLoadingMode,
   ModelSource,
   SpatializedStatic3DElementProperties,
+  StageMode,
 } from './types/types'
 import {
   ModelLoadSuccess,
@@ -11,6 +12,7 @@ import {
   SpatialWebMsgType,
   AnimationStateChangeDetail,
   AnimationStateChangeMsg,
+  EntityTransformChangeMsg,
 } from './WebMsgCommand'
 
 /**
@@ -137,6 +139,9 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     }
     if (properties.loading !== undefined) {
       this._loading = properties.loading
+    }
+    if (properties.stagemode !== undefined) {
+      this._stagemode = properties.stagemode
     }
     return new UpdateSpatializedStatic3DElementProperties(
       this,
@@ -297,6 +302,8 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       this._currentTime = data.detail.currentTime ?? 0
       this._anchorTimestamp = data.detail.timestamp ?? Date.now()
       this._onAnimationStateChangeCallback?.(data.detail)
+    } else if (data.type === SpatialWebMsgType.entitytransformchange) {
+      this._entityTransform = new DOMMatrixReadOnly(data.detail.transform)
     } else {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data)
@@ -363,9 +370,35 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     this._onLoadFailureCallback = callback
   }
 
-  updateModelTransform(transform: DOMMatrixReadOnly) {
-    const modelTransform = Array.from(transform.toFloat64Array())
-    this.updateProperties({ modelTransform })
+  /**
+   * Built-in interaction mode. In `'orbit'` the native layer drives the
+   * transform and `entityTransform` is read-only.
+   */
+  private _stagemode: StageMode = 'none'
+
+  get stagemode(): StageMode {
+    return this._stagemode
+  }
+
+  /**
+   * Latest transform of the model, including native-driven manipulations such
+   * as orbit interaction.
+   */
+  private _entityTransform: DOMMatrixReadOnly = new DOMMatrixReadOnly()
+
+  get entityTransform(): DOMMatrixReadOnly {
+    return this._entityTransform
+  }
+
+  set entityTransform(transform: DOMMatrixReadOnly) {
+    // In orbit mode the native layer owns the transform, so ignore writes.
+    if (this._stagemode === 'orbit') return
+    this._entityTransform = transform
+    // The public API is `entityTransform`, but the JSB property stays
+    // `modelTransform` so the native side remains backward compatible.
+    this.updateProperties({
+      modelTransform: Array.from(transform.toFloat64Array()),
+    })
   }
 }
 
@@ -379,3 +412,4 @@ type Static3DReceiveEventData =
   | ModelLoadFailure
   | ReceiveEventData
   | AnimationStateChangeMsg
+  | EntityTransformChangeMsg

--- a/packages/core/src/WebMsgCommand.ts
+++ b/packages/core/src/WebMsgCommand.ts
@@ -21,6 +21,9 @@ export enum SpatialWebMsgType {
 
   animationstatechange = 'animationstatechange',
 
+  // Native-driven transform updates (e.g. while in `stagemode="orbit"`)
+  entitytransformchange = 'entitytransformchange',
+
   // Animation terminal events (keyed by animationId, not by this enum)
   animationcompleted = 'animationcompleted',
   animationstopped = 'animationstopped',
@@ -101,6 +104,16 @@ export interface AnimationStateChangeDetail {
 export interface AnimationStateChangeMsg {
   type: SpatialWebMsgType.animationstatechange
   detail: AnimationStateChangeDetail
+}
+
+export interface EntityTransformChangeDetail {
+  /** Column-major 4x4 matrix (16 numbers) representing the manipulated transform. */
+  transform: number[]
+}
+
+export interface EntityTransformChangeMsg {
+  type: SpatialWebMsgType.entitytransformchange
+  detail: EntityTransformChangeDetail
 }
 
 // Animation terminal event payloads (delivered via SpatialWebEvent keyed by animationId)

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -751,7 +751,7 @@ describe('SpatializedStatic3DElement', () => {
     vi.unmock('./JSBCommand')
   })
 
-  it('updateModelTransform passes float64 array to updateProperties', async () => {
+  it('entityTransform setter passes float64 array to updateProperties', async () => {
     const execute = vi.fn().mockResolvedValue({
       success: true,
       data: undefined,
@@ -803,7 +803,7 @@ describe('SpatializedStatic3DElement', () => {
     }
 
     const el = new SpatializedStatic3DElement('m2')
-    el.updateModelTransform(new DOMMatrixWithArray() as any)
+    el.entityTransform = new DOMMatrixWithArray() as any
     expect(execute).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -102,11 +102,14 @@ export interface ModelSource {
 
 export type ModelLoadingMode = 'eager' | 'lazy'
 
+export type StageMode = 'orbit' | 'none'
+
 export interface SpatializedStatic3DElementProperties
   extends SpatializedElementProperties {
   modelURL: string
   sources?: ModelSource[]
   modelTransform?: number[]
+  stagemode?: StageMode
   autoplay?: boolean
   loop?: boolean
   animationPaused?: boolean

--- a/packages/react/src/Model.tsx
+++ b/packages/react/src/Model.tsx
@@ -41,6 +41,23 @@ function ModelBase(props: ModelProps, ref: ForwardedRef<ModelRef>) {
     return <model ref={ref} {...modelProps} />
   }
 
+  // In orbit mode the native layer drives the model's transform, so the
+  // `onSpatial*` gesture handlers are disabled.
+  if (restProps.stagemode === 'orbit') {
+    const {
+      onSpatialTap,
+      onSpatialDragStart,
+      onSpatialDrag,
+      onSpatialDragEnd,
+      onSpatialRotate,
+      onSpatialRotateEnd,
+      onSpatialMagnify,
+      onSpatialMagnifyEnd,
+      ...orbitProps
+    } = restProps
+    return <SpatializedStatic3DElementContainer ref={ref} {...orbitProps} />
+  }
+
   return <SpatializedStatic3DElementContainer ref={ref} {...restProps} />
 }
 

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1809,10 +1809,12 @@ describe('SpatializedStatic3DElementContainer', () => {
     }))
 
     const updateProperties = vi.fn()
-    const updateModelTransform = vi.fn()
+    const setEntityTransform = vi.fn()
     const spatializedStatic3DElement: any = {
       updateProperties,
-      updateModelTransform,
+      set entityTransform(value: unknown) {
+        setEntityTransform(value)
+      },
       ready: Promise.resolve(true),
       currentSrc: window.location.origin + '/resolved.usdz',
       onLoadCallback: undefined,
@@ -1904,6 +1906,7 @@ describe('SpatializedStatic3DElementContainer', () => {
       loop: undefined,
       posterURL: '',
       loading: 'eager',
+      stagemode: 'none',
     })
 
     spatializedStatic3DElement.onLoadCallback?.()
@@ -1920,8 +1923,8 @@ describe('SpatializedStatic3DElementContainer', () => {
     const m = extra.entityTransform
     ;(m as any).m11 = 2
     extra.entityTransform = m
-    expect(updateModelTransform).toHaveBeenCalledTimes(1)
-    expect(updateModelTransform).toHaveBeenCalledWith(expect.any(DOMMatrix))
+    expect(setEntityTransform).toHaveBeenCalledTimes(1)
+    expect(setEntityTransform).toHaveBeenCalledWith(expect.any(DOMMatrix))
     expect((domProxy as any).entityTransform).toBeUndefined()
     ;(globalThis as any).requestAnimationFrame = originalRAF
   })
@@ -1937,7 +1940,6 @@ describe('SpatializedStatic3DElementContainer', () => {
 
     const spatializedStatic3DElement: any = {
       updateProperties: vi.fn(),
-      updateModelTransform: vi.fn(),
       ready: Promise.resolve(false),
     }
     const createSpatializedStatic3DElement = vi

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -18,10 +18,7 @@ import {
   SpatializedStatic3DContentProps,
   SpatializedStatic3DElementRef,
 } from './types'
-import {
-  ModelSource,
-  SpatializedStatic3DElement,
-} from '@webspatial/core-sdk'
+import { ModelSource, SpatializedStatic3DElement } from '@webspatial/core-sdk'
 import { PortalInstanceContext } from './context/PortalInstanceContext'
 
 function getAbsoluteURL(url: string): string
@@ -96,6 +93,7 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
     autoPlay,
     loop,
     loading = 'eager',
+    stagemode = 'none',
   } = props
   const portalInstanceObject = useContext(PortalInstanceContext)
   const wasVisible = useRef(false)
@@ -144,17 +142,16 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
       loop,
       posterURL: posterURL ?? '',
       loading: loading === 'lazy' && wasVisible.current ? 'eager' : loading,
+      stagemode,
     })
-  }, [modelURL, sourcesKey, autoPlay, loop, posterURL, loading])
+  }, [modelURL, sourcesKey, autoPlay, loop, posterURL, loading, stagemode])
 
   useEffect(() => {
     const dom = portalInstanceObject?.dom
     if (onLoad && dom) {
       spatializedElement.onLoadCallback = () => {
         onLoad(
-          createLoadSuccessEvent(
-            () => dom as SpatializedStatic3DElementRef,
-          ),
+          createLoadSuccessEvent(() => dom as SpatializedStatic3DElementRef),
         )
       }
     } else {
@@ -163,13 +160,11 @@ function SpatializedContent(props: SpatializedStatic3DContentProps) {
   }, [onLoad, portalInstanceObject?.dom])
 
   useEffect(() => {
-   const dom = portalInstanceObject?.dom
+    const dom = portalInstanceObject?.dom
     if (onError && dom) {
       spatializedElement.onLoadFailureCallback = () => {
         onError(
-          createLoadFailureEvent(
-            () => dom as SpatializedStatic3DElementRef,
-          ),
+          createLoadFailureEvent(() => dom as SpatializedStatic3DElementRef),
         )
       }
     } else {
@@ -196,7 +191,6 @@ function SpatializedStatic3DElementContainerBase(
   }, [])
   const extraRefProps = useCallback(
     (domProxy: SpatializedStatic3DElementRef) => {
-      let modelTransform = new DOMMatrixReadOnly()
       return {
         get currentSrc(): string {
           const spatializedElement = (domProxy as any).__spatializedElement as
@@ -213,14 +207,18 @@ function SpatializedStatic3DElementContainerBase(
             })
         },
         get entityTransform(): DOMMatrixReadOnly {
-          return modelTransform
-        },
-        set entityTransform(value: DOMMatrixReadOnly) {
-          modelTransform = value
           const spatializedElement = (domProxy as any).__spatializedElement as
             | SpatializedStatic3DElement
             | undefined
-          spatializedElement?.updateModelTransform(modelTransform)
+          return spatializedElement?.entityTransform ?? new DOMMatrixReadOnly()
+        },
+        set entityTransform(value: DOMMatrixReadOnly) {
+          const spatializedElement = (domProxy as any).__spatializedElement as
+            | SpatializedStatic3DElement
+            | undefined
+          if (spatializedElement) {
+            spatializedElement.entityTransform = value
+          }
         },
         async play(): Promise<void> {
           const spatializedElement = (domProxy as any).__spatializedElement as

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -13,6 +13,7 @@ import {
   SpatialMagnifyEvent as CoreSpatialMagnifyEvent,
   SpatialMagnifyEndEvent as CoreSpatialMagnifyEndEvent,
   SpatializedStatic3DElement,
+  type StageMode,
   type Vec3,
 } from '@webspatial/core-sdk'
 
@@ -107,6 +108,7 @@ export type SpatializedStatic3DContainerProps =
       autoPlay?: boolean
       loop?: boolean
       loading?: ModelLoadingMode
+      stagemode?: StageMode
       children?: React.ReactNode
       onLoad?: (event: ModelLoadEvent) => void
       onError?: (event: ModelLoadEvent) => void
@@ -120,6 +122,7 @@ export type SpatializedStatic3DContentProps = {
   autoPlay?: boolean
   loop?: boolean
   loading?: ModelLoadingMode
+  stagemode?: StageMode
   children?: React.ReactNode
   onLoad?: (event: ModelLoadEvent) => void
   onError?: (event: ModelLoadEvent) => void


### PR DESCRIPTION
The stagemode attribute controls built-in user interaction modes for the model. When set to "orbit", user input events in a horizontal direction result in a rotation of the model about the Y axis, and events in a vertical direction result in a rotation about the horizontal axis. https://claude.ai/code/session_01S1F2e9zgh2UtzCW7VZZyF6

Issue #1130 



https://github.com/user-attachments/assets/9beb3c34-aa6e-4437-969a-32bd12fe6b9c

