### PR TITLE
feat: Model add stagemode property Swift plumbing

### DIFF
--- a/.changeset/mighty-lions-buy.md
+++ b/.changeset/mighty-lions-buy.md
@@ -1,6 +1,5 @@
 ---
-'@webspatial/core-sdk': minor
-'@webspatial/react-sdk': minor
+'@webspatial/platform-visionos': minor
 ---
 
 Add `stagemode` prop to `<Model>` for built-in orbit interaction

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -278,6 +278,7 @@ struct UpdateSpatializedStatic3DElementProperties: SpatializedElementProperties 
     let currentTime: Double?
     let posterURL: String?
     let loading: String?
+    let stagemode: String?
 }
 
 struct UpdateSpatializedDynamic3DElementProperties: SpatializedElementProperties {

--- a/packages/visionOS/web-spatial/WebMsgCommand.swift
+++ b/packages/visionOS/web-spatial/WebMsgCommand.swift
@@ -24,9 +24,8 @@ enum SpatialWebMsgType: String, Encodable {
     case spatialrotateend
     case spatialmagnify
     case spatialmagnifyend
-
     case animationstatechange
-
+    case entitytransformchange
     case objectdestroy
 }
 
@@ -127,6 +126,18 @@ struct AnimationStateChangeDetail: Encodable {
 struct AnimationStateChangeEvent: Encodable {
     let type: SpatialWebMsgType = .animationstatechange
     let detail: AnimationStateChangeDetail
+}
+
+/// 16-element column-major representation of the new `entityTransform`,
+/// matching the wire format that JS already uses when sending the matrix to
+/// native via `UpdateSpatializedStatic3DElementProperties.modelTransform`.
+struct EntityTransformChangeDetail: Encodable {
+    let transform: [Double]
+}
+
+struct EntityTransformChangeEvent: Encodable {
+    let type: SpatialWebMsgType = .entitytransformchange
+    let detail: EntityTransformChangeDetail
 }
 
 struct SpatialObjectDestroiedEvent: Encodable {

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -682,7 +682,7 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             let column3 = simd_double4(array[12], array[13], array[14], array[15])
             let simd_double4x4 = simd_double4x4(columns: (column0, column1, column2, column3))
             let affineTransform3D = AffineTransform3D(truncating: simd_double4x4)
-            spatializedElement.modelTransform = affineTransform3D
+            spatializedElement.entityTransform = affineTransform3D
         }
 
         if let autoplay = command.autoplay {
@@ -711,6 +711,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
 
         if let loading = command.loading {
             spatializedElement.loading = Loading(stringValue: loading)
+        }
+
+        if let stagemode = command.stagemode {
+            spatializedElement.stagemode = StageMode(stringValue: stagemode)
         }
 
         resolve(.success(baseReplyData))

--- a/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedStatic3DElement.swift
@@ -15,11 +15,20 @@ enum Loading: String {
     }
 }
 
+enum StageMode: String {
+    case none
+    case orbit
+
+    init(stringValue value: String) {
+        self = StageMode(rawValue: value) ?? .none
+    }
+}
+
 @Observable
 class SpatializedStatic3DElement: SpatializedElement {
     var modelURL: String?
     var sources: [ModelSource] = []
-    var modelTransform: AffineTransform3D = .identity
+    var entityTransform: AffineTransform3D = .identity
     var autoplay: Bool = false
     var loop: Bool = false
     var animationPaused: Bool = true
@@ -29,9 +38,14 @@ class SpatializedStatic3DElement: SpatializedElement {
     var pendingSeekTime: Double?
     var posterURL: String?
     var loading: Loading = .eager
+    var stagemode: StageMode = .none
     var allSources: [ModelSource] {
         if let modelURL { [ModelSource(src: modelURL, type: nil)] + sources }
         else { sources }
+    }
+
+    override var enableGesture: Bool {
+        stagemode == .orbit || super.enableGesture
     }
 
     enum CodingKeys: String, CodingKey {

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -26,7 +26,7 @@ struct SpatializedStatic3DView: View {
 
     var body: some View {
         let depth = spatializedElement.depth
-        let transform = spatializedStatic3DElement.modelTransform
+        let transform = spatializedStatic3DElement.entityTransform
         let translation = transform.translation
         let scale = transform.scale
         let rotation = transform.rotation!


### PR DESCRIPTION
Adds Swift plumbing for `<Model>` **stagemode** property. Rename `modelTransform` to `entityTransform` only in Swift code, JSB interface remains unchanged.

Issue https://github.com/webspatial/webspatial-sdk/issues/1130