### PR TITLE
Update AttachmentEntity API compatability matrix

### DIFF
--- a/.changeset/attachment-entity-placement.md
+++ b/.changeset/attachment-entity-placement.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/core-sdk': patch
+---
+
+Fix attachments failing to load on new picoOS runtimes (PicoWebApp/0.4.90 OTA0+) by sending the placement-shaped attachment payload they expect, detected via `supports('AttachmentEntity', ['placement'])`. No API change; visionOS and older runtimes are unaffected.

--- a/.changeset/attachment-entity-placement.md
+++ b/.changeset/attachment-entity-placement.md
@@ -2,4 +2,4 @@
 '@webspatial/core-sdk': patch
 ---
 
-Fix attachments failing to load on new picoOS runtimes (PicoWebApp/0.4.90 OTA0+) by sending the placement-shaped attachment payload they expect, detected via `supports('AttachmentEntity', ['placement'])`. No API change; visionOS and older runtimes are unaffected.
+Send placement-shaped attachment payloads when the runtime advertises AttachmentEntity placement support.

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -714,8 +714,8 @@ export class InitializeAttachmentCommand extends JSBCommand {
         ownerViewId: p.ownerViewId,
       }
     }
-    // Placement runtimes (PicoWebApp/0.4.90 OTA0+, WSAppShell/1.8.0+) only
-    // decode the placement-shaped payload: Vec3 position and meter dimensions.
+    // Runtimes advertising this capability decode a Vec3 position and meter
+    // dimensions instead of the legacy tuple and point size.
     return {
       id: this.attachmentId,
       placementId: p.parentEntityId,

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -672,6 +672,8 @@ export class AnimateTransformJSBCommand extends JSBCommand {
     return params
   }
 }
+// TODO(remove): temporary OTA0 compat shim — delete once #1330 lands and
+// attachment JSB always uses the placement-shaped payload.
 function usePlacementProtocol(): boolean {
   // WS_SHELL_VERSION debug shells claim every capability via supports(), but
   // the in-repo visionOS runtime still decodes only the legacy attachment

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -743,13 +743,16 @@ export class UpdateAttachmentEntityCommand extends JSBCommand {
       }
     }
     const { position, size } = this.options
-    const params: Record<string, any> = { id: this.attachmentId }
-    if (position) params.position = toPlacementVec3(position)
-    if (size) {
-      params.width = pointToPhysical(size.width)
-      params.height = pointToPhysical(size.height)
+    return {
+      id: this.attachmentId,
+      ...(position ? { position: toPlacementVec3(position) } : {}),
+      ...(size
+        ? {
+            width: pointToPhysical(size.width),
+            height: pointToPhysical(size.height),
+          }
+        : {}),
     }
-    return params
   }
 }
 

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -1,4 +1,10 @@
 import { getPlatform } from './platform-runtime'
+import { pointToPhysical } from './physicalMetrics'
+import {
+  getRuntime,
+  supports,
+  VISIONOS_DEBUG_SHELL_VERSION_PLACEHOLDER,
+} from './runtime/supports'
 import { SpatialComponent } from './reality/component/SpatialComponent'
 import { SpatialEntity } from './reality/entity/SpatialEntity'
 import { SpatialMaterial } from './reality/material/SpatialMaterial'
@@ -666,6 +672,29 @@ export class AnimateTransformJSBCommand extends JSBCommand {
     return params
   }
 }
