### PR TITLE
chore: document Model spatial gesture restrictions when in orbit mode

### DIFF
--- a/docs/Model.md
+++ b/docs/Model.md
@@ -41,7 +41,7 @@ Like standard HTML elements, the `<Model>` component supports a range of attribu
 `stagemode` Controls the built-in user interaction mode for the model.
 
 - **none** (default): No built-in interaction is enabled. All interactions must be handled via spatial events.
-- `orbit` Enables a native orbit interaction mode. Allows users to rotate the model by dragging. When in orbit mode `entityTransform` becomes read-only and gesture handlers `onSpatialDragStart`, `onSpatialDrag`, and `onSpatialDragEnd` are disabled
+- `orbit` Enables a native orbit interaction mode. Allows users to rotate the model by dragging. When in orbit mode `entityTransform` becomes read-only and all spatial gesture handlers `onSpatial*` are disabled
 
 ## Events
 
@@ -103,7 +103,7 @@ The <source> HTML element specifies one or more media resources for the <Model> 
 
 ## Usage Notes
 
-- **Orbit Interaction Conflicts**: Setting the `stagemode` attribute to `orbit` results in an **_orbit_** interaction mode, where the `entityTransform` becomes read-only, and the view is updated exclusively based on input events from the user. Native gesture handlers `onSpatialDragStart`, `onSpatialDrag`, and `onSpatialDragEnd` are disabled
+- **Orbit Interaction Conflicts**: Setting the `stagemode` attribute to `orbit` results in an **_orbit_** interaction mode, where the `entityTransform` becomes read-only, and the view is updated exclusively based on input events from the user. Spatial gesture handlers `onSpatial*` are disabled
 
 ## Examples
 
@@ -222,7 +222,7 @@ function LongScrollPage() {
 | `<source>` | ✓ (USD/USDZ)<br>26 | ✓ (USD/USDZ/GLB/GLTF)<br>6 ⍺2.1 | ✓<br>1.6       |
 | poster     | ✓<br>26            | ✓<br>6 β2.0                     | ✓<br>1.7       |
 | loading    | ✓<br>26            | ✓<br>6 β2.1                     | ✓<br>1.7       |
-| stagemode  | 26                 | 6                               | July           |
+| stagemode  | 26                 | 6.1                             | July           |
 
 ### CSS
 
@@ -249,8 +249,8 @@ function LongScrollPage() {
 | play()             | ✓<br>26  | ✓<br>6 ⍺2.1 | ✓<br>1.6       |
 | pause()            | ✓<br>26  | ✓<br>6 ⍺2.1 | ✓<br>1.6       |
 | currentTime        | ✓<br>26  | ✓<br>6 β2.0 | ✓<br>1.7       |
-| boundingBoxCenter  | 26       | 6           | July           |
-| boundingBoxExtents | 26       | 6           | July           |
+| boundingBoxCenter  | 26       | 6.2         | August         |
+| boundingBoxExtents | 26       | 6.2         | August         |
 
 ## Feature Implementation Details
 
@@ -277,11 +277,10 @@ This feature provides a built-in, intuitive way for users to inspect a 3D model 
 
 - **Interaction with&nbsp;entityTransform**: `entityTransform` will not be updated when the model is rotated using the orbit gesture. Similarly updates to `entityTransform` will not affect the model's orientation.
 
-- **Gesture Conflict Resolution**: `onSpatialDragStart`, `onSpatialDrag`, and `onSpatialDragEnd` will be disabled when stagemode is set to orbit.
+- **Gesture Conflict Resolution**: `onSpatial*` will be disabled when stagemode is set to orbit. This restriction can be loosened in the future based if there are no gesture conflicts.
 
 ## Risks
 
-- **Gesture Conflicts**: Our proposed solution of disabling drag listeners when orbit is present is a safe starting point.
 - **Safari Alignment**: Since the `<model>` element is still an evolving standard, our implementation is a best-effort interpretation. We must be prepared to adapt as the standard solidifies.
 
 ## References


### PR DESCRIPTION
When stagemode is set to orbit then spatial gestures are disabled. This is to avoid gesture handling conflicts. Also entityTransform is read-only in orbit mode.

Issue #1130 
