### PR TITLE
feat: Model add stagemode property Swift changes

### DIFF
--- a/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
+++ b/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
@@ -63,8 +63,8 @@
 		2B06AF312E4C1AF8000327E9 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				dynamic3d/EntityAnimationSession.swift,
 				dynamic3d/EntityAnimationManager.swift,
+				dynamic3d/EntityAnimationSession.swift,
 				dynamic3d/Geometry.swift,
 				dynamic3d/SpatialComponent.swift,
 				dynamic3d/SpatialEntity.swift,
@@ -115,6 +115,7 @@
 				SpatialSceneView.swift,
 				"view-modifier/HideViewModifier.swift",
 				"view-modifier/MaterialWithBorderCornerModifier.swift",
+				"view-modifier/OrbitModifier.swift",
 			);
 			target = 2B2F1D622BEBFAAA006897EE /* web-spatial */;
 		};
@@ -604,7 +605,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
 	};
 	rootObject = 2B2F1D5B2BEBFAAA006897EE /* Project object */;
 }

--- a/packages/visionOS/web-spatial/WebMsgCommand.swift
+++ b/packages/visionOS/web-spatial/WebMsgCommand.swift
@@ -138,6 +138,19 @@ struct EntityTransformChangeDetail: Encodable {
 struct EntityTransformChangeEvent: Encodable {
     let type: SpatialWebMsgType = .entitytransformchange
     let detail: EntityTransformChangeDetail
+
+    /// Emits the transform to the web layer as a 16-element column-major matrix.
+    init(_ transform: AffineTransform3D) {
+        let m = transform.matrix
+        let c0 = m.columns.0, c1 = m.columns.1, c2 = m.columns.2, c3 = m.columns.3
+        let array: [Double] = [
+            c0.x, c0.y, c0.z, 0,
+            c1.x, c1.y, c1.z, 0,
+            c2.x, c2.y, c2.z, 0,
+            c3.x, c3.y, c3.z, 1,
+        ]
+        detail = EntityTransformChangeDetail(transform: array)
+    }
 }
 
 struct SpatialObjectDestroiedEvent: Encodable {

--- a/packages/visionOS/web-spatial/manifest.swift
+++ b/packages/visionOS/web-spatial/manifest.swift
@@ -6,7 +6,7 @@ var pwaManager = PWAManager()
 struct PWAManager: Codable {
     var isLocal: Bool = false
 
-//    var start_url: String = "http://localhost:5173/#/"
+    ///    var start_url: String = "http://localhost:5173/#/"
     var start_url: String = "http://localhost:5173/#/runtime-capabilities"
 
     // var start_url: String = "http://localhost:5173/#/spatial-drag-gesture"

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -2,7 +2,7 @@ import RealityKit
 import SwiftUI
 
 struct SpatializedStatic3DView: View {
-    let spatializedStatic3DElement: SpatializedStatic3DElement
+    @Bindable var spatializedStatic3DElement: SpatializedStatic3DElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
 
     @State private var loadState: LoadState = .idle
@@ -18,6 +18,10 @@ struct SpatializedStatic3DView: View {
 
     func onLoadFailure() {
         spatialScene.sendWebMsg(spatializedStatic3DElement.id, ModelLoadFailure())
+    }
+
+    private func onOrbit(_ transform: AffineTransform3D) {
+        spatialScene.sendWebMsg(spatializedStatic3DElement.id, EntityTransformChangeEvent(transform))
     }
 
     var body: some View {
@@ -40,10 +44,7 @@ struct SpatializedStatic3DView: View {
                     Model3D(asset: asset) { resolvedModel3D in
                         resolvedModel3D
                             .resizable(true)
-                            .aspectRatio(
-                                nil,
-                                contentMode: .fit
-                            )
+                            .aspectRatio(nil, contentMode: .fit)
                             .if(!depth.isZero) { view in view.scaledToFit3D() }
                             .if(enableGesture) { view in view.hoverEffect() }
                     }
@@ -51,13 +52,12 @@ struct SpatializedStatic3DView: View {
                     posterView {}
                 }
             }
-            .scaleEffect(
-                x: scale.width,
-                y: scale.height,
-                z: scale.depth
-            )
-            .rotation3DEffect(
-                rotation
+            .scaleEffect(scale)
+            .rotation3DEffect(rotation)
+            .orbit(
+                enabled: spatializedStatic3DElement.stagemode == .orbit,
+                entityTransform: $spatializedStatic3DElement.entityTransform,
+                onChange: onOrbit
             )
             .offset(x: x, y: y)
             .offset(z: z)

--- a/packages/visionOS/web-spatial/view/view-modifier/OrbitModifier.swift
+++ b/packages/visionOS/web-spatial/view/view-modifier/OrbitModifier.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+private let degreesPerPoint = 0.5
+private let pitchLimitDegrees = 100.0
+private let springBack = Animation.spring(response: 0.45, dampingFraction: 0.7)
+
+/// Adds an orbital camera-style rotation gesture to a 3D model.
+///
+/// Both horizontal yaw (around the Y-axis) and vertical pitch (around the
+/// X-axis, clamped to ±100° so the model can't flip past upright) are folded
+/// directly into the bound `entityTransform` on each drag tick, so the web
+/// layer always observes an accurate transform. On release, the pitch
+/// elastically springs back to 0: the data is set to the unpitched final state
+/// immediately while SwiftUI animates the existing `.rotation3DEffect` from the
+/// old (pitched) rotation to the new (unpitched) rotation for a smooth visual.
+struct OrbitModifier: ViewModifier {
+    let enabled: Bool
+    @Binding var entityTransform: AffineTransform3D
+    let onChange: (AffineTransform3D) -> Void
+
+    @State private var dragStartTransform: AffineTransform3D?
+    @State private var dragYawDegrees: Double = 0
+
+    func body(content: Content) -> some View {
+        content
+            .simultaneousGesture(enabled ? orbitGesture : nil)
+            .onChange(of: enabled) { _, isEnabled in
+                if !isEnabled { releaseElastic() }
+            }
+    }
+
+    private var orbitGesture: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                let base = dragStartTransform ?? entityTransform
+                if dragStartTransform == nil { dragStartTransform = base }
+
+                dragYawDegrees = Double(value.translation.width) * degreesPerPoint
+                let pitchTarget = Double(-value.translation.height) * degreesPerPoint
+                let pitchDegrees = max(-pitchLimitDegrees, min(pitchLimitDegrees, pitchTarget))
+
+                let new = compose(base: base, yawDegrees: dragYawDegrees, pitchDegrees: pitchDegrees)
+                entityTransform = new
+                onChange(new)
+            }
+            .onEnded { _ in releaseElastic() }
+    }
+
+    private func releaseElastic() {
+        guard let base = dragStartTransform else { return }
+        let unpitched = compose(base: base, yawDegrees: dragYawDegrees, pitchDegrees: 0)
+        withAnimation(springBack) { entityTransform = unpitched }
+        onChange(unpitched)
+        dragStartTransform = nil
+        dragYawDegrees = 0
+    }
+
+    private func compose(
+        base: AffineTransform3D,
+        yawDegrees: Double,
+        pitchDegrees: Double
+    ) -> AffineTransform3D {
+        let translation = AffineTransform3D(translation: base.translation)
+        let yaw = AffineTransform3D(rotation: Rotation3D(angle: .degrees(yawDegrees), axis: .y))
+        let pitch = AffineTransform3D(rotation: Rotation3D(angle: .degrees(pitchDegrees), axis: .x))
+        let baseRotation = AffineTransform3D(rotation: base.rotation ?? .identity)
+        let scale = AffineTransform3D(scale: base.scale)
+        return translation
+            .concatenating(yaw)
+            .concatenating(pitch)
+            .concatenating(baseRotation)
+            .concatenating(scale)
+    }
+}
+
+extension View {
+    func orbit(
+        enabled: Bool,
+        entityTransform: Binding<AffineTransform3D>,
+        onChange: @escaping (AffineTransform3D) -> Void
+    ) -> some View {
+        modifier(OrbitModifier(enabled: enabled, entityTransform: entityTransform, onChange: onChange))
+    }
+}


### PR DESCRIPTION
The stagemode attribute controls built-in user interaction modes for the
model. When set to "orbit", user input events in a horizontal direction
result in a rotation of the model about the Y axis, and events in a
vertical direction result in a rotation about the horizontal axis.
https://claude.ai/code/session_01S1F2e9zgh2UtzCW7VZZyF6

Fixes #1130 


https://github.com/user-attachments/assets/408505ea-9420-4dd0-bf69-5d97fa396c89