+function usePlacementProtocol(): boolean {
+  // WS_SHELL_VERSION debug shells claim every capability via supports(), but
+  // the in-repo visionOS runtime still decodes only the legacy attachment
+  // payload — keep sending it there.
+  const rt = getRuntime()
+  if (
+    rt.type === 'visionos' &&
+    rt.shellVersion === VISIONOS_DEBUG_SHELL_VERSION_PLACEHOLDER
+  ) {
+    return false
+  }
+  return supports('AttachmentEntity', ['placement'])
+}
+
+function toPlacementVec3(position?: [number, number, number]): {
+  x: number
+  y: number
+  z: number
+} {
+  const [x, y, z] = position ?? [0, 0, 0]
+  return { x, y, z }
+}
+
 export class InitializeAttachmentCommand extends JSBCommand {
   commandType = 'InitializeAttachment'
   constructor(
@@ -675,12 +704,25 @@ export class InitializeAttachmentCommand extends JSBCommand {
     super()
   }
   protected getParams() {
+    const p = this.options
+    if (!usePlacementProtocol()) {
+      return {
+        id: this.attachmentId,
+        parentEntityId: p.parentEntityId,
+        position: p.position ?? [0, 0, 0],
+        size: p.size,
+        ownerViewId: p.ownerViewId,
+      }
+    }
+    // Placement runtimes (PicoWebApp/0.4.90 OTA0+, WSAppShell/1.8.0+) only
+    // decode the placement-shaped payload: Vec3 position and meter dimensions.
     return {
       id: this.attachmentId,
-      parentEntityId: this.options.parentEntityId,
-      position: this.options.position ?? [0, 0, 0],
-      size: this.options.size,
-      ownerViewId: this.options.ownerViewId,
+      placementId: p.parentEntityId,
+      position: toPlacementVec3(p.position),
+      width: pointToPhysical(p.size.width),
+      height: pointToPhysical(p.size.height),
+      ownerViewId: p.ownerViewId,
     }
   }
 }
@@ -694,10 +736,20 @@ export class UpdateAttachmentEntityCommand extends JSBCommand {
     super()
   }
   protected getParams() {
-    return {
-      id: this.attachmentId,
-      ...this.options,
+    if (!usePlacementProtocol()) {
+      return {
+        id: this.attachmentId,
+        ...this.options,
+      }
     }
+    const { position, size } = this.options
+    const params: Record<string, any> = { id: this.attachmentId }
+    if (position) params.position = toPlacementVec3(position)
+    if (size) {
+      params.width = pointToPhysical(size.width)
+      params.height = pointToPhysical(size.height)
+    }
+    return params
   }
 }
 

--- a/packages/core/src/runtime/capability-data.ts
+++ b/packages/core/src/runtime/capability-data.ts
@@ -52,6 +52,9 @@ function matrixVision_1_5_0_Flags(): Record<string, boolean> {
   flags['SpatialRotateEvent:constrainedToAxis'] = true
   // Container useAnimation is not supported until WSAppShell/1.8.0.
   flags['useAnimation'] = false
+  // Placement-shaped attachment protocol lands in picoOS PicoWebApp/0.4.90
+  // (OTA0); no visionOS shell decodes it yet.
+  flags['AttachmentEntity:placement'] = false
   return flags
 }
 
@@ -67,6 +70,9 @@ function matrixVision_1_6_0_Flags(): Record<string, boolean> {
   flags['SpatialRotateEvent:constrainedToAxis'] = true
   // Container useAnimation is not supported until WSAppShell/1.8.0.
   flags['useAnimation'] = false
+  // Placement-shaped attachment protocol lands in picoOS PicoWebApp/0.4.90
+  // (OTA0); no visionOS shell decodes it yet.
+  flags['AttachmentEntity:placement'] = false
   return flags
 }
 
@@ -139,6 +145,7 @@ function matrixPico_0_3_1_Flags(): Record<string, boolean> {
 function matrixPico_0_4_90_Flags(): Record<string, boolean> {
   const flags = matrixPico_0_3_1_Flags()
   flags['useAnimation'] = true
+  flags['AttachmentEntity:placement'] = true
   return flags
 }
 

--- a/packages/core/src/runtime/keys.ts
+++ b/packages/core/src/runtime/keys.ts
@@ -107,6 +107,10 @@ export const SUB_TOKENS_BY_NAME: Readonly<Record<string, readonly string[]>> = {
     'baseplateVisibility',
   ],
   SpatialRotateEvent: ['constrainedToAxis'],
+  // Placement-shaped attachment JSB protocol (placementId + Vec3 transform +
+  // meter width/height). Runtimes without it take the legacy payload
+  // (parentEntityId + tuple position + point size).
+  AttachmentEntity: ['placement'],
   Model: [
     'autoplay',
     'loop',


### PR DESCRIPTION
##Summary

Adds compatibility for attachment placement on new runtimes without changing the existing public API.

- Detects AttachmentEntity:placement support on newer runtimes.
- Converts existing attachment options into the new placement payload.
- Preserves the existing payload for older runtimes.
- Leaves the new entity-style API to #1330.