### PR TITLE
chore: Swift simplify retrieval and passing of elements to Views

### DIFF
--- a/.changeset/plain-hairs-join.md
+++ b/.changeset/plain-hairs-join.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Improve type safety of Swift code

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -41,8 +41,8 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
     var parent: (any ScrollAbleSpatialElementContainer)?
 
     var attachmentManager = AttachmentManager()
-    // NOTE: `@Observable` + `lazy` 在新版本 Swift 宏展开下会触发编译器报错（init accessor 访问 backing storage）。
-    // 这里不需要让动画管理器参与 Observation，避免生成 `@ObservationTracked` 相关访问器即可。
+    /// NOTE: `@Observable` + `lazy` 在新版本 Swift 宏展开下会触发编译器报错（init accessor 访问 backing storage）。
+    /// 这里不需要让动画管理器参与 Observation，避免生成 `@ObservationTracked` 相关访问器即可。
     @ObservationIgnored
     lazy var animationManager: EntityAnimationManager = .init(scene: self)
 
@@ -930,17 +930,8 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
         children.removeValue(forKey: spatializedElement.id)
     }
 
-    func getChildrenOfType(_ type: SpatializedElementType) -> [String: SpatializedElement] {
-        return children.filter {
-            switch type {
-            case .Spatialized2DElement:
-                return $0.value is Spatialized2DElement
-            case .SpatializedStatic3DElement:
-                return $0.value is SpatializedStatic3DElement
-            case .SpatializedDynamic3DElement:
-                return $0.value is SpatializedDynamic3DElement
-            }
-        }
+    func getChildren<T: SpatializedElement>(ofType type: T.Type) -> [T] {
+        return children.values.compactMap { $0 as? T }
     }
 
     func getChildren() -> [String: SpatializedElement] {

--- a/packages/visionOS/web-spatial/model/Spatialized2DElement.swift
+++ b/packages/visionOS/web-spatial/model/Spatialized2DElement.swift
@@ -74,17 +74,8 @@ class Spatialized2DElement: SpatializedElement, ScrollAbleSpatialElementContaine
         return children
     }
 
-    func getChildrenOfType(_ type: SpatializedElementType) -> [String: SpatializedElement] {
-        return children.filter {
-            switch type {
-            case .Spatialized2DElement:
-                return $0.value is Spatialized2DElement
-            case .SpatializedStatic3DElement:
-                return $0.value is SpatializedStatic3DElement
-            case .SpatializedDynamic3DElement:
-                return $0.value is SpatializedDynamic3DElement
-            }
-        }
+    func getChildren<T: SpatializedElement>(ofType type: T.Type) -> [T] {
+        return children.values.compactMap { $0 as? T }
     }
 
     func loadHtml(_ html: String) {

--- a/packages/visionOS/web-spatial/protocol/SpatializedElementContainer.swift
+++ b/packages/visionOS/web-spatial/protocol/SpatializedElementContainer.swift
@@ -4,5 +4,5 @@ protocol SpatializedElementContainer {
     func addChild(_ spatializedElement: SpatializedElement)
     func removeChild(_ spatializedElement: SpatializedElement)
     func getChildren() -> [String: SpatializedElement]
-    func getChildrenOfType(_ type: SpatializedElementType) -> [String: SpatializedElement]
+    func getChildren<T: SpatializedElement>(ofType type: T.Type) -> [T]
 }

--- a/packages/visionOS/web-spatial/view/SpatialSceneContentView.swift
+++ b/packages/visionOS/web-spatial/view/SpatialSceneContentView.swift
@@ -32,31 +32,28 @@ struct SpatialSceneContentView: View {
                         .frame(width: width, height: height)
                         .offset(z: -1)
 
-                    let childrenOfSpatialized2DElement: [SpatializedElement] = Array(spatialScene.getChildrenOfType(.Spatialized2DElement).values)
+                    let childrenOfSpatialized2DElement = spatialScene.getChildren(ofType: Spatialized2DElement.self)
 
                     ForEach(childrenOfSpatialized2DElement, id: \.id) { child in
-                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset) {
-                            Spatialized2DElementView()
+                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset, spatializedElement: child) {
+                            Spatialized2DElementView(spatialized2DElement: child)
                         }
-                        .environment(child)
                     }
 
-                    let childrenOfSpatializedStatic3DElement: [SpatializedElement] = Array(spatialScene.getChildrenOfType(.SpatializedStatic3DElement).values)
+                    let childrenOfSpatializedStatic3DElement = spatialScene.getChildren(ofType: SpatializedStatic3DElement.self)
 
                     ForEach(childrenOfSpatializedStatic3DElement, id: \.id) { child in
-                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset) {
-                            SpatializedStatic3DView()
+                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset, spatializedElement: child) {
+                            SpatializedStatic3DView(spatializedStatic3DElement: child)
                         }
-                        .environment(child)
                     }
 
-                    let childrenOfSpatializedDynamic3DElement: [SpatializedElement] = Array(spatialScene.getChildrenOfType(.SpatializedDynamic3DElement).values)
+                    let childrenOfSpatializedDynamic3DElement = spatialScene.getChildren(ofType: SpatializedDynamic3DElement.self)
 
                     ForEach(childrenOfSpatializedDynamic3DElement, id: \.id) { child in
-                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset) {
-                            SpatializedDynamic3DView()
+                        SpatializedElementView(parentScrollOffset: spatialScene.scrollOffset, spatializedElement: child) {
+                            SpatializedDynamic3DView(spatializedDynamic3DElement: child)
                         }
-                        .environment(child)
                     }
                 }
             }

