### PR TITLE
fix(core): persist html material bracket assignment

### DIFF
--- a/.changeset/fix-html-material-bracket-assignment.md
+++ b/.changeset/fix-html-material-bracket-assignment.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Fix html background material updates written through bracket syntax so CSS custom
+properties are stored in CSSOM before later html style mutations recompute scene
+material.

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -484,6 +484,13 @@ describe('spatialWindowPolyfill', () => {
         .getPropertyValue('--xr-background-material')
         .trim(),
     ).toBe('translucent')
+    expect(
+      (
+        (document.documentElement.style as any)[
+          '--xr-background-material'
+        ] as string
+      ).trim(),
+    ).toBe('translucent')
 
     updateSpatialProperties.mockClear()
     document.documentElement.style.setProperty('border-radius', '80px')

--- a/packages/core/src/coverage-boost.test.ts
+++ b/packages/core/src/coverage-boost.test.ts
@@ -470,6 +470,37 @@ describe('spatialWindowPolyfill', () => {
     expect(updateSpatialProperties).toHaveBeenCalledWith({
       material: 'none',
     })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    updateSpatialProperties.mockClear()
+    ;(document.documentElement.style as any)['--xr-background-material'] =
+      'translucent'
+    expect(updateSpatialProperties).toHaveBeenCalledWith({
+      material: 'translucent',
+    })
+    expect(
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--xr-background-material')
+        .trim(),
+    ).toBe('translucent')
+
+    updateSpatialProperties.mockClear()
+    document.documentElement.style.setProperty('border-radius', '80px')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(updateSpatialProperties).toHaveBeenCalledWith({
+      cornerRadius: {
+        topLeading: 80,
+        topTrailing: 80,
+        bottomLeading: 80,
+        bottomTrailing: 80,
+      },
+    })
+    expect(updateSpatialProperties).not.toHaveBeenCalledWith({
+      material: 'none',
+    })
   })
 })
 

--- a/packages/core/src/spatial-window-polyfill.ts
+++ b/packages/core/src/spatial-window-polyfill.ts
@@ -116,6 +116,12 @@ function hijackDocumentElementStyle() {
       return ret
     },
     get: function (target, prop: string) {
+      if (prop === SpatialGlobalCustomVars.backgroundMaterial) {
+        return target.getPropertyValue(
+          SpatialGlobalCustomVars.backgroundMaterial,
+        )
+      }
+
       if (typeof target[prop as keyof CSSStyleDeclaration] === 'function') {
         return function (this: any, ...args: any[]) {
           if (prop === 'setProperty') {

--- a/packages/core/src/spatial-window-polyfill.ts
+++ b/packages/core/src/spatial-window-polyfill.ts
@@ -78,10 +78,20 @@ function hijackDocumentElementStyle() {
   const rawDocumentStyle = document.documentElement.style
   const styleProxy = new Proxy(rawDocumentStyle, {
     set: function (target, key, value) {
-      const ret = Reflect.set(target, key, value)
+      let ret: boolean
 
       if (key === SpatialGlobalCustomVars.backgroundMaterial) {
-        setCurrentWindowStyle(value)
+        target.setProperty(
+          SpatialGlobalCustomVars.backgroundMaterial,
+          String(value),
+        )
+        ret = true
+      } else {
+        ret = Reflect.set(target, key, value)
+      }
+
+      if (key === SpatialGlobalCustomVars.backgroundMaterial) {
+        setCurrentWindowStyle(String(value))
       }
 
       if (


### PR DESCRIPTION
## Summary

Fix html-level background material updates when `--xr-background-material` is assigned through bracket syntax on `document.documentElement.style`.

Before this change, bracket assignment could update the SDK's internal material state and emit a material update, but fail to persist the CSS custom property into CSSOM. A later html style mutation could then cause the polyfill to recompute material from `getComputedStyle(document.documentElement)` and emit a stale computed material value.

In the reported case, the stale computed value was empty, so the fallback emitted `material: "none"`. The broader issue is that the recomputed material could come from stale computed style rather than the value assigned through bracket syntax.

Fixes #1289

## Root Cause

`spatial-window-polyfill` intercepts `document.documentElement.style` writes through a Proxy.

For bracket assignment to CSS custom properties, the previous implementation used `Reflect.set(...)`. That path could trigger the SDK's material update logic, but it did not reliably persist the CSS custom property into CSSOM.

After a later html style mutation, such as `border-radius`, the MutationObserver recomputes tracked html-level properties from:

```ts
getComputedStyle(document.documentElement)
```

Because the bracket-assigned custom property was not reliably present in computed style, the SDK could read and emit a stale computed material value. If the computed value was empty, the existing fallback converted it to `"none"`.

## Changes

- Persist `--xr-background-material` bracket assignments through the raw `CSSStyleDeclaration.setProperty(...)` path.
- Preserve the existing Proxy `set` trap flow, including border-radius and opacity handling.
- Keep the material cache and computed style state aligned so later html style mutations do not emit stale material values.
- Add a regression test covering:
  - bracket assignment for `--xr-background-material`
  - CSSOM/computed-style persistence
  - later html style mutation not emitting stale computed material
- Add a patch changeset for `@webspatial/core-sdk`.

## Verification

- `pnpm --filter @webspatial/core-sdk test`
- `pnpm --filter @webspatial/core-sdk run lint`