### PR TITLE
feat: add React experimental entry

### DIFF
--- a/.changeset/react-sdk-experimental-entry.md
+++ b/.changeset/react-sdk-experimental-entry.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/react-sdk': minor
+---
+
+Add an opt-in `@webspatial/react-sdk/experimental` entry for APIs whose names or parameters may change before they graduate into the default stable entry.

--- a/apps/test-server/esbuild.mjs
+++ b/apps/test-server/esbuild.mjs
@@ -87,6 +87,9 @@ const buildOptions = {
     '@webspatial/react-sdk/eager': path.resolve(
       `${packagesBasePath}/react/src/eager.ts`,
     ),
+    '@webspatial/react-sdk/experimental': path.resolve(
+      `${packagesBasePath}/react/src/experimental.ts`,
+    ),
     '@webspatial/react-sdk': path.resolve(
       `${packagesBasePath}/react/src/index.ts`,
     ),

--- a/apps/test-server/tsconfig.json
+++ b/apps/test-server/tsconfig.json
@@ -32,6 +32,9 @@
         "../../packages/react/src/spatial/index.ts"
       ],
       "@webspatial/react-sdk/eager": ["../../packages/react/src/eager.ts"],
+      "@webspatial/react-sdk/experimental": [
+        "../../packages/react/src/experimental.ts"
+      ],
       "@webspatial/react-sdk/jsx-runtime": [
         "../../packages/react/src/jsx/jsx-runtime.ts"
       ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
   "sideEffects": [
     "./dist/index.js",
     "./dist/eager.js",
+    "./dist/experimental.js",
     "./dist/spatial.js",
     "./src/eager.ts",
     "./src/runtime/registerEagerEntry.ts",
@@ -21,6 +22,10 @@
     "./eager": {
       "types": "./dist/eager.d.ts",
       "default": "./dist/eager.js"
+    },
+    "./experimental": {
+      "types": "./dist/experimental.d.ts",
+      "default": "./dist/experimental.js"
     },
     "./spatial": {
       "types": "./dist/spatial.d.ts",

--- a/packages/react/src/__tests__/published-package-shape.test.ts
+++ b/packages/react/src/__tests__/published-package-shape.test.ts
@@ -91,6 +91,7 @@ describe('packages/react/package.json — published shape (spec tasks.md §8.7 /
         expect.arrayContaining([
           './dist/index.js',
           './dist/eager.js',
+          './dist/experimental.js',
           './dist/spatial.js',
           './src/eager.ts',
           './src/spatial/index.ts',
@@ -122,6 +123,19 @@ describe('packages/react/package.json — published shape (spec tasks.md §8.7 /
         | undefined
       const file = typeof sub === 'string' ? sub : sub?.default
       expect(file).toBe('./dist/spatial.js')
+    })
+
+    it('exports["./experimental"] resolves to dist/experimental.js (opt-in unstable surface)', () => {
+      const pkg = loadPackageJson()
+      const sub = pkg.exports?.['./experimental'] as
+        | Record<string, string>
+        | string
+        | undefined
+      expect(sub).toBeDefined()
+      const file = typeof sub === 'string' ? sub : sub?.default
+      const types = typeof sub === 'string' ? undefined : sub?.types
+      expect(file).toBe('./dist/experimental.js')
+      expect(types).toBe('./dist/experimental.d.ts')
     })
 
     it('exports["./jsx-runtime"] is a single mapping (NO `react-server` conditional)', () => {

--- a/packages/react/src/__tests__/test-server-sdk-subpath-aliases.test.ts
+++ b/packages/react/src/__tests__/test-server-sdk-subpath-aliases.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const testServerDir = resolve(__dirname, '../../../../apps/test-server')
+
+describe('test-server React SDK subpath aliases', () => {
+  it('maps the experimental entry before the root React SDK alias in esbuild', () => {
+    const source = readFileSync(resolve(testServerDir, 'esbuild.mjs'), 'utf8')
+    const experimentalSpecifier =
+      "'@webspatial/react-sdk/experimental': path.resolve("
+    const rootSpecifier = "'@webspatial/react-sdk': path.resolve("
+
+    const experimentalIndex = source.indexOf(experimentalSpecifier)
+    const rootIndex = source.indexOf(rootSpecifier)
+
+    expect(experimentalIndex).toBeGreaterThanOrEqual(0)
+    expect(source).toContain('/react/src/experimental.ts')
+    expect(rootIndex).toBeGreaterThan(experimentalIndex)
+  })
+
+  it('maps the experimental entry in TypeScript paths', () => {
+    const source = readFileSync(resolve(testServerDir, 'tsconfig.json'), 'utf8')
+
+    expect(source).toContain('"@webspatial/react-sdk/experimental"')
+    expect(source).toContain('../../packages/react/src/experimental.ts')
+  })
+})

--- a/packages/react/src/__tests__/use-client-directive.test.ts
+++ b/packages/react/src/__tests__/use-client-directive.test.ts
@@ -64,6 +64,15 @@ describe('"use client" directive on published dist (spec tasks.md §13.1)', () =
       expect(startsWithUseClient(eagerPath)).toBe(true)
     })
 
+    it('dist/experimental.js begins with the "use client" directive', () => {
+      // The experimental entry is an opt-in public surface. It may expose
+      // React hooks or components before their default-entry API is stable,
+      // so it needs the same RSC boundary treatment as the default entry.
+      const experimentalPath = resolve(distDir, 'experimental.js')
+      expect(existsSync(experimentalPath)).toBe(true)
+      expect(startsWithUseClient(experimentalPath)).toBe(true)
+    })
+
     it('dist/internal/facades-client.js begins with the "use client" directive', () => {
       // The internal facade boundary used by the JSX runtime
       // (`src/internal/facades-client.ts`). It is reached transitively

--- a/packages/react/src/experimental.ts
+++ b/packages/react/src/experimental.ts
@@ -1,0 +1,7 @@
+'use client'
+
+// Opt-in surface for APIs whose names or parameters are still allowed to
+// change before they graduate into the default entry. Keep this module small:
+// only export APIs that are intentionally available to npm consumers via
+// `@webspatial/react-sdk/experimental`.
+export {}

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -14,6 +14,8 @@
 //                       family, materials/assets, real `useMetrics`, real
 //                       containers, real monitor) + the `initPolyfill()`
 //                       bootstrap moved out of the default entry by PR 4.
+// - `dist/experimental.js` — opt-in public entry for APIs whose names or
+//                            parameters may still change before graduation.
 // - `dist/jsx/jsx-runtime.js` and `dist/jsx/jsx-dev-runtime.js` — single
 //   unified JSX runtime serving plain web, AVP, SSR, and RSC consumers (per
 //   spec "JSX runtime strips spatial markers and wraps with facade HOCs"
@@ -170,6 +172,10 @@ export default defineConfig([
       // common chunk and the eager entry does NOT duplicate code that the
       // default entry already ships.
       eager: 'src/eager.ts',
+      // Opt-in public surface for unstable APIs. Publishing it as a subpath
+      // keeps experiments available to npm consumers without widening the
+      // default-entry semver contract.
+      experimental: 'src/experimental.ts',
       // Emitted as its OWN entry (not inlined into `eager.js`) so the eager
       // mixed-entry registration runs during the import-evaluation phase —
       // before `eager.js` evaluates its `./spatial` import. If this module
@@ -228,6 +234,11 @@ export default defineConfig([
       // the directive the RSC compiler would attempt server execution
       // of the underlying hook code and fail at the first hook call.
       ensureRscClientBoundary(resolve(__dirname, 'dist/eager.js'), {
+        stampVersion: true,
+      })
+      // Experimental entry — public opt-in RSC boundary. It may expose hooks
+      // or components before their default-entry API is stable.
+      ensureRscClientBoundary(resolve(__dirname, 'dist/experimental.js'), {
         stampVersion: true,
       })
       // Spatial entry — no RSC directive (dynamic-import target), but it


### PR DESCRIPTION
## Summary

- Add an opt-in `@webspatial/react-sdk/experimental` package subpath for unstable React SDK APIs.
- Wire `src/experimental.ts` into the React SDK tsup entry graph so npm publishes `dist/experimental.js` and `dist/experimental.d.ts`.
- Keep the default `@webspatial/react-sdk` entry stable-only while tests guard the experimental export mapping and RSC `use client` boundary.
- Add a changeset documenting the new minor React SDK surface.

## Impact

Consumers can explicitly opt into experimental APIs via:

```ts
import { SomeExperimentalApi } from '@webspatial/react-sdk/experimental'
```

The experimental entry currently exports no APIs. It establishes the package boundary for future unstable APIs without widening the default-entry semver contract.

## Validation

- `git diff --check HEAD~1..HEAD`
- `PATH="/usr/local/bin:/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" /usr/local/bin/pnpm --dir packages/react test`

Note: the React test run prints expected `useAnimation` validation error stacks from negative-path tests, but the command exits successfully with `41 passed` test files and `522 passed | 4 todo` tests.