--- a/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
+++ b/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
@@ -19,12 +19,8 @@ class Spatialized2DViewGestureData {
 }
 
 struct Spatialized2DElementView: View {
-    @Environment(SpatializedElement.self) var spatializedElement: SpatializedElement
+    let spatialized2DElement: Spatialized2DElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
-
-    private var spatialized2DElement: Spatialized2DElement {
-        return spatializedElement as! Spatialized2DElement
-    }
 
     @State private var gestureData = Spatialized2DViewGestureData()
 
@@ -40,30 +36,27 @@ struct Spatialized2DElementView: View {
                 )
                 .simultaneousGesture(spatialized2DElement.scrollPageEnabled ? dragWebGesture : nil)
 
-            let childrenOfSpatialized2DElement: [SpatializedElement] = Array(spatialized2DElement.getChildrenOfType(.Spatialized2DElement).values)
+            let childrenOfSpatialized2DElement = spatialized2DElement.getChildren(ofType: Spatialized2DElement.self)
 
             ForEach(childrenOfSpatialized2DElement, id: \.id) { child in
-                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset) {
-                    Spatialized2DElementView()
+                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset, spatializedElement: child) {
+                    Spatialized2DElementView(spatialized2DElement: child)
                 }
-                .environment(child)
             }
 
-            let childrenOfSpatializedStatic3DElement: [SpatializedElement] = Array(spatialized2DElement.getChildrenOfType(.SpatializedStatic3DElement).values)
+            let childrenOfSpatializedStatic3DElement = spatialized2DElement.getChildren(ofType: SpatializedStatic3DElement.self)
             ForEach(childrenOfSpatializedStatic3DElement, id: \.id) { child in
-                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset) {
-                    SpatializedStatic3DView()
+                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset, spatializedElement: child) {
+                    SpatializedStatic3DView(spatializedStatic3DElement: child)
                 }
-                .environment(child)
             }
 
-            let childrenOfSpatializedDynamic3DElement: [SpatializedElement] = Array(spatialized2DElement.getChildrenOfType(.SpatializedDynamic3DElement).values)
+            let childrenOfSpatializedDynamic3DElement = spatialized2DElement.getChildren(ofType: SpatializedDynamic3DElement.self)
 
             ForEach(childrenOfSpatializedDynamic3DElement, id: \.id) { child in
-                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset) {
-                    SpatializedDynamic3DView()
+                SpatializedElementView(parentScrollOffset: spatialized2DElement.scrollOffset, spatializedElement: child) {
+                    SpatializedDynamic3DView(spatializedDynamic3DElement: child)
                 }
-                .environment(child)
             }
         }
     }

