### PR TITLE
fix(visionos): preserve double-click for child webviews

### DIFF
--- a/.changeset/collapsible-sidebar-groups.md
+++ b/.changeset/collapsible-sidebar-groups.md
@@ -1,5 +1,0 @@
----
-'web-content': patch
----
-
-Make the test-server sidebar groups collapsible while keeping the active route group expanded.

--- a/.changeset/collapsible-sidebar-groups.md
+++ b/.changeset/collapsible-sidebar-groups.md
@@ -1,0 +1,5 @@
+---
+'web-content': patch
+---
+
+Make the test-server sidebar groups collapsible while keeping the active route group expanded.

--- a/.changeset/fix-visionos-child-window-dblclick.md
+++ b/.changeset/fix-visionos-child-window-dblclick.md
@@ -1,0 +1,8 @@
+---
+'@webspatial/core-sdk': patch
+'@webspatial/platform-visionos': patch
+---
+
+Fix visionOS child windows created through `window.open` so DOM double-click events continue to be synthesized.
+
+Core now rewrites tokenless visionOS spatial child-window commands to `about:blank` URLs with query parameters. The visionOS runtime accepts and parses those opaque `about:` URLs while preserving legacy `webspatial://` command support.

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { entityAnimationRoutes } from '../pages/entity-animation/routes'
 import { spatialElementMotionRoutes } from '../pages/spatial-element-motion/routes'
@@ -78,13 +79,13 @@ export const routes = [
     ],
   },
   { path: '/unit-convert', label: 'Unit Convert' },
