### PR TITLE
Rename AttachmentAsset prop from `name` to `id` and key registry by asset id

### DIFF
--- a/.changeset/attachment-asset-id.md
+++ b/.changeset/attachment-asset-id.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/react-sdk': major
+---
+
+BREAKING: rename `<AttachmentAsset>`'s `name` prop to `id` to align attachment asset declarations with other asset APIs such as `<ModelAsset id="...">`.
+
+Update declarations from `<AttachmentAsset name="hud">` to `<AttachmentAsset id="hud">`. `<AttachmentEntity attachment="hud">` continues to reference the matching asset id, and the existing size and tuple position API is unchanged.

--- a/apps/test-server/src/pages/reality/attachments.tsx
+++ b/apps/test-server/src/pages/reality/attachments.tsx
@@ -42,7 +42,7 @@ function TestBasicAttachment() {
         style={{ width: '400px', height: '400px', border: '1px solid black' }}
       >
         <UnlitMaterial id="matBasic" color="#ff0000" />
-        <AttachmentAsset name="basic-attachment">
+        <AttachmentAsset id="basic-attachment">
           <div
             style={{
               background: 'black',
@@ -92,7 +92,7 @@ function TestNestedRealityInSpatialDiv() {
       >
         <Reality style={{ width: '100%', height: '100%' }}>
           <UnlitMaterial id="matDiv" color="#0000ff" />
-          <AttachmentAsset name="nested-spatialdiv-attachment">
+          <AttachmentAsset id="nested-spatialdiv-attachment">
             <div
               style={{
                 background: 'rgba(0,0,100,0.8)',
@@ -141,7 +141,7 @@ function TestModelFallback() {
           src="/modelasset/cone.usdz"
           style={{ width: 100, height: 100, background: '#fff' }}
         /> */}
-        <AttachmentAsset name="model-fallback-attachment">
+        <AttachmentAsset id="model-fallback-attachment">
           <div
             style={{
               background: 'rgba(0,100,0,0.8)',
@@ -186,7 +186,7 @@ function TestRealityFallback() {
       <Reality
         style={{ width: '400px', height: '400px', border: '1px solid red' }}
       >
-        <AttachmentAsset name="reality-fallback-attachment">
+        <AttachmentAsset id="reality-fallback-attachment">
           <div
             style={{
               background: 'rgba(100,0,0,0.8)',
@@ -233,7 +233,7 @@ function TestSpatialDivFallback() {
       <Reality
         style={{ width: '400px', height: '400px', border: '1px solid purple' }}
       >
-        <AttachmentAsset name="spatialdiv-fallback-attachment">
+        <AttachmentAsset id="spatialdiv-fallback-attachment">
           <div
             style={{
               background: 'rgba(50,0,100,0.8)',
@@ -288,7 +288,7 @@ function TestSharedAttachmentState() {
         <UnlitMaterial id="matSharedA" color="#ff8800" />
         <UnlitMaterial id="matSharedB" color="#ffaa00" />
 
-        <AttachmentAsset name="shared-counter">
+        <AttachmentAsset id="shared-counter">
           <div
             style={{
               background: 'rgba(80,40,0,0.85)',
@@ -383,7 +383,7 @@ function TestAttachmentAnimation() {
         style={{ width: '400px', height: '400px', border: '1px solid teal' }}
       >
         <UnlitMaterial id="matAnim" color="#00aaaa" />
-        <AttachmentAsset name="anim-attachment">
+        <AttachmentAsset id="anim-attachment">
           <div
             style={{
               background: 'rgba(0,80,80,0.85)',
@@ -447,14 +447,14 @@ function TestNestedAttachmentSwap() {
         <UnlitMaterial id="matChild" color="#44ff44" />
 
         {/* Asset 1: HUD */}
-        <AttachmentAsset name="hud">
+        <AttachmentAsset id="hud">
           <div style={{ background: 'blue', color: 'white', padding: 10 }}>
             <strong>HUD ASSET</strong>
           </div>
         </AttachmentAsset>
 
         {/* Asset 2: HUD Child */}
-        <AttachmentAsset name="hudChild">
+        <AttachmentAsset id="hudChild">
           <div style={{ background: 'green', color: 'white', padding: 10 }}>
             <strong>HUD CHILD ASSET</strong>
           </div>
@@ -556,7 +556,7 @@ function TestGSAPSingleAttachment() {
         style={{ width: '400px', height: '400px', border: '1px solid #0a7' }}
       >
         <UnlitMaterial id="matGsapSingle" color="#008877" />
-        <AttachmentAsset name="gsap-single-pulse">
+        <AttachmentAsset id="gsap-single-pulse">
           <GsapPulseAttachmentContent />
         </AttachmentAsset>
         <SceneGraph>
@@ -592,7 +592,7 @@ function TestGSAPSharedAttachmentAsset() {
       >
         <UnlitMaterial id="matGsapSharedA" color="#006666" />
         <UnlitMaterial id="matGsapSharedB" color="#008888" />
-        <AttachmentAsset name="gsap-shared-pulse">
+        <AttachmentAsset id="gsap-shared-pulse">
           <GsapPulseAttachmentContent />
         </AttachmentAsset>
         <SceneGraph>
@@ -733,7 +733,7 @@ function TestAttachmentPositionSizeSliders() {
         style={{ width: '480px', height: '420px', border: '1px solid #6366f1' }}
       >
         <UnlitMaterial id="matSliderAtt" color="#6366f1" />
-        <AttachmentAsset name="slider-dynamic-attachment">
+        <AttachmentAsset id="slider-dynamic-attachment">
           <div
             style={{
               background: 'rgba(40,40,90,0.92)',
@@ -773,9 +773,9 @@ function TestAttachmentPositionSizeSliders() {
 
 function TestLastDefinitionWins() {
   return (
-    <TestCase title="9. Last Definition Wins — Duplicate AttachmentAsset name">
+    <TestCase title="9. Last Definition Wins — Duplicate AttachmentAsset id">
       <p className="text-sm text-gray-600 mb-2">
-        Only the second asset with the same name should render.
+        Only the second asset with the same id should render.
       </p>
       <Reality
         style={{ width: '500px', height: '400px', border: '1px solid #555' }}
@@ -783,7 +783,7 @@ function TestLastDefinitionWins() {
         <UnlitMaterial id="matLWLeft" color="#5555ff" />
         <UnlitMaterial id="matLWRight" color="#55ff55" />
 
-        <AttachmentAsset name="dup-asset">
+        <AttachmentAsset id="dup-asset">
           <div
             style={{
               background: 'rgba(180,0,0,0.85)',
@@ -796,7 +796,7 @@ function TestLastDefinitionWins() {
             FIRST
           </div>
         </AttachmentAsset>
-        <AttachmentAsset name="dup-asset">
+        <AttachmentAsset id="dup-asset">
           <div
             style={{
               background: 'rgba(0,150,0,0.85)',

--- a/docs/Attachments.md
+++ b/docs/Attachments.md
@@ -13,13 +13,13 @@ This enables a 1→N pattern: one content template can be rendered into multiple
 
 ## `<AttachmentAsset>`
 
-Declares an attachment content template by name. When one or more `<AttachmentEntity>` components register containers for that name, `<AttachmentAsset>` uses `createPortal` to render its children into each container.
+Declares an attachment content template by asset id. When one or more `<AttachmentEntity>` components register containers for that id, `<AttachmentAsset>` uses `createPortal` to render its children into each container.
 
 ### Attributes
 
-`name`
+`id`
 
-**Required.** A string identifier that links this content template to one or more `<AttachmentEntity>` instances. Must match the `attachment` prop on the corresponding entities.
+**Required.** A string identifier that links this content template to one or more `<AttachmentEntity>` instances. Must match the `attachment` prop on the corresponding entities. This aligns attachment asset declarations with other asset declarations such as `<ModelAsset id="...">`.
 
 `children`
 
@@ -28,8 +28,8 @@ The React content to render inside the attachment. This can be any valid React J
 ### Usage Notes
 
 - `<AttachmentAsset>` must be a direct child of `<Reality>`, placed **outside** `<SceneGraph>`.
-- If no `<AttachmentEntity>` has registered for the given `name`, the asset renders nothing.
-- Multiple `<AttachmentEntity>` components with the same `attachment` name will each receive a portal of the same children.
+- If no `<AttachmentEntity>` has registered for the given `id`, the asset renders nothing.
+- Multiple `<AttachmentEntity>` components with the same `attachment` id will each receive a portal of the same children.
 - Spatial components (`<SpatialDiv>`, `<Reality>`, `<Model>`) inside an `<AttachmentAsset>` will gracefully degrade to plain HTML with a console warning. Attachments are 2D surfaces only.
 
 ## `<AttachmentEntity>`
@@ -40,7 +40,7 @@ Creates a native attachment (a child WKWebView on visionOS) parented under a 3D 
 
 `attachment`
 
-**Required.** A string matching the `name` prop on the corresponding `<AttachmentAsset>`. This is how the entity knows which content template to display.
+**Required.** A string matching the `id` prop on the corresponding `<AttachmentAsset>`. This is how the entity knows which content template to display.
 
 `position`
 

--- a/packages/react/src/facades/lazy-load-facades.test.tsx
+++ b/packages/react/src/facades/lazy-load-facades.test.tsx
@@ -297,7 +297,6 @@ describe('lazy-load facades', () => {
             id="x"
             url="u"
             src="s"
-            name="n"
             attachment="a"
             size={{ width: 0, height: 0 }}
           >

--- a/packages/react/src/facades/resources.tsx
+++ b/packages/react/src/facades/resources.tsx
@@ -61,7 +61,7 @@ export type ModelAssetProps = {
 }
 
 export type AttachmentAssetProps = {
-  name: string
+  id: string
   children?: ReactNode
 }
 

--- a/packages/react/src/reality/components/AttachmentAsset.tsx
+++ b/packages/react/src/reality/components/AttachmentAsset.tsx
@@ -5,12 +5,12 @@ import type { ContainerEntry } from '../context/AttachmentContext'
 import { InsideAttachmentContext } from '../context/InsideAttachmentContext'
 
 type AttachmentAssetProps = {
-  name: string
+  id: string
   children?: React.ReactNode
 }
 
 export const AttachmentAsset: React.FC<AttachmentAssetProps> = ({
-  name,
+  id,
   children,
 }) => {
   const ctx = useRealityContext()
@@ -18,8 +18,8 @@ export const AttachmentAsset: React.FC<AttachmentAssetProps> = ({
 
   useEffect(() => {
     if (!ctx) return
-    return ctx.attachmentRegistry.onContainersChange(name, setContainers)
-  }, [ctx, name])
+    return ctx.attachmentRegistry.onContainersChange(id, setContainers)
+  }, [ctx, id])
 
   if (!containers.length) return null
   return (

--- a/packages/react/src/reality/context/AttachmentContext.test.ts
+++ b/packages/react/src/reality/context/AttachmentContext.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AttachmentRegistry } from './AttachmentContext'
+
+describe('AttachmentRegistry', () => {
+  it('keys containers by asset id', () => {
+    const registry = new AttachmentRegistry()
+    const first = document.createElement('div')
+    const second = document.createElement('div')
+
+    registry.addContainer('asset-a', 'instance-1', first)
+    registry.addContainer('asset-b', 'instance-2', second)
+
+    expect(registry.getContainers('asset-a')).toEqual([
+      { instanceId: 'instance-1', container: first },
+    ])
+    expect(registry.getContainers('asset-b')).toEqual([
+      { instanceId: 'instance-2', container: second },
+    ])
+  })
+
+  it('notifies listeners for the matching asset id only', () => {
+    const registry = new AttachmentRegistry()
+    const container = document.createElement('div')
+    const matchingListener = vi.fn()
+    const otherListener = vi.fn()
+
+    registry.onContainersChange('asset-a', matchingListener)
+    registry.onContainersChange('asset-b', otherListener)
+
+    registry.addContainer('asset-a', 'instance-1', container)
+
+    expect(matchingListener).toHaveBeenCalledWith([
+      { instanceId: 'instance-1', container },
+    ])
+    expect(otherListener).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/reality/context/AttachmentContext.tsx
+++ b/packages/react/src/reality/context/AttachmentContext.tsx
@@ -5,28 +5,28 @@ export type ContainerEntry = { instanceId: string; container: HTMLElement }
 type ContainersChangeCallback = (containers: ContainerEntry[]) => void
 
 export class AttachmentRegistry {
-  // name → (instanceId → container)
+  // asset id → (instanceId → container)
   private containers = new Map<string, Map<string, HTMLElement>>()
   private listeners = new Map<string, ContainersChangeCallback>()
 
-  addContainer(name: string, instanceId: string, container: HTMLElement) {
-    if (!this.containers.has(name)) {
-      this.containers.set(name, new Map())
+  addContainer(assetId: string, instanceId: string, container: HTMLElement) {
+    if (!this.containers.has(assetId)) {
+      this.containers.set(assetId, new Map())
     }
-    this.containers.get(name)!.set(instanceId, container)
-    this.notifyListeners(name)
+    this.containers.get(assetId)!.set(instanceId, container)
+    this.notifyListeners(assetId)
   }
 
-  removeContainer(name: string, instanceId: string) {
-    this.containers.get(name)?.delete(instanceId)
-    if (this.containers.get(name)?.size === 0) {
-      this.containers.delete(name)
+  removeContainer(assetId: string, instanceId: string) {
+    this.containers.get(assetId)?.delete(instanceId)
+    if (this.containers.get(assetId)?.size === 0) {
+      this.containers.delete(assetId)
     }
-    this.notifyListeners(name)
+    this.notifyListeners(assetId)
   }
 
-  getContainers(name: string): ContainerEntry[] {
-    const map = this.containers.get(name)
+  getContainers(assetId: string): ContainerEntry[] {
+    const map = this.containers.get(assetId)
     if (!map) return []
     return Array.from(map, ([instanceId, container]) => ({
       instanceId,
@@ -34,24 +34,27 @@ export class AttachmentRegistry {
     }))
   }
 
-  onContainersChange(name: string, cb: ContainersChangeCallback): () => void {
-    const current = this.getContainers(name)
+  onContainersChange(
+    assetId: string,
+    cb: ContainersChangeCallback,
+  ): () => void {
+    const current = this.getContainers(assetId)
     if (current.length > 0) {
       cb(current)
     }
-    const prev = this.listeners.get(name)
+    const prev = this.listeners.get(assetId)
     if (prev) prev([])
-    this.listeners.set(name, cb)
+    this.listeners.set(assetId, cb)
     return () => {
-      if (this.listeners.get(name) === cb) {
-        this.listeners.delete(name)
+      if (this.listeners.get(assetId) === cb) {
+        this.listeners.delete(assetId)
       }
     }
   }
 
-  private notifyListeners(name: string) {
-    const cs = this.getContainers(name)
-    this.listeners.get(name)?.(cs)
+  private notifyListeners(assetId: string) {
+    const cs = this.getContainers(assetId)
+    this.listeners.get(assetId)?.(cs)
   }
 
   destroy() {


### PR DESCRIPTION
### Motivation
- Align `AttachmentAsset` declarations with other asset APIs (e.g. `ModelAsset id="..."`) by using an `id` prop instead of `name`.
- Keep `AttachmentEntity` transform/size/tuple API unchanged while updating the registry wiring to use an asset identifier.

### Description
- Change `AttachmentAsset` public prop from `name` to `id` and subscribe to the registry using `id` in `packages/react/src/reality/components/AttachmentAsset.tsx`.
- Update `AttachmentRegistry` to key containers and listeners by `assetId` and rename method parameters accordingly in `packages/react/src/reality/context/AttachmentContext.tsx` while preserving behavior.
- Update facade typings (`AttachmentAssetProps`) and the lazy-load fallback test to drop the old `name="n"` usage in `packages/react/src/facades/resources.tsx` and `packages/react/src/facades/lazy-load-facades.test.tsx`.
- Update demo declarations and docs (`apps/test-server/src/pages/reality/attachments.tsx` and `docs/Attachments.md`) to use `id`, and add focused registry tests in `packages/react/src/reality/context/AttachmentContext.test.ts`.

### Testing
- Ran `pnpm -C packages/react vitest run src/reality/context/AttachmentContext.test.ts src/facades/lazy-load-facades.test.tsx` and all tests passed.
- Ran TypeScript check with `pnpm -C packages/react exec tsc -p ./tsconfig.json --noEmit` and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b308c9bb88323b71dd352ee6392ba)