### PR TITLE
fix: ModelLoadEvent typing to cover bubbled child load/error events

### DIFF
--- a/.changeset/model-load-event-child-target.md
+++ b/.changeset/model-load-event-child-target.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Fix `ModelLoadEvent` typings to cover bubbled child load/error events (#1293).

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -48,7 +48,7 @@ function App() {
         }}
         ref={modelRef}
         onError={e => logLine(`Model error ${modelRef.current?.currentSrc}`)}
-        onLoad={e => logLine(`Model success ${e.target.currentSrc}`)}
+        onLoad={e => logLine(`Model success ${e.currentTarget.currentSrc}`)}
         onSpatialTap={e => {
           logLine('model onSpatialTap', e.detail.location3D)
         }}

--- a/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
+++ b/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
@@ -5,11 +5,11 @@ import { Logger, useLogger } from './Logger'
 const MODEL_SRC =
   'https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz'
 
-function describeTarget(event: ModelLoadEvent) {
+function describeCurrentTarget(event: ModelLoadEvent) {
   return {
-    tagName: event.target.tagName,
-    currentSrc: event.target.currentSrc,
-    readyProperty: 'ready' in event.target,
+    tagName: event.currentTarget.tagName,
+    currentSrc: event.currentTarget.currentSrc,
+    readyProperty: 'ready' in event.currentTarget,
   }
 }
 
@@ -25,39 +25,45 @@ export default function NestedStatic3DModelReady() {
   useEffect(() => {
     logLine(
       'page mounted',
-      'Mounts <div enable-xr><Model enable-xr /></div> and reads event.target.ready from onLoad.',
+      'Mounts <div enable-xr><Model enable-xr /></div> and reads event.currentTarget.ready from onLoad.',
     )
   }, [logLine])
 
   const handleLoad = useCallback(
     (event: ModelLoadEvent) => {
-      const target = describeTarget(event)
-      logLine('onLoad target', target)
-      setStatus('onLoad fired; waiting for event.target.ready')
+      const currentTarget = describeCurrentTarget(event)
+      logLine('onLoad currentTarget', currentTarget)
+      setStatus('onLoad fired; waiting for event.currentTarget.ready')
 
       let ready
       try {
-        ready = event.target.ready
+        ready = event.currentTarget.ready
       } catch (error) {
-        logLine('event.target.ready getter threw', getErrorMessage(error))
-        setStatus('event.target.ready getter threw')
+        logLine(
+          'event.currentTarget.ready getter threw',
+          getErrorMessage(error),
+        )
+        setStatus('event.currentTarget.ready getter threw')
         return
       }
 
       if (!ready || typeof ready.then !== 'function') {
-        logLine('event.target.ready unavailable')
-        setStatus('event.target.ready unavailable')
+        logLine('event.currentTarget.ready unavailable')
+        setStatus('event.currentTarget.ready unavailable')
         return
       }
 
       ready
         .then(readyEvent => {
-          logLine('event.target.ready resolved', describeTarget(readyEvent))
-          setStatus('event.target.ready resolved')
+          logLine(
+            'event.currentTarget.ready resolved',
+            describeCurrentTarget(readyEvent),
+          )
+          setStatus('event.currentTarget.ready resolved')
         })
         .catch(error => {
-          logLine('event.target.ready rejected', getErrorMessage(error))
-          setStatus('event.target.ready rejected')
+          logLine('event.currentTarget.ready rejected', getErrorMessage(error))
+          setStatus('event.currentTarget.ready rejected')
         })
     },
     [logLine],
@@ -65,7 +71,7 @@ export default function NestedStatic3DModelReady() {
 
   const handleError = useCallback(
     (event: ModelLoadEvent) => {
-      logLine('onError target', describeTarget(event))
+      logLine('onError currentTarget', describeCurrentTarget(event))
       setStatus('Model onError fired')
     },
     [logLine],
@@ -76,8 +82,8 @@ export default function NestedStatic3DModelReady() {
       <h1>Nested Static 3D Model Ready</h1>
       <p className="max-w-3xl text-sm text-gray-300">
         Reproduces the nested static 3D model path where a spatial parent owns
-        the branch and the Model load event target still needs a working ready
-        promise.
+        the branch and the Model load event currentTarget still needs a working
+        ready promise.
       </p>
 
       <div className="mb-4 flex flex-wrap items-center gap-2 not-prose">
@@ -122,7 +128,10 @@ export default function NestedStatic3DModelReady() {
           onClick={() => {
             modelRef.current?.ready
               .then(event => {
-                logLine('ref.current.ready resolved', describeTarget(event))
+                logLine(
+                  'ref.current.ready resolved',
+                  describeCurrentTarget(event),
+                )
               })
               .catch(error => {
                 logLine('ref.current.ready rejected', getErrorMessage(error))

--- a/packages/react/src/coverage-boost.test.ts
+++ b/packages/react/src/coverage-boost.test.ts
@@ -1915,6 +1915,8 @@ describe('SpatializedStatic3DElementContainer', () => {
     expect(onLoad.mock.calls[0]?.[0].type).toBe('modelloaded')
     expect(onError.mock.calls[0]?.[0].type).toBe('modelloadfailed')
     expect(onLoad.mock.calls[0]?.[0].target).toEqual({ tid: 1 })
+    expect(onLoad.mock.calls[0]?.[0].currentTarget).toEqual({ tid: 1 })
+    expect(onError.mock.calls[0]?.[0].currentTarget).toEqual({ tid: 1 })
 
     expect(extra.currentSrc).toBe(window.location.origin + '/resolved.usdz')
     await expect(extra.ready).resolves.toMatchObject({ type: 'modelloaded' })

--- a/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
+++ b/packages/react/src/spatialized-container/SpatializedStatic3DElementContainer.tsx
@@ -43,7 +43,7 @@ function createLoadEvent(
   })
   const proxyEvent = new Proxy(event, {
     get(target, prop) {
-      if (prop === 'target') {
+      if (prop === 'target' || prop === 'currentTarget') {
         return targetGetter()
       }
       return Reflect.get(target, prop)

--- a/packages/react/src/spatialized-container/types.ts
+++ b/packages/react/src/spatialized-container/types.ts
@@ -237,6 +237,8 @@ export type ModelSpatialMagnifyEvent =
 export type ModelSpatialMagnifyEndEvent =
   SpatialMagnifyEndEvent<SpatializedStatic3DElementRef>
 
-export type ModelLoadEvent = CustomEvent & {
-  target: SpatializedStatic3DElementRef
-}
+export type ModelLoadEvent<T extends EventTarget = EventTarget> =
+  CustomEvent & {
+    target: T
+    currentTarget: SpatializedStatic3DElementRef
+  }

--- a/packages/react/src/types/global.d.ts
+++ b/packages/react/src/types/global.d.ts
@@ -1,4 +1,5 @@
 import type React from 'react'
+import type { ModelLoadEvent } from '../spatialized-container/types'
 
 declare global {
   interface Window {
@@ -19,8 +20,8 @@ declare global {
           poster?: string
           autoplay?: boolean
           loop?: boolean
-          onLoad?: (...args: any[]) => void
-          onError?: (...args: any[]) => void
+          onLoad?: (event: ModelLoadEvent) => void
+          onError?: (event: ModelLoadEvent) => void
         },
         HTMLElement
       >


### PR DESCRIPTION
ModelLoadEvent hard-typed target as the Model ref and omitted currentTarget. This breaks when a child <img>/<video> fires a load/error that bubbles to the Model, target is the child element. Co-Authored-By Claude Opus 4.8

Fixes #1293 
