### PR TITLE
[codex] fix Model ready DOM binding

### DIFF
--- a/.changeset/model-ready-dom-binding.md
+++ b/.changeset/model-ready-dom-binding.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Resolve Model ref and load event APIs from the DOM-linked spatial element so `event.target.ready` works when a Model is nested inside another spatial container.

--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -60,6 +60,7 @@ import SpatialCorner from './src/pages/spatialCorner/index'
 import GeometryVerify from './src/pages/geometry-verify/index'
 import TransformVerify from './src/pages/transform-verify/index'
 import Static3DModel from './src/pages/static-3d-model/index'
+import NestedStatic3DModelReady from './src/pages/static-3d-model/nested-ready'
 import VisibleTest from './src/pages/visibleTest/index'
 import { CleanupSpa, CleanupIframe, CleanupModel } from './src/pages/cleanup'
 import HeadStyleSyncPage from './src/pages/head-style-sync/index'
@@ -337,6 +338,10 @@ function App() {
                 <Route path="/geometry-verify" element={<GeometryVerify />} />
                 <Route path="/transform-verify" element={<TransformVerify />} />
                 <Route path="/static-3d-model" element={<Static3DModel />} />
+                <Route
+                  path="/static-3d-model/nested-ready"
+                  element={<NestedStatic3DModelReady />}
+                />
                 <Route path="/visible-test" element={<VisibleTest />} />
                 <Route
                   path="/head-style-sync"

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -119,6 +119,10 @@ export const routes = [
       { path: '/geometry-verify', label: 'Geometry Verify' },
       { path: '/transform-verify', label: 'Transform Verify' },
       { path: '/static-3d-model', label: 'Static 3D Model' },
+      {
+        path: '/static-3d-model/nested-ready',
+        label: 'Nested Model Ready',
+      },
       { path: '/visible-test', label: 'Visible Test' },
     ],
   },

