### PR TITLE
chore(deps): tighten Vite and esbuild ranges to patched versions

### DIFF
--- a/apps/spatial-remix-min/package.json
+++ b/apps/spatial-remix-min/package.json
@@ -29,6 +29,6 @@
     "@types/react-dom": "^18.3.7",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.7.3",
-    "vite": "^6.2.4"
+    "vite": ">=6.4.2 <7.0.0"
   }
 }

--- a/apps/spatial-vite-min/package.json
+++ b/apps/spatial-vite-min/package.json
@@ -21,6 +21,6 @@
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.7.3",
-    "vite": "^6.2.4"
+    "vite": ">=6.4.2 <7.0.0"
   }
 }

--- a/apps/test-server/package.json
+++ b/apps/test-server/package.json
@@ -60,7 +60,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "concurrently": "^8.2.2",
     "daisyui": "^4.12.10",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.25.3",
     "esbuild-css-modules-plugin": "^3.1.2",
     "esbuild-plugin-tailwindcss": "^1.2.0",
     "esbuild-sass-plugin": "^3.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -88,7 +88,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitejs/plugin-react": "^4.4.1",
     "@webspatial/core-sdk": "workspace:*",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.25.3",
     "esbuild-plugin-d.ts": "^1.3.1",
     "esbuild-plugin-define": "^0.5.0",
     "jsdom": "^24.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,7 +417,7 @@ importers:
         specifier: ^4.12.10
         version: 4.12.24(postcss@8.5.12)
       esbuild:
-        specifier: ^0.25.0
+        specifier: ^0.25.3
         version: 0.25.3
       esbuild-css-modules-plugin:
         specifier: ^3.1.2
@@ -605,7 +605,7 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
       esbuild:
-        specifier: ^0.25.0
+        specifier: ^0.25.3
         version: 0.25.3
       esbuild-plugin-d.ts:
         specifier: ^1.3.1

--- a/tests/autoTest/package.json
+++ b/tests/autoTest/package.json
@@ -33,7 +33,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
-    "vite": "^6.3.1"
+    "vite": ">=6.4.2 <7.0.0"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.17",

--- a/tests/ci-test/package.json
+++ b/tests/ci-test/package.json
@@ -35,6 +35,6 @@
     "globals": "^16.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.3.1"
+    "vite": ">=6.4.2 <7.0.0"
   }
 }

--- a/tests/marginal-delta-vite/package.json
+++ b/tests/marginal-delta-vite/package.json
@@ -13,7 +13,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vite": "^6.2.4",
+    "vite": ">=6.4.2 <7.0.0",
     "vitest": "^3.1.2"
   },
   "devDependencies": {

--- a/tests/react18-compat/package.json
+++ b/tests/react18-compat/package.json
@@ -11,7 +11,7 @@
     "@webspatial/react-sdk": "workspace:*",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.7.3",
-    "vite": "^6.2.4",
+    "vite": ">=6.4.2 <7.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
### Motivation
- Address Dependabot/OSSVC advisories by ensuring workspace fixtures and tests require the patched Vite 6.4.2+ floor and the patched `esbuild` release. 
- Align manifest specifiers with already-resolved lockfile overrides to avoid accidental install of vulnerable versions. 
- Reduce noise from transient vulnerable ranges in consumer-shaped demo and test manifests so CI and local installs use known-patched versions. 

### Description
- Updated multiple `package.json` dev/dependency specifiers to require `vite` as `>=6.4.2 <7.0.0` across fixture and test projects (apps/spatial-vite-min, apps/spatial-remix-min, tests/autoTest, tests/ci-test, tests/marginal-delta-vite, tests/react18-compat). 
- Bumped direct `esbuild` dev ranges to `^0.25.3` where the repo already resolves that patched version (apps/test-server, packages/react, etc.). 
- Kept `pnpm-lock.yaml` importer specifiers and lockfile entries aligned with the manifest changes so the lockfile reflects the tightened specifiers.

### Testing
- Ran `pnpm install --frozen-lockfile --offline` which completed successfully with the updated manifest/lockfile alignment. 
- Ran `pnpm run test:workflows` which completed successfully. 
- Verified manifests/lockfile edits with a repository search (`rg`) for the previous vulnerable specifiers which returned no remaining matches. 
- `pnpm audit --json` could not be executed in this environment because the npm audit endpoint returned HTTP 403, and `pnpm --filter spatial-vite-min --fail-if-no-match build` failed due to workspace packages not being built (local `@webspatial/react-sdk` outputs/types were not available at fixture build time).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4258b1d54c832caf36c016b2011edd)