### PR TITLE
docs: add release API guides

### DIFF
--- a/docs/main-release-alpha-2.1-diff.md
+++ b/docs/main-release-alpha-2.1-diff.md
@@ -1,0 +1,385 @@
+# Main Release Notes and Alpha 2.1 Diff
+
+This document summarizes the current `main` branch for release planning. It
+covers release notes, migration guidance for breaking changes, and the user
+visible diff against the public WebSpatial docs that describe the alpha 2.1
+baseline.
+
+Snapshot:
+
+- Branch: `main`
+- Commit: `e892d53d372813b140e3c7018dce2334322270db`
+- Package manifests currently report `1.7.0`, while pending changesets include
+  major changes for `@webspatial/react-sdk`.
+- Public docs baseline:
+  <https://webspatial.dev/docs/introduction/getting-started>
+- Runtime baseline in public docs: alpha 2.1. In the repo capability table this
+  maps closest to `PicoWebApp 0.1.1`; `main` also contains later beta and
+  post-alpha capability rows.
+
+## Executive Summary
+
+The current `main` branch is materially ahead of the public alpha 2.1 docs.
+The largest changes are:
+
+- The React SDK public entry is now lazy and SSR-capable.
+- The React SDK removes several public internals, including legacy spatial
+  container factories, `SSRProvider`, and `getAbsoluteUrl`.
+- Attachment APIs now use entity-style transforms and meter sizing.
+- Model support is significantly expanded: playback state, multiple sources,
+  poster, lazy loading, `currentTime`, `stagemode="orbit"`, and spatial event
+  props are present on `main`.
+- Runtime capability detection is now a first-class surface for components,
+  CSS, DOM, events, JS APIs, Model subfeatures, and scene options.
+- Several user-visible behavior fixes landed for portal CSS, CSS-in-JS style
+  sync, SpatialDiv HMR recovery, HTML material updates, Model poster/loading,
+  and scene refresh handling.
+
+## Release Notes Draft
+
+### Breaking Changes
+
+#### React SDK entry points and boot flow
+
+The default `@webspatial/react-sdk` entry is now the recommended entry for web,
+SSR, RSC-compatible, and mixed 2D plus spatial React apps. It lazily loads the
+spatial runtime only when a WebSpatial environment is available.
+
+Removed or no longer public:
+
+- `@webspatial/react-sdk/web`
+- `@webspatial/react-sdk/default`
+- `SSRProvider`
+- Legacy spatial container factories and HOC helpers
+- Internal container and monitor APIs
+- `getAbsoluteUrl`
+
+New readiness APIs:
+
+- `SpatialBoot`
+- `bootSpatial`
+- `useSpatialReady`
+- `isSpatialReady`
+- `onSpatialLoadError`
+- `WebSpatialBootError`
+- `WebSpatialRuntimeError`
+
+#### Attachment API migration
+
+Attachments now align with entity-style transforms and meter-based sizing.
+
+Breaking changes:
+
+- `<AttachmentAsset name="...">` is replaced by `<AttachmentAsset id="...">`.
+- `<AttachmentEntity position={[x, y, z]}>` is replaced by
+  `<AttachmentEntity position={{ x, y, z }}>`.
+- `<AttachmentEntity size={{ width, height }}>` in points is replaced by
+  optional `width` and `height` props in meters.
+- `rotation` and `scale` are now available as Vec3-style props.
+
+#### React version and readiness semantics
+
+React 18 or newer is required.
+
+`useMetrics` pins its placeholder or real implementation for the lifetime of the
+hook instance. Remount if an app must switch from placeholder metrics to real
+runtime metrics after spatial boot.
+
+### New Features
+
+#### Model
+
+`<Model>` is expanded beyond the alpha 2.1 surface. Main now includes:
+
+- Multiple sources through nested `<source>` elements
+- `poster`
+- `loading="eager" | "lazy"`
+- `autoPlay`
+- `loop`
+- `duration`
+- `currentTime`
+- `playbackRate`
+- `paused`
+- `play()`
+- `pause()`
+- `stagemode="none" | "orbit"`
+- Spatial gesture event props
+
+Supported model MIME types documented on `main` are:
+
+- `model/vnd.usdz+zip`
+- `model/gltf-binary`
+
+When `stagemode="orbit"` is active, native orbit interaction owns the transform;
+`entityTransform` is read-only and `onSpatial*` gesture handlers are disabled.
+
+#### Runtime capability detection
+
+The public runtime capability surface now covers:
+
+- Components and component aliases
+- CSS properties
+- Spatial gesture events
+- JS APIs
+- DOM depth properties
+- Scene and manifest options
+- Model subfeatures
+
+#### Scene and manifest aliases
+
+Manifest scene configuration accepts both snake_case and camelCase keys for
+scene defaults. If both spellings are present, snake_case wins. `main` also adds
+the `xr_spatial_scene` scene config path alongside the existing documented
+`xr_main_scene` path.
+
+### Fixes and Behavior Changes
+
+- CSS-in-JS portal style sync is fixed for libraries that inject CSSOM rules
+  into the host document head, such as styled-components and Emotion default
+  targets.
+- SpatialDiv intrinsic tag selector mirroring is fixed. A selector like
+  `h1[enable-xr]` can now match the probe host for an `<h1 enable-xr>`.
+- Ancestor selectors still do not cross the native portal/webview boundary. Put
+  stable classes or inline styles on the visible portal node.
+- SpatialDiv portal recovery during linked SDK HMR is more robust.
+- HTML background material updates via bracket syntax are fixed.
+- Model poster, loading, duration, and DOM-linked ready/load behavior are fixed.
+- VisionOS scene refresh handling now guards against stale spatial creation
+  requests and can recreate a missing spatial scene from WindowGroup data.
+- `<UnlitMaterial textureId>` no longer blocks material creation when the
+  texture is not declared yet; it falls back to color-only and binds later when
+  the texture appears.
+
+## Migration Guide
+
+### 1. React SDK import and boot flow
+
+For normal web, SSR, RSC-compatible, and mixed 2D plus spatial apps, import from
+the default entry and gate spatial UI behind `SpatialBoot`.
+
+Before:
+
+```tsx
+import { Model, Reality, SSRProvider } from '@webspatial/react-sdk/default'
+
+export function App() {
+  return (
+    <SSRProvider>
+      <Model enable-xr src="/chair.usdz" />
+    </SSRProvider>
+  )
+}
+```
+
+After:
+
+```tsx
+import { Model, SpatialBoot } from '@webspatial/react-sdk'
+
+export function App() {
+  return (
+    <SpatialBoot>
+      <Model enable-xr src="/chair.usdz" />
+    </SpatialBoot>
+  )
+}
+```
+
+Rules:
+
+- Replace legacy `/web` and `/default` imports.
+- Replace internal container or HOC usage with JSX markers and public
+  components.
+
+### 2. Attachment API migration
+
+Before:
+
+```tsx
+<Reality>
+  <AttachmentAsset name="panel">
+    <Panel />
+  </AttachmentAsset>
+  <World>
+    <AttachmentEntity
+      attachment="panel"
+      position={[0, 0.2, -0.5]}
+      size={{ width: 360, height: 240 }}
+    />
+  </World>
+</Reality>
+```
+
+After:
+
+```tsx
+<Reality>
+  <AttachmentAsset id="panel">
+    <Panel />
+  </AttachmentAsset>
+  <World>
+    <AttachmentEntity
+      attachment="panel"
+      position={{ x: 0, y: 0.2, z: -0.5 }}
+      rotation={{ x: 0, y: 15, z: 0 }}
+      scale={{ x: 1, y: 1, z: 1 }}
+      width={0.36}
+      height={0.24}
+    />
+  </World>
+</Reality>
+```
+
+Notes:
+
+- `width` and `height` are meters, not points.
+- `position` is meters.
+- `rotation` is Euler degrees.
+- Attachment assets must remain direct children of `<Reality>`, outside
+  `<World>` or `<SceneGraph>`.
+
+### 3. Model migration
+
+Alpha 2.1 Model usage still works:
+
+```tsx
+<Model enable-xr src="/robot.usdz" />
+```
+
+Use new playback and loading features when the target runtime supports them:
+
+```tsx
+<Model
+  enable-xr
+  poster="/robot-poster.png"
+  loading="lazy"
+  autoPlay
+  loop
+  src="/robot.usdz"
+/>
+```
+
+For multiple sources:
+
+```tsx
+<Model enable-xr poster="/robot-poster.png">
+  <source src="/robot.usdz" type="model/vnd.usdz+zip" />
+  <source src="/robot.glb" type="model/gltf-binary" />
+</Model>
+```
+
+For native orbit:
+
+```tsx
+<Model enable-xr stagemode="orbit" src="/product.usdz" />
+```
+
+Do not attach custom spatial drag, rotate, magnify, or tap handlers to a Model
+in orbit mode. The native orbit interaction owns the transform.
+
+### 4. Portal CSS migration
+
+Selectors scoped through ancestors may fail once content is rendered in a child
+portal/webview. Move styling to a class on the visible node or use inline style.
+
+Fragile:
+
+```css
+.card .menu {
+  border-radius: 12px;
+}
+```
+
+Preferred:
+
+```tsx
+<div enable-xr className="spatial-menu" />
+```
+
+```css
+.spatial-menu {
+  border-radius: 12px;
+}
+```
+
+## Public Alpha 2.1 Docs vs Main
+
+| Area                      | Public alpha 2.1 docs                                                                                                                            | Current `main`                                                                                                                                                                                                   | Migration or docs action                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Getting started           | Install React SDK; configure JSX runtime; SSR docs mention `Context`/`SSRProvider`.                                                              | Public React entry is lazy and SSR-capable; `SpatialBoot` and readiness APIs replace `SSRProvider`; React 18+ required.                                                                                          | Update getting-started docs to recommend the public entry plus `SpatialBoot`.                  |
+| Import paths              | Public docs mostly show `@webspatial/react-sdk` and package-level installs.                                                                      | `/web` and `/default` entries are removed from the public API.                                                                                                                                                   | Add import-path migration table.                                                               |
+| RSC and SSR               | Public docs mention SSR setup but do not describe lazy facades or RSC-safe imports.                                                              | Default entry exports client facades and is compatible with SSR/RSC import patterns; no public `/server` helper in v1.                                                                                           | Document request-time runtime branching through User-Agent or runtime detection on the client. |
+| JSX markers               | Docs describe `enable-xr`, `__enableXr__`, `style={{ enableXr: true }}`, and `enable-xr-monitor`.                                                | Marker model remains the preferred path. Internal containers/HOCs are no longer public. Intrinsic tag selector mirroring is fixed.                                                                               | Keep marker docs; remove or avoid internal container guidance.                                 |
+| Model API                 | Docs list `src`, `onLoad`, `onError`, `currentSrc`, `ready`, and `entityTransform`.                                                              | Adds `<source>`, `poster`, `loading`, `autoPlay`, `loop`, `duration`, `currentTime`, `playbackRate`, `paused`, `play()`, `pause()`, `stagemode`, and spatial events.                                             | Expand Model docs and add runtime support rows for each subfeature.                            |
+| Model file types          | Docs imply static 3D model loading but do not clearly list all current source behaviors.                                                         | Main docs list `model/vnd.usdz+zip` and `model/gltf-binary`; USD and glTF text docs were removed.                                                                                                                | Document supported MIME types and source selection behavior.                                   |
+| Model orbit               | Not in alpha 2.1 docs.                                                                                                                           | `stagemode="orbit"` enables native orbit drag rotation.                                                                                                                                                          | Add usage notes and warn that spatial gesture props are disabled in orbit mode.                |
+| Reality components        | Docs list Reality, Material, ModelAsset, AttachmentAsset, World, Entity, primitives, ModelEntity, and AttachmentEntity.                          | Public facade exports aliases such as `Box`, `Sphere`, `Cone`, `Cylinder`, `Plane`, `World`, plus entity variants. `Texture` and `UnlitMaterial` behavior are improved.                                          | Update component inventory and examples.                                                       |
+| Attachment API            | Docs say AttachmentEntity currently supports `position` and `size`; future versions will add full transform props.                               | The future API is now the breaking API: `id`, object `position`, meter `width`/`height`, `rotation`, and `scale`.                                                                                                | Replace alpha attachment examples and add a migration section.                                 |
+| CSS `background-material` | Docs list `translucent`, `transparent`, and `none`.                                                                                              | The current style surface also includes `thick`, `regular`, and `thin`.                                                                                                                                          | Verify platform support before documenting as portable; otherwise document as conditional.     |
+| CSS transform/back/depth  | Docs cover `back`, spatial transforms, `background-material`, and `--xr-depth`.                                                                  | Behavior remains, with additional portal/CSS quirks documentation and selector fixes.                                                                                                                            | Add portal boundary caveats and CSS-in-JS support notes.                                       |
+| CSS-in-JS                 | Getting-started docs state the latest version has a styled-components bug.                                                                       | CSSOM head sync fixes are present on `main`.                                                                                                                                                                     | Remove stale warning after release validation.                                                 |
+| DOM depth APIs            | Docs list User-Agent, `xrOffsetBack`, `xrClientDepth`, and `xrInnerDepth`.                                                                       | Runtime keys also include `xrOuterDepth`.                                                                                                                                                                        | Decide whether `xrOuterDepth` is public and document if yes.                                   |
+| Spatial events            | Docs cover spatial tap, drag, magnify, and rotate.                                                                                               | Event surface remains, with capability subkeys such as constrained rotate axis and Model spatial event props.                                                                                                    | Add capability-gated event support table.                                                      |
+| JS APIs                   | Docs list `initScene`, `useMetrics`, and `convertCoordinate`.                                                                                    | React SDK now also exposes runtime readiness and capability detection APIs.                                                                                                                                      | Add runtime detection and readiness docs; update `useMetrics` readiness caveat.                |
+| Manifest and scene config | Docs cover `xr_main_scene` and scene options such as type, default size, resizability, world scaling, world alignment, and baseplate visibility. | Main adds alias handling, `xr_spatial_scene`, camelCase/snake_case support, `worldAlignment: "adaptive"`, and `baseplateVisibility: "visible"`.                                                                  | Update manifest schema docs and document precedence when both spellings exist.                 |
+| Platform matrix           | Docs state visionOS and PICO OS 6 are supported.                                                                                                 | Capability data distinguishes visionOS 1.5/1.6/1.7 and Pico alpha2.1, beta2.0, and beta2.1 rows. Entity animation is intentionally excluded from this DC release because PicoOS runtime support is not included. | Publish a versioned capability matrix instead of a single support statement.                   |
+
+## Capability Highlights After Alpha 2.1
+
+These are the most visible deltas from alpha 2.1:
+
+| Feature                                                           | Main branch status       | Notes                                                                |
+| ----------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------- |
+| [Cross-platform feature detection API](./runtime-capabilities.md) | Present                  | Use runtime capability keys instead of hardcoding platform versions. |
+| [React SDK distribution for SSR/RSC](./react-sdk-distribution.md) | Present                  | Public React entry is lazy and SSR/RSC-capable.                      |
+| [`onSpatialContentReady` reliability](./spatial-content-ready.md) | Improved                 | Still depends on connected DOM and spatial host readiness.           |
+| Textures                                                          | Present in public facade | `UnlitMaterial textureId` fallback behavior improved.                |
+| Model `currentTime`                                               | Present                  | Capability-gate per runtime.                                         |
+| Model poster                                                      | Present                  | Fixes landed for poster display when no sources are active.          |
+| Model loading                                                     | Present                  | Supports eager and lazy loading modes.                               |
+| Model orbit stage mode                                            | Present                  | `stagemode="orbit"` disables custom spatial gesture handlers.        |
+
+## Release Checklist
+
+- Decide final package version after applying pending changesets.
+- Confirm whether this release should be branded as a major React SDK release
+  because of the lazy-entry and attachment API breaks.
+- Validate runtime capability table against the final native shells that will
+  ship with the release.
+- Update public docs for getting started, Model, AttachmentEntity, manifest
+  aliases, and CSS-in-JS. Runtime detection, SSR/RSC distribution, and
+  `onSpatialContentReady` now have draft API docs in this repo.
+- Remove the stale styled-components warning from the public getting-started
+  page after release validation.
+- Decide whether `xrOuterDepth`, extra background material values, and
+  `boundingBoxCenter`/`boundingBoxExtents` are public for this release or should
+  remain internal/future-facing.
+
+## Source Map
+
+Local sources:
+
+- `.changeset/attachment-asset-id.md`
+- `.changeset/react-sdk-lazy-load-major.md`
+- `.changeset/model-stagemode-orbit.md`
+- `docs/migration/lazy-load-spatial-runtime.md`
+- `docs/react-sdk-distribution.md`
+- `docs/runtime-capabilities.md`
+- `docs/spatial-content-ready.md`
+- `docs/Attachments.md`
+- `docs/Model.md`
+- `docs/webspatial-quirks.md`
+- `packages/react/src/index.ts`
+- `packages/react/src/Model.tsx`
+
+Public docs compared:
+
+- <https://webspatial.dev/docs/introduction/getting-started>
+- <https://webspatial.dev/docs/react/overview>
+- <https://webspatial.dev/docs/react/model>
+- <https://webspatial.dev/docs/react/reality>
+- <https://webspatial.dev/docs/css/overview>
+- <https://webspatial.dev/docs/dom/overview>
+- <https://webspatial.dev/docs/event/overview>
+- <https://webspatial.dev/docs/js/overview>
+- <https://webspatial.dev/docs/manifest/main_scene>