--- a/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
+++ b/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
@@ -1,0 +1,139 @@
+import { Model, ModelLoadEvent, ModelRef } from '@webspatial/react-sdk'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Logger, useLogger } from './Logger'
+
+const MODEL_SRC =
+  'https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz'
+
+function describeTarget(event: ModelLoadEvent) {
+  return {
+    tagName: event.target.tagName,
+    currentSrc: event.target.currentSrc,
+    readyProperty: 'ready' in event.target,
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : JSON.stringify(error)
+}
+
+export default function NestedStatic3DModelReady() {
+  const modelRef = useRef<ModelRef | null>(null)
+  const [logs, logLine, clearLog] = useLogger()
+  const [status, setStatus] = useState('waiting for Model onLoad')
+
+  useEffect(() => {
+    logLine(
+      'page mounted',
+      'Mounts <div enable-xr><Model enable-xr /></div> and reads event.target.ready from onLoad.',
+    )
+  }, [logLine])
+
+  const handleLoad = useCallback(
+    (event: ModelLoadEvent) => {
+      const target = describeTarget(event)
+      logLine('onLoad target', target)
+      setStatus('onLoad fired; waiting for event.target.ready')
+
+      let ready
+      try {
+        ready = event.target.ready
+      } catch (error) {
+        logLine('event.target.ready getter threw', getErrorMessage(error))
+        setStatus('event.target.ready getter threw')
+        return
+      }
+
+      if (!ready || typeof ready.then !== 'function') {
+        logLine('event.target.ready unavailable')
+        setStatus('event.target.ready unavailable')
+        return
+      }
+
+      ready
+        .then(readyEvent => {
+          logLine('event.target.ready resolved', describeTarget(readyEvent))
+          setStatus('event.target.ready resolved')
+        })
+        .catch(error => {
+          logLine('event.target.ready rejected', getErrorMessage(error))
+          setStatus('event.target.ready rejected')
+        })
+    },
+    [logLine],
+  )
+
+  const handleError = useCallback(
+    (event: ModelLoadEvent) => {
+      logLine('onError target', describeTarget(event))
+      setStatus('Model onError fired')
+    },
+    [logLine],
+  )
+
+  return (
+    <div className="prose max-w-none p-10 text-gray-100">
+      <h1>Nested Static 3D Model Ready</h1>
+      <p className="max-w-3xl text-sm text-gray-300">
+        Reproduces the nested static 3D model path where a spatial parent owns
+        the branch and the Model load event target still needs a working ready
+        promise.
+      </p>
+
+      <div className="mb-4 flex flex-wrap items-center gap-2 not-prose">
+        <span className="rounded border border-gray-700 bg-gray-900 px-3 py-2 text-sm">
+          {status}
+        </span>
+      </div>
+
+      <div
+        enable-xr
+        className="mb-6 flex min-h-[260px] items-center justify-center rounded border border-cyan-500/60 bg-cyan-950/20 p-6 not-prose"
+        style={{
+          '--xr-depth': '180px',
+          '--xr-back': '40px',
+        }}
+      >
+        <Model
+          ref={modelRef}
+          enable-xr
+          src={MODEL_SRC}
+          poster="/img/toy_drummer.png"
+          stagemode="orbit"
+          style={{
+            width: '280px',
+            height: '220px',
+            '--xr-depth': '120px',
+            '--xr-back': '30px',
+          }}
+          onLoad={handleLoad}
+          onError={handleError}
+        >
+          <img
+            src="/img/toy_drummer.png"
+            className="h-[220px] w-[280px] object-contain"
+          />
+        </Model>
+      </div>
+
+      <div className="mb-6 not-prose">
+        <button
+          className="btn"
+          onClick={() => {
+            modelRef.current?.ready
+              .then(event => {
+                logLine('ref.current.ready resolved', describeTarget(event))
+              })
+              .catch(error => {
+                logLine('ref.current.ready rejected', getErrorMessage(error))
+              })
+          }}
+        >
+          Check ref.current.ready
+        </button>
+      </div>
+
+      <Logger logs={logs} clearLog={clearLog} />
+    </div>
+  )
+}

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
@@ -32,6 +32,9 @@ const spatializedElement: SpatializedElementStub = {
 const portalInstanceValue = {
   dom: document.createElement('div'),
 } as { dom?: HTMLElement }
+let lastExtraRefProps:
+  | ((domProxy: unknown) => Record<string, unknown>)
+  | undefined
 
 vi.mock('@webspatial/core-sdk', () => ({
   SpatializedStatic3DElement: class {},
@@ -44,6 +47,7 @@ vi.mock('./SpatializedContainer', () => ({
   }: {
     spatializedContent: React.ComponentType<Record<string, unknown>>
   } & Record<string, unknown>) => {
+    lastExtraRefProps = props.extraRefProps as typeof lastExtraRefProps
     return (
       <PortalInstanceContext.Provider
         value={portalInstanceValue as unknown as PortalInstanceObject}
@@ -80,6 +84,7 @@ function lastObserver() {
 describe('SpatializedStatic3DElementContainer lazy/eager loading behavior', () => {
   beforeEach(() => {
     updateProperties.mockClear()
+    lastExtraRefProps = undefined
     IntersectionObserverMock.instances = []
     portalInstanceValue.dom = document.createElement('div')
     globalThis.IntersectionObserver =
@@ -235,5 +240,24 @@ describe('SpatializedStatic3DElementContainer lazy/eager loading behavior', () =
     expect(updateProperties).toHaveBeenLastCalledWith(
       expect.objectContaining({ loading: 'eager' }),
     )
+  })
+
+  it('resolves ready from the DOM-linked spatialized element when a nested standard branch did not create one', async () => {
+    const readyTarget = {
+      ready: Promise.resolve(true),
+    }
+
+    render(<SpatializedStatic3DElementContainer src="/model.usdz" />)
+
+    const domProxy = Object.assign(document.createElement('div'), {
+      __innerSpatializedElement: () => readyTarget,
+    })
+    const extra = lastExtraRefProps!(domProxy)
+
+    await expect(
+      Promise.resolve().then(() => extra.ready),
+    ).resolves.toMatchObject({
+      type: 'modelloaded',
+    })
   })
 })

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -82,6 +82,20 @@ function collectSources(children: React.ReactNode): ModelSource[] {
   return sources
 }
 
+type Static3DDomProxy = SpatializedStatic3DElementRef & {
+  __spatializedElement?: SpatializedStatic3DElement
+  __innerSpatializedElement?: () => SpatializedStatic3DElement | undefined
+}
+
+function getDomSpatializedStaticElement(
+  domProxy: SpatializedStatic3DElementRef,
+): SpatializedStatic3DElement | undefined {
+  const proxy = domProxy as Static3DDomProxy
+  // Nested standard branches expose the DOM/ref while the portal branch owns
+  // the actual static 3D element, so resolve through either DOM binding.
+  return proxy.__spatializedElement ?? proxy.__innerSpatializedElement?.()
+}
+
 function SpatializedContent(props: SpatializedStatic3DContentProps) {
   const {
     src,
@@ -193,81 +207,66 @@ function SpatializedStatic3DElementContainerBase(
     (domProxy: SpatializedStatic3DElementRef) => {
       return {
         get currentSrc(): string {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.currentSrc ?? ''
         },
         get ready(): Promise<ModelLoadEvent> {
-          return promiseRef
-            .current!.then(spatializedElement => spatializedElement.ready)
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
+          const readySource = spatializedElement
+            ? Promise.resolve(spatializedElement)
+            : promiseRef.current
+          if (!readySource) {
+            return Promise.reject(createLoadFailureEvent(() => domProxy))
+          }
+          return readySource
+            .then(element => element.ready)
             .then(success => {
               if (success) return createLoadSuccessEvent(() => domProxy)
               throw createLoadFailureEvent(() => domProxy)
             })
         },
         get entityTransform(): DOMMatrixReadOnly {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.entityTransform ?? new DOMMatrixReadOnly()
         },
         set entityTransform(value: DOMMatrixReadOnly) {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           if (spatializedElement) {
             spatializedElement.entityTransform = value
           }
         },
         async play(): Promise<void> {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           await spatializedElement?.play()
         },
         async pause(): Promise<void> {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           await spatializedElement?.pause()
         },
         get paused(): boolean {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.paused ?? true
         },
         get duration(): number {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.duration ?? 0
         },
         get playbackRate(): number {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.playbackRate ?? 1
         },
         set playbackRate(value: number) {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           if (spatializedElement) {
             spatializedElement.playbackRate = value
           }
         },
         get currentTime(): number {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           return spatializedElement?.currentTime ?? 0
         },
         set currentTime(value: number) {
-          const spatializedElement = (domProxy as any).__spatializedElement as
-            | SpatializedStatic3DElement
-            | undefined
+          const spatializedElement = getDomSpatializedStaticElement(domProxy)
           if (spatializedElement) {
             spatializedElement.currentTime = value
           }


### PR DESCRIPTION
## Summary

Fixes #1296.

Fixes `Model` load/ref APIs when a spatial Model is nested under another spatial container, for example:

```tsx
<div enable-xr>
  <Model enable-xr onLoad={event => event.target.ready} />
</div>
```

In this structure, React renders separate standard and portal branches. The standard branch can expose the DOM/ref target, while the actual `SpatializedStatic3DElement` is created by the portal branch. The previous `ready` getter only read the current component instance's `promiseRef.current`, which can be `null` for the standard branch and throw when `event.target.ready` is accessed.

This change makes Model ref APIs resolve the spatial element from the DOM-linked binding first:

```ts
dom.__spatializedElement ?? dom.__innerSpatializedElement?.()
```

and keeps the existing local promise fallback for early root `ref.current.ready` reads before DOM binding has completed.

## Changes

- Add a shared helper for resolving the `SpatializedStatic3DElement` from a Model DOM/ref proxy.
- Update Model ref APIs (`ready`, `currentSrc`, transform, playback controls, timing fields) to use the DOM-linked spatialized element.
- Make `ready` reject with a Model load failure event instead of throwing when no ready source exists.
- Add a regression test for the nested standard-branch case where the DOM target has an inner spatialized element but no local creation promise.
- Add a test-server demo at `/static-3d-model/nested-ready` for manual verification in visionOS / WebSpatial.

## Testing

- `pnpm --filter @webspatial/react-sdk test`
- `pnpm --filter @webspatial/react-sdk exec tsc -p ./tsconfig.json --pretty false`
- `pnpm --filter web-content test`
- `pnpm --filter web-content build`
- `git diff --check`

## Reviewer note

This PR intentionally does not replace the internal `__spatializedElement` / `__innerSpatializedElement` DOM bindings. A follow-up cleanup can move that binding to a WeakMap-backed internal API; this PR only fixes the runtime bug with minimal surface area.