-  { path: '/scene/ornament-test', label: 'Ornament Test' },
   {
     path: '/scene',
     label: 'Scene',
     children: [
       { path: '/scene', label: 'Scene Landing' },
       { path: '/scene/volume', label: 'Volume' },
+      { path: '/scene/ornament-test', label: 'Ornament Test' },
       { path: '/scene/xrapp', label: 'XR App' },
       { path: '/scene/nosdk', label: 'No SDK' },
     ],
@@ -159,6 +160,41 @@ export default function Sidebar() {
         typeof child.path === 'string' &&
         location.pathname === child.path,
     )
+  const [expandedRoutes, setExpandedRoutes] = useState<Set<string>>(
+    () => new Set(items.filter(isRouteActive).map(route => route.path)),
+  )
+
+  useEffect(() => {
+    const activeParents = items
+      .filter(route => route.children && isRouteActive(route))
+      .map(route => route.path)
+
+    if (activeParents.length === 0) return
+
+    setExpandedRoutes(prev => {
+      const next = new Set(prev)
+      let changed = false
+      activeParents.forEach(path => {
+        if (!next.has(path)) {
+          next.add(path)
+          changed = true
+        }
+      })
+      return changed ? next : prev
+    })
+  }, [items, location.pathname])
+
+  const toggleRoute = (path: string) => {
+    setExpandedRoutes(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
 
   return (
     <div className={containerClass}>
@@ -171,17 +207,40 @@ export default function Sidebar() {
       <nav className="flex-1 overflow-y-auto p-4 space-y-1">
         {items.map(route => (
           <div key={route.path}>
-            <Link
-              to={route.path}
-              className={`block px-4 py-2 rounded-lg text-sm transition-colors ${
-                isRouteActive(route)
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-400 hover:bg-gray-800 hover:text-white'
-              }`}
-            >
-              {route.label}
-            </Link>
-            {route.children && (
+            {route.children ? (
+              <div
+                className={`flex items-center rounded-lg text-sm transition-colors ${
+                  isRouteActive(route)
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                }`}
+              >
+                <Link to={route.path} className="min-w-0 flex-1 px-4 py-2">
+                  {route.label}
+                </Link>
+                <button
+                  type="button"
+                  aria-label={`${expandedRoutes.has(route.path) ? 'Collapse' : 'Expand'} ${route.label}`}
+                  aria-expanded={expandedRoutes.has(route.path)}
+                  onClick={() => toggleRoute(route.path)}
+                  className="px-3 py-2 text-xs text-current/80 hover:text-white"
+                >
+                  {expandedRoutes.has(route.path) ? '▾' : '▸'}
+                </button>
+              </div>
+            ) : (
+              <Link
+                to={route.path}
+                className={`block px-4 py-2 rounded-lg text-sm transition-colors ${
+                  isRouteActive(route)
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                }`}
+              >
+                {route.label}
+              </Link>
+            )}
+            {route.children && expandedRoutes.has(route.path) && (
               <div className="ml-4 mt-1 space-y-1">
                 {route.children.map(child => {
                   const key = (child as any).path || (child as any).href

--- a/apps/test-server/src/pages/ornament-test/index.tsx
+++ b/apps/test-server/src/pages/ornament-test/index.tsx
@@ -155,6 +155,8 @@ function NumberField({
 }
 
 function NormalDomContent() {
+  const [doubleClickCount, setDoubleClickCount] = useState(0)
+
   return (
     <div
       data-testid="ornament-content-dom"
@@ -163,9 +165,25 @@ function NormalDomContent() {
       <div className="text-xs uppercase tracking-[0.18em] text-white/60">
         Normal DOM
       </div>
-      <div className="mt-2 text-lg font-semibold">Styled by Ornament</div>
-      <div className="mt-3 rounded-lg bg-black/20 px-3 py-2 text-sm">
+      <div className="mt-1 text-base font-semibold">Styled by Ornament</div>
+      <div className="mt-1 rounded-lg bg-black/20 px-2 py-1 text-xs">
         Ordinary CSS is applied to the Ornament document root.
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <button
+          type="button"
+          data-testid="ornament-dblclick"
+          onDoubleClick={() => setDoubleClickCount(count => count + 1)}
+          className="rounded-lg bg-cyan-300 px-2 py-1 text-xs font-semibold text-slate-950"
+        >
+          Double-click me
+        </button>
+        <span
+          data-testid="ornament-dblclick-count"
+          className="text-xs text-white/80"
+        >
+          Count: {doubleClickCount}
+        </span>
       </div>
     </div>
   )

--- a/packages/core/src/scene-polyfill.request-metadata.test.ts
+++ b/packages/core/src/scene-polyfill.request-metadata.test.ts
@@ -15,16 +15,16 @@ describe('scene polyfill request metadata forwarding', () => {
         genToken: vi.fn(() => 'token-123'),
       }
       const originalOpen = vi.fn(() => null)
-      vi.spyOn(window, 'open').mockImplementation(originalOpen)
+      const testWindow = { open: originalOpen } as unknown as WindowProxy
 
       const { hijackWindowOpen } = await import('./scene-polyfill')
-      hijackWindowOpen(window)
+      hijackWindowOpen(testWindow)
 
       const ornamentParams =
         command === 'createOrnament'
           ? '&attachmentAnchor=bottomTrailingFront&contentAlignment=back&visibility=visible&width=240&height=120'
           : ''
-      window.open(
+      testWindow.open(
         `webspatial://${command}?rid=req_1&wsepoch=9${ornamentParams}`,
         '_blank',
       )
@@ -33,11 +33,9 @@ describe('scene polyfill request metadata forwarding', () => {
       const redirectedUrl = (originalOpen.mock.calls as unknown[][])[0]?.[0]
       expect(typeof redirectedUrl).toBe('string')
       const redirected = new URL(String(redirectedUrl))
-      if (redirected.protocol === 'webspatial:') {
-        expect(redirected.host).toBe(command)
-      } else {
-        expect(redirected.searchParams.get('command')).toBe(command)
-      }
+      expect(redirected.origin).toBe(window.location.origin)
+      expect(redirected.pathname).toBe('/token-123/')
+      expect(redirected.searchParams.get('command')).toBe(command)
       expect(redirected.searchParams.get('rid')).toBe('req_1')
       expect(redirected.searchParams.get('wsepoch')).toBe('9')
       expect(redirected.searchParams.get('wsrid')).toBeNull()
@@ -52,4 +50,55 @@ describe('scene polyfill request metadata forwarding', () => {
       }
     },
   )
+
+  it.each(['createSpatialized2DElement', 'createAttachment', 'createOrnament'])(
+    'rewrites %s to about:blank on visionOS when no Swan token is available',
+    async command => {
+      const userAgent =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) WSAppShell/1.8.0 WebSpatial/1.7.0'
+      vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(userAgent)
+      const originalOpen = vi.fn(() => null)
+      const testWindow = { open: originalOpen } as unknown as WindowProxy
+
+      const { hijackWindowOpen } = await import('./scene-polyfill')
+      hijackWindowOpen(testWindow)
+
+      const sourceUrl = `webspatial://${command}?rid=req_2&wsepoch=10&command=${command}&width=240`
+      testWindow.open(sourceUrl, '_blank')
+
+      expect(originalOpen).toHaveBeenCalledTimes(1)
+      const redirectedUrl = (originalOpen.mock.calls as unknown[][])[0]?.[0]
+      const redirected = new URL(String(redirectedUrl))
+      expect(redirected.protocol).toBe('about:')
+      expect(redirected.pathname).toBe('blank')
+      expect(redirected.searchParams.getAll('command')).toEqual([command])
+      expect(redirected.searchParams.get('rid')).toBe('req_2')
+      expect(redirected.searchParams.get('wsepoch')).toBe('10')
+      expect(redirected.searchParams.get('width')).toBe('240')
+    },
+  )
+
+  it.each([
+    [
+      'Pico OS without token injection',
+      'Mozilla/5.0 PicoBrowser PicoWebApp/1.0.0 WebSpatial/1.0.0',
+    ],
+    ['Puppeteer', 'Mozilla/5.0 Puppeteer HeadlessChrome/120.0.0.0'],
+  ])('keeps webspatial URL unchanged on %s', async (_label, userAgent) => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(userAgent)
+    const originalOpen = vi.fn(() => null)
+    const testWindow = { open: originalOpen } as unknown as WindowProxy
+
+    const { hijackWindowOpen } = await import('./scene-polyfill')
+    hijackWindowOpen(testWindow)
+
+    const sourceUrl =
+      'webspatial://createOrnament?rid=req_3&wsepoch=11&command=createOrnament'
+    testWindow.open(sourceUrl, '_blank')
+
+    expect(originalOpen).toHaveBeenCalledOnce()
+    const openCall = (originalOpen.mock.calls as unknown[][])[0]
+    expect(openCall?.[0]).toBe(sourceUrl)
+    expect(openCall?.[1]).toBe('_blank')
+  })
 })

--- a/packages/core/src/scene-polyfill.ts
+++ b/packages/core/src/scene-polyfill.ts
@@ -15,6 +15,7 @@ import {
 import { SpatialSceneCreationOptionsInternal } from './types/internal'
 import { deepCloneJSON } from './utils'
 import { pointToPhysical, physicalToPoint } from './physicalMetrics'
+import { resolveJsbAdapterPlatform } from './runtime/jsbAdapterPlatform'
 
 const defaultSceneConfig: SpatialSceneCreationOptions = {
   defaultSize: {
@@ -288,18 +289,32 @@ class SceneManager {
     if (url?.startsWith(INTERNAL_SCHEMA_PREFIX)) {
       const spatialContentCommand = getSpatialContentCommand(url)
       if (spatialContentCommand) {
+        const sourceParams = new URL(url).searchParams
         const token = //@ts-ignore
           (window.webSpatial || window.__webspatialShell__)?.genToken?.()
         if (token) {
           const host = window.location.host
           const protocol = window.location.protocol
           const finalURL = `${protocol}//${host}/${token}/`
-          const sourceParams = new URL(url).searchParams
           const final = new URL(finalURL)
           sourceParams.forEach((value, key) => {
             final.searchParams.set(key, value)
           })
           final.searchParams.set('command', spatialContentCommand)
+          return this.originalOpen(final.toString(), target, features)
+        }
+        // A legacy Pico shell may lack genToken, so use the adapter resolver
+        // instead of treating every tokenless runtime as visionOS.
+        if (
+          resolveJsbAdapterPlatform(window.navigator.userAgent) === 'visionos'
+        ) {
+          const final = new URL('about:blank')
+          final.searchParams.set('command', spatialContentCommand)
+          sourceParams.forEach((value, key) => {
+            if (key !== 'command') {
+              final.searchParams.append(key, value)
+            }
+          })
           return this.originalOpen(final.toString(), target, features)
         }
       }

--- a/packages/visionOS/web-spatial/model/OrnamentElement.swift
+++ b/packages/visionOS/web-spatial/model/OrnamentElement.swift
@@ -59,8 +59,7 @@ struct OrnamentOptions: Codable, Equatable {
     }
 
     private static func queryValue(_ name: String, from url: URL) -> String? {
-        URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?
+        webSpatialQueryItems(from: url)
             .first { $0.name == name }?
             .value
     }

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -36,6 +36,50 @@ let defaultSceneConfig = SceneOptions(
     baseplateVisibility: .automatic
 )
 
+func webSpatialQueryItems(from url: URL) -> [URLQueryItem] {
+    let absoluteString = url.absoluteString
+    guard absoluteString.hasPrefix("about:blank?") else {
+        return URLComponents(string: absoluteString)?.queryItems ?? []
+    }
+
+    // For the opaque about: URL supplied by WKNavigationAction on visionOS,
+    // absoluteString retains the query while both url.query and
+    // URLComponents(string: absoluteString)?.queryItems are nil.
+    let queryAndFragment = absoluteString.dropFirst("about:blank?".count)
+    let percentEncodedQuery = queryAndFragment.split(
+        separator: "#",
+        maxSplits: 1,
+        omittingEmptySubsequences: false
+    ).first.map(String.init) ?? ""
+
+    var components = URLComponents()
+    components.percentEncodedQuery = percentEncodedQuery
+    return components.queryItems ?? []
+}
+
+enum SpatialOpenWindowCommand: String {
+    case createSpatialScene
+    case createSpatialized2DElement
+    case createAttachment
+    case createOrnament
+
+    init?(url: URL) {
+        let rawCommand = webSpatialQueryItems(from: url)
+            .first { $0.name == "command" }?
+            .value
+            ?? url.host
+
+        guard let rawCommand,
+              let command = SpatialOpenWindowCommand(rawValue: rawCommand),
+              url.scheme == "webspatial"
+              || (url.absoluteString.starts(with: "about:blank?") && command != .createSpatialScene)
+        else {
+            return nil
+        }
+        self = command
+    }
+}
+
 @Observable
 class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSender {
     var parent: (any ScrollAbleSpatialElementContainer)?
@@ -349,6 +393,7 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
         spatialWebViewModel.addJSBListener(CreateSpatializedElementAnimationCommand.self, onCreateSpatializedElementAnimation)
         spatialWebViewModel.addJSBListener(ControlSpatializedElementAnimationCommand.self, onControlSpatializedElementAnimation)
         spatialWebViewModel.addOpenWindowListener(protocal: "webspatial", onOpenWindowHandler)
+        spatialWebViewModel.addOpenWindowListener(protocal: "about:blank?", onOpenWindowHandler)
 
         spatialWebViewModel
             .addNavigationListener(protocal: SpatialApp.Instance.scope, event: handleNavigationCheck)
@@ -419,24 +464,26 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
     }
 
     private func onOpenWindowHandler(url: URL) -> WebViewElementInfo? {
-        let host = url.host ?? ""
-        if host == "createSpatialScene" {
+        guard let command = SpatialOpenWindowCommand(url: url) else {
+            logger.warning("Unknown spatial open-window request: scheme=\(url.scheme ?? "nil"), host=\(url.host ?? "nil")")
+            return nil
+        }
+
+        switch command {
+        case .createSpatialScene:
             return handleWindowOpenCustom(url)
-        } else if host == "createAttachment" {
+        case .createAttachment:
             return handleCreateAttachment(url)
-        } else if host == "createOrnament" {
+        case .createOrnament:
             return handleOrnamentWindowOpen(url)
-        } else if host == "createSpatialized2DElement" {
-            guard shouldAcceptSpatialRequest(url, command: host) else {
+        case .createSpatialized2DElement:
+            guard shouldAcceptSpatialRequest(url, command: command.rawValue) else {
                 return nil
             }
             let spatialized2DElement: Spatialized2DElement = createSpatializedElement(
                 .Spatialized2DElement
             )
             return WebViewElementInfo(id: spatialized2DElement.id, element: spatialized2DElement.getWebViewModel())
-        } else {
-            logger.warning("Unknown webspatial open-window command: \(host)")
-            return nil
         }
     }
 
@@ -538,7 +585,7 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
     }
 
     private func parseSpatialRequestMetadata(_ url: URL) -> SpatialRequestMetadata {
-        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let items = webSpatialQueryItems(from: url)
         let rid = items.first { $0.name == "rid" }?.value
         let pageEpoch = items.first { $0.name == "wsepoch" }?.value
         return SpatialRequestMetadata(rid: rid, pageEpoch: pageEpoch)

--- a/packages/visionOS/web-spatial/webview/SpatialWebController.swift
+++ b/packages/visionOS/web-spatial/webview/SpatialWebController.swift
@@ -78,10 +78,13 @@ class SpatialWebController: NSObject, WKNavigationDelegate, WKScriptMessageHandl
         var needAllow = deciside ?? false
 
         if !needAllow {
-            // webspatial:// is an internal scheme for in-app routing between main and attachment windows.
-            // Only open non-webspatial URLs externally via the system.
-            if navigationAction.request.url?.scheme != "webspatial" {
-                UIApplication.shared.open(navigationAction.request.url!, options: [:], completionHandler: nil)
+            let url = navigationAction.request.url!
+            if url.scheme == "about", SpatialOpenWindowCommand(url: url) != nil {
+                // Allow the child returned by createWebViewWith to finish its internal about:blank navigation.
+                needAllow = true
+            } else if url.scheme != "webspatial" {
+                // webspatial:// is an internal scheme for in-app routing between main and attachment windows.
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         }
         decisionHandler(needAllow ? .allow : .cancel)

--- a/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
+++ b/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
@@ -32,3 +32,51 @@ final class NavigationCleanupTests: XCTestCase {
         XCTAssertNil(SpatialObject.get(panel.id))
     }
 }
+
+final class SpatialOpenWindowCommandTests: XCTestCase {
+    func test_parsesLegacyWebSpatialCommands() throws {
+        let commands: [SpatialOpenWindowCommand] = [
+            .createSpatialScene,
+            .createSpatialized2DElement,
+            .createAttachment,
+            .createOrnament,
+        ]
+
+        for command in commands {
+            let url = try XCTUnwrap(URL(string: "webspatial://\(command.rawValue)?rid=req_1"))
+            XCTAssertEqual(SpatialOpenWindowCommand(url: url), command)
+        }
+    }
+
+    func test_parsesAboutBlankSpatialContentCommands() throws {
+        let commands: [SpatialOpenWindowCommand] = [
+            .createSpatialized2DElement,
+            .createAttachment,
+            .createOrnament,
+        ]
+
+        for command in commands {
+            let url = try XCTUnwrap(URL(string: "about:blank?command=\(command.rawValue)&rid=req_2&wsepoch=9"))
+            XCTAssertEqual(SpatialOpenWindowCommand(url: url), command)
+        }
+    }
+
+    func test_prefersQueryCommandOverLegacyHost() throws {
+        let url = try XCTUnwrap(URL(string: "webspatial://createOrnament?command=createAttachment"))
+        XCTAssertEqual(SpatialOpenWindowCommand(url: url), .createAttachment)
+    }
+
+    func test_rejectsUnsupportedCommands() throws {
+        let urls = [
+            "about:blank",
+            "about:blank?command=createSpatialScene",
+            "about:blank?command=unknown",
+            "https://example.com/?command=createOrnament",
+        ]
+
+        for value in urls {
+            let url = try XCTUnwrap(URL(string: value))
+            XCTAssertNil(SpatialOpenWindowCommand(url: url))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1316.

Fix visionOS child `WKWebView` double-click synthesis by avoiding `webspatial://...` as the initial `window.open` URL for spatial child windows.

## Problem

On visionOS, WebSpatial creates child windows for `SpatialDiv`, `Attachment`, and `Ornament` through:

```ts
window.open("webspatial://<command>?...")</command>
```

Native handles the request in `WKUIDelegate.webView(_:createWebViewWith:for:windowFeatures:)`, creates the corresponding native container, and returns a child `WKWebView`.

The user-facing issue was first observed on Ornament: DOM `dblclick` and React `onDoubleClick` inside an Ornament child `WKWebView` did not fire reliably. Further isolation showed the same root cause also applies to other spatial child windows created through the same custom-scheme `window.open` path, including `SpatialDiv`.

The repro matrix showed:

- `about:blank` child `WKWebView`: `click detail=2`, DOM `dblclick`, and React `onDoubleClick` work.
- `webspatial://createOrnament?...` child `WKWebView`: `dblclick` / React `onDoubleClick` do not fire reliably.
- `webspatial://createSpatialized2DElement?...` child `WKWebView`: the same double-click synthesis issue appears outside Ornament as well.
- React Portal, SwiftUI Ornament, viewport/style sync, nested views, and z offset were ruled out.

So the key variable is the initial URL scheme used by `window.open`.

## Fix

Instead of opening spatial child windows with the internal custom scheme on visionOS, the SDK now rewrites supported spatial content commands to a standard blank-page URL:

```text
about:blank?command=<command>&rid=<rid>&wsepoch=<wsepoch>&...</wsepoch></rid></command>
```

This keeps the synchronous `window.open -> WindowProxy` contract while avoiding the WebKit custom-scheme child browsing-context behavior that breaks double-click synthesis.

### Frontend

In `scene-polyfill.ts`:

- Keep the existing Pico token URL path unchanged when `genToken()` is available.
- For tokenless visionOS runtimes, rewrite these commands to `about:blank?...`:
  - `createSpatialized2DElement`
  - `createAttachment`
  - `createOrnament`
- Preserve request metadata and existing command params in the query string.
- Avoid treating all tokenless runtimes as visionOS by using the existing adapter resolver.

### Native visionOS

In `SpatialScene.swift`:

- Add unified command parsing for both:
  - legacy `webspatial://<command>?...`
  - new `about:blank?command=<command>&...`
- Keep `createSpatialScene` restricted to the legacy `webspatial://` path.
- Allow only spatial child content commands through `about:blank`.
- Parse `rid`, `wsepoch`, and Ornament create options from the same query source.
- Handle WebKit’s opaque `about:` URL behavior where `absoluteString` contains the query, but `url.query` / direct `URLComponents(string:)` parsing may not expose it.

In `SpatialWebController.swift`:

- Keep the original navigation decision order.
- Fold internal `about:blank?...` child navigation allowance into the existing denied-navigation fallback.
- Continue canceling internal `webspatial://` navigation and externally opening ordinary non-internal URLs.

## Demo Update

The Ornament test-server demo now includes a visible double-click probe inside Ornament content:

- `Double-click me` button
- visible counter
- stable test ids:
  - `ornament-dblclick`
  - `ornament-dblclick-count`

This makes manual verification of React `onDoubleClick` inside the child `WKWebView` straightforward.

## Validation

- `@webspatial/core-sdk` type check passed.
- Focused `scene-polyfill` request metadata tests passed.
- `apps/test-server` TypeScript check passed.
- SwiftFormat passed.
- visionOS Simulator build passed.
- Runtime verification on visionOS Simulator confirmed:
  - SpatialDiv child `WKWebView` creation returns non-null `WindowProxy`.
  - Ornament child `WKWebView` creation returns non-null `WindowProxy`.
  - Native command parsing, `rid`, `wsepoch`, and child `WKWebView` creation all succeed with `about:blank?...`.
  - Ornament demo renders the double-click test button.