--- a/docs/react-sdk-distribution.md
+++ b/docs/react-sdk-distribution.md
@@ -1,0 +1,307 @@
+# React SDK Distribution
+
+## Overview
+
+`@webspatial/react-sdk` is the public React SDK entry for web-first apps, SSR,
+RSC, and mixed 2D plus spatial experiences.
+
+It exports public facades for components such as `Model`, `Reality`, and
+entities. In plain web and SSR, those facades render documented fallbacks. In a
+WebSpatial runtime, call `bootSpatial()` or use `<SpatialBoot>` to load the real
+spatial implementation.
+
+```tsx
+import { Model, SpatialBoot } from '@webspatial/react-sdk'
+
+export function App() {
+  return (
+    <SpatialBoot>
+      <Model enable-xr src="/models/robot.glb" />
+    </SpatialBoot>
+  )
+}
+```
+
+## Type Reference
+
+```ts
+import type { ReactNode } from 'react'
+
+type SpatialBootProps = {
+  children: ReactNode
+  onReady?: () => void
+  onError?: (error: WebSpatialBootError) => void
+}
+
+function bootSpatial(): Promise<void>
+
+function isSpatialReady(): boolean
+
+function useSpatialReady(): boolean
+
+function onSpatialLoadError(
+  callback: (error: WebSpatialBootError) => void,
+): () => void
+
+class WebSpatialBootError extends Error {
+  name: 'WebSpatialBootError'
+  cause: unknown
+  attempt: number
+}
+```
+
+## API Details
+
+### `<SpatialBoot>`
+
+```ts
+type SpatialBootProps = {
+  children: React.ReactNode
+  onReady?: () => void
+  onError?: (error: WebSpatialBootError) => void
+}
+```
+
+`SpatialBoot` calls `bootSpatial()` after mount and renders `children` only
+after boot succeeds. While boot is pending, it renders `null`. If boot fails,
+it calls `onError` and keeps `children` unmounted.
+
+There is no public `fallback` prop. Render loading or error UI outside
+`SpatialBoot` when needed.
+
+```tsx
+import { SpatialBoot, WebSpatialBootError } from '@webspatial/react-sdk'
+
+export function SpatialSection() {
+  return (
+    <SpatialBoot
+      onReady={() => console.log('WebSpatial ready')}
+      onError={(error: WebSpatialBootError) => {
+        console.error('WebSpatial failed to boot', error.cause)
+      }}
+    >
+      <SpatialExperience />
+    </SpatialBoot>
+  )
+}
+```
+
+### `bootSpatial()`
+
+```ts
+function bootSpatial(): Promise<void>
+```
+
+Loads the spatial implementation in a WebSpatial runtime.
+
+Behavior:
+
+- Plain web: resolves immediately and does not request the spatial chunk.
+- SSR: resolves without throwing and does not request the spatial chunk.
+- WebSpatial runtime: dynamically imports the spatial implementation.
+- Concurrent calls share the same in-flight load attempt.
+- Successful loads are cached for the page lifetime.
+- Failed loads reject with `WebSpatialBootError`.
+- Calling again after a failure starts a new load attempt.
+
+### `isSpatialReady()`
+
+```ts
+function isSpatialReady(): boolean
+```
+
+Returns `true` only after the spatial implementation has loaded successfully in
+the current page.
+
+### `useSpatialReady()`
+
+```ts
+function useSpatialReady(): boolean
+```
+
+React hook that re-renders when spatial readiness changes. It returns `false`
+during SSR and in plain web.
+
+```tsx
+import { Model, useSpatialReady } from '@webspatial/react-sdk'
+
+export function ReadyGatedModel() {
+  const ready = useSpatialReady()
+  if (!ready) return null
+  return <Model enable-xr src="/models/drone.glb" />
+}
+```
+
+### `onSpatialLoadError()`
+
+```ts
+function onSpatialLoadError(
+  callback: (error: WebSpatialBootError) => void,
+): () => void
+```
+
+Registers a listener for spatial chunk load failures. The returned function
+unsubscribes the listener.
+
+```ts
+import { onSpatialLoadError } from '@webspatial/react-sdk'
+
+const unsubscribe = onSpatialLoadError(error => {
+  reportError(error)
+})
+
+unsubscribe()
+```
+
+### `WebSpatialBootError`
+
+`WebSpatialBootError` is the error type used when boot fails.
+
+Important fields:
+
+- `name === 'WebSpatialBootError'`
+- `cause`: the original dynamic import error
+- `attempt`: the 1-based load attempt number
+
+## Common Use Cases
+
+### Recommended React integration
+
+```tsx
+import { SpatialBoot } from '@webspatial/react-sdk'
+
+export function AppRoot() {
+  return (
+    <AppShell>
+      <SpatialBoot>
+        <SpatialRoutes />
+      </SpatialBoot>
+    </AppShell>
+  )
+}
+```
+
+### Advanced CSR manual boot
+
+Most React apps should use `<SpatialBoot>` and let it call `bootSpatial()`.
+Client-rendered apps that want full manual control can await `bootSpatial()`
+before the first render, then render the spatial app directly.
+
+Do not use this as the default SSR recipe. If boot fails, catch the
+`WebSpatialBootError` and render an application fallback.
+
+```tsx
+import ReactDOM from 'react-dom/client'
+import { bootSpatial } from '@webspatial/react-sdk'
+import { App } from './App'
+import { FallbackApp } from './FallbackApp'
+
+const root = ReactDOM.createRoot(document.getElementById('root')!)
+
+try {
+  await bootSpatial()
+  root.render(<App />)
+} catch (error) {
+  root.render(<FallbackApp error={error} />)
+}
+```
+
+### Next.js client boundary
+
+Use the default entry inside a client component.
+
+```tsx
+'use client'
+
+import { SpatialBoot, Model } from '@webspatial/react-sdk'
+
+export function SpatialProductView() {
+  return (
+    <SpatialBoot>
+      <Model enable-xr src="/models/product.glb" />
+    </SpatialBoot>
+  )
+}
+```
+
+### Error UI outside `SpatialBoot`
+
+Because `SpatialBoot` renders `null` before success, keep loading and error UI
+outside it.
+
+```tsx
+import { useState } from 'react'
+import { SpatialBoot, type WebSpatialBootError } from '@webspatial/react-sdk'
+
+export function SpatialPanel() {
+  const [error, setError] = useState<WebSpatialBootError | null>(null)
+
+  if (error) return <FallbackPanel />
+
+  return (
+    <>
+      <LoadingShell />
+      <SpatialBoot onError={setError}>
+        <SpatialExperience />
+      </SpatialBoot>
+    </>
+  )
+}
+```
+
+## Migration
+
+Replace legacy import roots:
+
+```tsx
+// Before
+import { Model } from '@webspatial/react-sdk/web'
+import { Reality } from '@webspatial/react-sdk/default'
+
+// After
+import { Model, Reality } from '@webspatial/react-sdk'
+```
+
+Remove `SSRProvider` wrappers:
+
+```tsx
+// Before
+<SSRProvider>
+  <Model enable-xr src="/models/robot.glb" />
+</SSRProvider>
+
+// After
+<SpatialBoot>
+  <Model enable-xr src="/models/robot.glb" />
+</SpatialBoot>
+```
+
+Replace removed internal container imports with JSX markers:
+
+```tsx
+// Before
+import { Spatialized2DElementContainer } from '@webspatial/react-sdk'
+
+// After
+export function Card() {
+  return <div enable-xr>...</div>
+}
+```
+
+## Usage Notes
+
+- Prefer named imports. Namespace imports may reduce tree-shaking quality.
+- `SpatialBoot` has no `fallback` prop.
+- Plain web users do not request the spatial chunk when using the default
+  entry.
+- `useMetrics()` returns a stable placeholder until a component remounts after
+  boot. Mount components that require real metrics after `SpatialBoot`.
+- Request-time server branching is outside this API. Use request information
+  such as User-Agent for server routing decisions.
+
+## References
+
+- `openspec/specs/spatial-lazy-load/spec.md`
+- `docs/migration/lazy-load-spatial-runtime.md`
+- `packages/react/src/runtime/SpatialBoot.tsx`
+- `packages/react/src/runtime/boot.ts`

