### PR TITLE
Fix Model load event typing

### DIFF
--- a/.changeset/gentle-mammals-mate.md
+++ b/.changeset/gentle-mammals-mate.md
@@ -1,0 +1,6 @@
+---
+'web-content': patch
+'@webspatial/react-sdk': patch
+---
+
+Fix Model load event typing

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -48,7 +48,7 @@ function App() {
         }}
         ref={modelRef}
         onError={e => logLine(`Model error ${modelRef.current?.currentSrc}`)}
-        onLoad={e => logLine(`Model success ${e.target.currentSrc}`)}
+        onLoad={e => logLine(`Model success ${e.currentTarget.currentSrc}`)}
         onSpatialTap={e => {
           logLine('model onSpatialTap', e.detail.location3D)
         }}

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1915,6 +1915,8 @@ describe('SpatializedStatic3DElementContainer', () => {
     expect(onLoad.mock.calls[0]?.[0].type).toBe('modelloaded')
     expect(onError.mock.calls[0]?.[0].type).toBe('modelloadfailed')
     expect(onLoad.mock.calls[0]?.[0].target).toEqual({ tid: 1 })
+    expect(onLoad.mock.calls[0]?.[0].currentTarget).toEqual({ tid: 1 })
+    expect(onError.mock.calls[0]?.[0].currentTarget).toEqual({ tid: 1 })
 
     expect(extra.currentSrc).toBe(window.location.origin + '/resolved.usdz')
     await expect(extra.ready).resolves.toMatchObject({ type: 'modelloaded' })

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.test.tsx
@@ -258,6 +258,8 @@ describe('SpatializedStatic3DElementContainer lazy/eager loading behavior', () =
       Promise.resolve().then(() => extra.ready),
     ).resolves.toMatchObject({
       type: 'modelloaded',
+      currentTarget: domProxy,
+      target: domProxy,
     })
   })
 })

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -43,7 +43,7 @@ function createLoadEvent(
   })
   const proxyEvent = new Proxy(event, {
     get(target, prop) {
-      if (prop === 'target') {
+      if (prop === 'target' || prop === 'currentTarget') {
         return targetGetter()
       }
       return Reflect.get(target, prop)

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -237,6 +237,10 @@ export type ModelSpatialMagnifyEvent =
 export type ModelSpatialMagnifyEndEvent =
   SpatialMagnifyEndEvent<SpatializedStatic3DElementRef>
 
-export type ModelLoadEvent = CustomEvent & {
-  target: SpatializedStatic3DElementRef
+export type ModelLoadEvent<Target extends HTMLElement = HTMLElement> = Omit<
+  CustomEvent,
+  'currentTarget' | 'target'
+> & {
+  currentTarget: SpatializedStatic3DElementRef
+  target: Target
 }


### PR DESCRIPTION
Model load/error handlers may receive bubbled child events, so event.target should describe the emitting HTMLElement while event.currentTarget remains the Model ref.

Fixes #1293