--- a/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
@@ -2,15 +2,11 @@ import RealityKit
 import SwiftUI
 
 struct SpatializedDynamic3DView: View {
-    @Environment(SpatializedElement.self) var spatializedElement: SpatializedElement
+    let spatializedDynamic3DElement: SpatializedDynamic3DElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
     @State private var isDrag = false
     @State private var isRotate = false
     @State private var isScale = false
-
-    private var spatializedDynamic3DElement: SpatializedDynamic3DElement {
-        return spatializedElement as! SpatializedDynamic3DElement
-    }
 
     var spatialTapEvent: some Gesture {
         SpatialTapGesture(count: 1).targetedToAnyEntity()
@@ -63,7 +59,7 @@ struct SpatializedDynamic3DView: View {
     }
 
     private func makeRotateGesture3D() -> RotateGesture3D {
-        guard let raw = spatializedElement.rotateConstrainedToAxis else {
+        guard let raw = spatializedDynamic3DElement.rotateConstrainedToAxis else {
             return RotateGesture3D()
         }
         let dx = Double(raw.x)

--- a/packages/visionOS/web-spatial/view/SpatializedElementView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedElementView.swift
@@ -7,7 +7,7 @@ final class GestureState {
 }
 
 struct SpatializedElementView<Content: View>: View {
-    @Environment(SpatializedElement.self) var spatializedElement: SpatializedElement
+    let spatializedElement: SpatializedElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
 
     var parentScrollOffset: Vec2
@@ -15,8 +15,9 @@ struct SpatializedElementView<Content: View>: View {
 
     @State private var gestureState = GestureState()
 
-    init(parentScrollOffset: Vec2, @ViewBuilder content: () -> Content) {
+    init(parentScrollOffset: Vec2, spatializedElement: SpatializedElement, @ViewBuilder content: () -> Content) {
         self.parentScrollOffset = parentScrollOffset
+        self.spatializedElement = spatializedElement
         self.content = content()
     }
 

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -2,14 +2,10 @@ import RealityKit
 import SwiftUI
 
 struct SpatializedStatic3DView: View {
-    @Environment(SpatializedElement.self) var spatializedElement: SpatializedElement
+    let spatializedStatic3DElement: SpatializedStatic3DElement
     @Environment(SpatialScene.self) var spatialScene: SpatialScene
 
     @State private var loadState: LoadState = .idle
-
-    private var spatializedStatic3DElement: SpatializedStatic3DElement {
-        return spatializedElement as! SpatializedStatic3DElement
-    }
 
     private var asset: Model3DAsset? {
         if case let .loaded(asset, _) = loadState { return asset }
@@ -17,15 +13,15 @@ struct SpatializedStatic3DView: View {
     }
 
     func onLoadSuccess(src: String) {
-        spatialScene.sendWebMsg(spatializedElement.id, ModelLoadSuccess(src: src))
+        spatialScene.sendWebMsg(spatializedStatic3DElement.id, ModelLoadSuccess(src: src))
     }
 
     func onLoadFailure() {
-        spatialScene.sendWebMsg(spatializedElement.id, ModelLoadFailure())
+        spatialScene.sendWebMsg(spatializedStatic3DElement.id, ModelLoadFailure())
     }
 
     var body: some View {
-        let depth = spatializedElement.depth
+        let depth = spatializedStatic3DElement.depth
         let transform = spatializedStatic3DElement.entityTransform
         let translation = transform.translation
         let scale = transform.scale
@@ -34,7 +30,7 @@ struct SpatializedStatic3DView: View {
         let y = translation.y
         let z = translation.z
 
-        let enableGesture = spatializedElement.enableGesture
+        let enableGesture = spatializedStatic3DElement.enableGesture
         if spatializedStatic3DElement.loading == .eager {
             Group {
                 switch loadState {
@@ -151,7 +147,7 @@ struct SpatializedStatic3DView: View {
         let duration = controller?.duration ?? 0
         let currentTime = controller?.time ?? 0
         spatialScene.sendWebMsg(
-            spatializedElement.id,
+            spatializedStatic3DElement.id,
             AnimationStateChangeEvent(
                 detail: AnimationStateChangeDetail(
                     paused: isPaused,


### PR DESCRIPTION
Previously children of a particular type were retrieved and passed to SwiftUI views. But the type was erased before passing to the views requiring a runtime casting. This change adds stricter type safety and requires the element to be passed as a property instead of environment variable.