--- a/docs/runtime-capabilities.md
+++ b/docs/runtime-capabilities.md
@@ -1,0 +1,201 @@
+# Runtime Capabilities
+
+## Overview
+
+Runtime capabilities let applications ask whether the current WebSpatial
+runtime supports a feature before using it. Prefer capability checks over
+hardcoded platform names or shell versions.
+
+Use this API when a feature is optional, version-gated, or has a web fallback.
+
+Release scope note: entity animation capability checks are intentionally omitted
+from this release document because the required PicoOS DC runtime support is not
+included in this DC release.
+
+```tsx
+import { WebSpatialRuntime } from '@webspatial/react-sdk'
+
+if (WebSpatialRuntime.supports('Model', ['poster'])) {
+  // Safe to use Model poster behavior in the current runtime.
+}
+```
+
+## Type Reference
+
+```ts
+type RuntimeCapabilityName = string
+type RuntimeCapabilityToken = string
+
+type WebSpatialRuntime = {
+  supports: (
+    name: RuntimeCapabilityName,
+    tokens?: RuntimeCapabilityToken[],
+  ) => boolean
+}
+
+class WebSpatialRuntimeError extends Error {
+  name: 'WebSpatialRuntimeError'
+  capability: string
+}
+```
+
+Use string capability names directly. The public API accepts unknown strings and
+returns `false` for unsupported or unrecognized capabilities, so applications do
+not need to import a key registry.
+
+## API Details
+
+### `WebSpatialRuntime.supports(name, tokens?)`
+
+```ts
+WebSpatialRuntime.supports(name: string, tokens?: string[]): boolean
+```
+
+Returns `true` when the current runtime supports a capability.
+
+Rules:
+
+- Unknown top-level capability names return `false`.
+- Unknown sub-tokens return `false`.
+- Multiple sub-tokens use AND semantics: every token must be supported.
+- An empty token array behaves the same as omitting `tokens`.
+- Plain web and SSR return `false` for spatial-dependent features.
+
+### `WebSpatialRuntimeError`
+
+Some APIs fail fast when the capability they require is unavailable. Those
+failures use `WebSpatialRuntimeError`.
+
+```tsx
+import {
+  WebSpatialRuntimeError,
+  convertCoordinate,
+} from '@webspatial/react-sdk'
+
+try {
+  await convertCoordinate({ x: 0, y: 0, z: 0 }, { from, to })
+} catch (error) {
+  if (error instanceof WebSpatialRuntimeError) {
+    console.warn(error.capability)
+  }
+}
+```
+
+Capability checks are still the recommended path for optional UI. Error handling
+is mainly for imperative code where the capability may disappear from the
+control flow.
+
+## Capability Keys
+
+Top-level keys currently include:
+
+| Group             | Keys                                                                                                                                                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Components        | `Model`, `Reality`, `Entity`, `BoxEntity`, `SphereEntity`, `ConeEntity`, `CylinderEntity`, `PlaneEntity`, `SceneGraph`, `ModelAsset`, `ModelEntity`, `Material`, `UnlitMaterial`, `AttachmentAsset`, `AttachmentEntity` |
+| Component aliases | `Box`, `Sphere`, `Cone`, `Cylinder`, `Plane`, `World`                                                                                                                                                                   |
+| CSS               | `-xr-background-material`, `-xr-back`, `-xr-depth`, `-xr-transform`                                                                                                                                                     |
+| Events            | `SpatialTapEvent`, `SpatialDragStartEvent`, `SpatialDragEvent`, `SpatialDragEndEvent`, `SpatialRotateEvent`, `SpatialRotateEndEvent`, `SpatialMagnifyEvent`, `SpatialMagnifyEndEvent`                                   |
+| JavaScript APIs   | `useMetrics`, `convertCoordinate`, `initScene`, `WindowScene`, `VolumeScene`                                                                                                                                            |
+| DOM readbacks     | `xrClientDepth`, `xrOffsetBack`, `xrInnerDepth`, `xrOuterDepth`                                                                                                                                                         |
+
+Supported sub-tokens:
+
+| Capability           | Sub-tokens                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Model`              | `autoplay`, `loop`, `stagemode`, `poster`, `loading`, `source`, `ready`, `currentSrc`, `entityTransform`, `paused`, `duration`, `playbackRate`, `play`, `pause`, `currentTime` |
+| `Material`           | `unlit`                                                                                                                                                                        |
+| `WindowScene`        | `defaultSize`, `resizability`                                                                                                                                                  |
+| `VolumeScene`        | `defaultSize`, `resizability`, `worldScaling`, `worldAlignment`, `baseplateVisibility`                                                                                         |
+| `SpatialRotateEvent` | `constrainedToAxis`                                                                                                                                                            |
+
+## Common Use Cases
+
+### Gate Model features
+
+```tsx
+import { Model, WebSpatialRuntime } from '@webspatial/react-sdk'
+
+export function ProductModel() {
+  const canUsePoster = WebSpatialRuntime.supports('Model', ['poster'])
+  const canLazyLoad = WebSpatialRuntime.supports('Model', ['loading'])
+
+  return (
+    <Model
+      enable-xr
+      src="/models/product.glb"
+      poster={canUsePoster ? '/models/product-poster.png' : undefined}
+      loading={canLazyLoad ? 'lazy' : 'eager'}
+    />
+  )
+}
+```
+
+### Avoid platform version checks
+
+Avoid:
+
+```ts
+const canUseCurrentTime = isPicoBeta20OrNewer || isVisionOS17OrNewer
+```
+
+Prefer:
+
+```ts
+const canUseCurrentTime = WebSpatialRuntime.supports('Model', ['currentTime'])
+```
+
+### Show optional controls
+
+```tsx
+import { WebSpatialRuntime } from '@webspatial/react-sdk'
+
+export function PlaybackControls() {
+  if (!WebSpatialRuntime.supports('Model', ['play', 'pause', 'currentTime'])) {
+    return null
+  }
+
+  return <ModelTimeline />
+}
+```
+
+### Handle unsupported imperative APIs
+
+```tsx
+import {
+  WebSpatialRuntime,
+  WebSpatialRuntimeError,
+  convertCoordinate,
+} from '@webspatial/react-sdk'
+
+async function convertIfSupported(point, from, to) {
+  if (!WebSpatialRuntime.supports('convertCoordinate')) {
+    return null
+  }
+
+  try {
+    return await convertCoordinate(point, { from, to })
+  } catch (error) {
+    if (error instanceof WebSpatialRuntimeError) {
+      return null
+    }
+    throw error
+  }
+}
+```
+
+## Usage Notes
+
+- Capability values are stable for the current page/session.
+- `supports()` is synchronous and safe in SSR.
+- `supports()` does not boot the spatial runtime and does not request the
+  spatial implementation chunk.
+- Use string keys directly or wrap them in application-level constants. The
+  public API does not require importing key constants.
+- For React rendering, prefer feature-gated UI over try/catch.
+- For SSR request-time branching, use request information such as User-Agent.
+  The client capability API is not a server request classifier.
+
+## References
+
+- `openspec/specs/runtime-capabilities/spec.md`
+- `packages/react/src/webSpatialRuntime.ts`

--- a/docs/spatial-content-ready.md
+++ b/docs/spatial-content-ready.md
@@ -1,0 +1,256 @@
+# Spatial Content Ready
+
+## Overview
+
+`onSpatialContentReady` is a lifecycle callback for a 2D spatial element:
+a normal JSX element such as `<div>` that is marked with `enable-xr`.
+
+Use it for libraries such as Three.js, canvas renderers, chart renderers, or
+other code that must attach DOM outside normal React rendering.
+
+```tsx
+<div
+  enable-xr
+  onSpatialContentReady={({ host }) => {
+    const canvas = document.createElement('canvas')
+    host.appendChild(canvas)
+
+    return () => {
+      canvas.remove()
+    }
+  }}
+/>
+```
+
+## Terminology
+
+**SpatialDiv** means a 2D HTML element that becomes spatial because it has the
+`enable-xr` marker. In most app code this is just a normal intrinsic element:
+
+```tsx
+<div enable-xr />
+```
+
+The name "SpatialDiv" is shorthand for "a spatialized 2D `div`". The same
+lifecycle applies to other supported 2D intrinsic elements when they use the
+`enable-xr` marker.
+
+**Host** means the concrete DOM element that the SDK gives to your callback.
+It is the safe mount target for imperative code. If you use Three.js, canvas, or
+a chart library, append or mount that library under `host`.
+
+```tsx
+onSpatialContentReady={({ host }) => {
+  host.appendChild(canvas)
+}}
+```
+
+In a WebSpatial runtime, this host belongs to the visible spatial content. In
+plain web fallback, there is no spatial content host, so this callback does not
+fire.
+
+## Type Reference
+
+```ts
+type SpatialContentReadyContext = {
+  host: HTMLElement
+}
+
+type SpatialContentReadyCallback = (
+  ctx: SpatialContentReadyContext,
+) => void | (() => void)
+
+type SpatialContentReadyProps = {
+  onSpatialContentReady?: SpatialContentReadyCallback
+}
+```
+
+`onSpatialContentReady` is a prop for 2D elements marked with `enable-xr`.
+
+## API Details
+
+`host` is the connected DOM element for the visible 2D spatial content.
+Application code may append imperative renderer DOM under this element.
+When the callback runs, `host.isConnected` is guaranteed to be `true`;
+`isConnected` is the standard DOM property on `Node`.
+
+The callback can return a cleanup function. The cleanup runs before the next
+ready callback for the same container and when the container unmounts or is
+replaced.
+
+## Where It Is Supported
+
+`onSpatialContentReady` is supported on 2D spatial elements, typically a `<div>`
+marked with `enable-xr`.
+
+```tsx
+<div enable-xr onSpatialContentReady={handleReady} />
+```
+
+It is not a public API for `Model`, `Reality`, or other non-2D portal
+components.
+
+## When It Fires
+
+The callback fires when all of the following are true:
+
+- A real spatialized 2D element exists.
+- The portal DOM is available.
+- The callback host has committed and `host.isConnected === true`.
+
+The callback runs in layout-effect timing after DOM mutations and before the
+browser paints. It is edge-triggered:
+
+- It fires on a `not ready -> ready` transition.
+- It does not fire again for ordinary re-renders while the same host remains
+  ready.
+- If the host is replaced, the previous cleanup runs and a new ready callback
+  may fire for the new host.
+
+## When It Does Not Fire
+
+`onSpatialContentReady` does not fire when no real spatial portal host exists.
+
+That includes:
+
+- Plain web fallback.
+- SSR.
+- Before `bootSpatial()` has produced a spatial host.
+
+The prop is also stripped from the DOM attribute space, so it is not emitted as
+an `onSpatialContentReady` HTML attribute.
+
+Use your own `ref` and React effect for plain-web imperative rendering.
+
+## Common Use Cases
+
+### Mount Three.js into a SpatialDiv
+
+```tsx
+import { useCallback } from 'react'
+
+export function ThreePanel() {
+  const handleReady = useCallback(({ host }) => {
+    const canvas = document.createElement('canvas')
+    canvas.style.width = '100%'
+    canvas.style.height = '100%'
+    host.appendChild(canvas)
+
+    const renderer = createThreeRenderer(canvas)
+    renderer.start()
+
+    return () => {
+      renderer.dispose()
+      canvas.remove()
+    }
+  }, [])
+
+  return (
+    <div
+      enable-xr
+      className="three-panel"
+      onSpatialContentReady={handleReady}
+    />
+  )
+}
+```
+
+### Support both spatial and plain web
+
+Use `onSpatialContentReady` for the spatial portal and a normal ref for the
+plain-web fallback.
+
+```tsx
+import { useEffect, useRef } from 'react'
+import { useSpatialReady } from '@webspatial/react-sdk'
+
+export function ChartPanel() {
+  const flatHostRef = useRef<HTMLDivElement | null>(null)
+  const spatialReady = useSpatialReady()
+
+  useEffect(() => {
+    if (spatialReady) return
+    const host = flatHostRef.current
+    if (!host) return
+
+    const chart = mountChart(host)
+    return () => chart.dispose()
+  }, [spatialReady])
+
+  return (
+    <div
+      ref={flatHostRef}
+      enable-xr
+      onSpatialContentReady={({ host }) => {
+        const chart = mountChart(host)
+        return () => chart.dispose()
+      }}
+    />
+  )
+}
+```
+
+## Do and Do Not
+
+Do attach imperative renderers to `ctx.host`:
+
+```tsx
+<div
+  enable-xr
+  onSpatialContentReady={({ host }) => {
+    const renderer = mountRenderer(host)
+    return () => renderer.dispose()
+  }}
+/>
+```
+
+Do not rely on a child DOM ref inside a SpatialDiv as the spatial portal mount
+target:
+
+```tsx
+function FragilePanel() {
+  const childRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    // Fragile: this may refer to host-page fallback DOM instead of the visible
+    // spatial portal host.
+    if (childRef.current) {
+      mountRenderer(childRef.current)
+    }
+  }, [])
+
+  return (
+    <div enable-xr>
+      <div ref={childRef} />
+    </div>
+  )
+}
+```
+
+## Nested SpatialDivs
+
+Nested SpatialDivs initialize independently. Do not rely on parent and child
+ready callback ordering. Each callback should attach only to its own `ctx.host`.
+
+```tsx
+<div enable-xr onSpatialContentReady={mountOuter}>
+  <div enable-xr onSpatialContentReady={mountInner} />
+</div>
+```
+
+## Usage Notes
+
+- The callback is not invoked during render.
+- The callback receives a connected host.
+- A provided SpatialDiv ref is non-null when the callback runs, but the
+  recommended imperative mount target is still `ctx.host`.
+- Cleanup should be idempotent.
+- Ordinary re-renders do not re-fire the callback while the host remains ready.
+- Plain web fallback requires a normal `ref` and effect.
+
+## References
+
+- `openspec/changes/archive/2026-06-30-spatialdiv-content-ready-lifecycle/specs/spatialdiv-content-host-lifecycle/spec.md`
+- `packages/react/src/spatialized-container/types.ts`
+- `packages/react/src/spatialized-container/hooks/useSpatialContentReady.ts`
+- `apps/test-server/src/pages/spatial-content-ready-three/index.tsx`


### PR DESCRIPTION
## Summary

- Add release planning notes for the upcoming main branch vs the public alpha 2.1 docs.
- Add public API/use-case docs for runtime capabilities, React SDK distribution and boot flow, and `onSpatialContentReady`.
- Keep release scope aligned with current decisions: no Core SDK public surface, no `@webspatial/react-sdk/eager` public API docs, and no `useAnimation` release API content because PicoOS DC runtime support is not included.

## Validation

- `pnpm exec prettier --check docs/runtime-capabilities.md docs/react-sdk-distribution.md docs/spatial-content-ready.md docs/main-release-alpha-2.1-diff.md`
- Pre-commit hooks: `check-filesize.js`, `check-valid-characters.js`
- Searched docs for disallowed public-surface terms: `@webspatial/react-sdk/eager`, `useAnimation`, `Core SDK`, `core-sdk`, and CJK characters.