### PR TITLE
fix(visionos): update navigation cleanup attachment fixture

### DIFF
--- a/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
+++ b/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
@@ -16,9 +16,11 @@ final class NavigationCleanupTests: XCTestCase {
 
         _ = scene.attachmentManager.create(
             id: "test-attachment",
-            parentEntityId: "test-parent-entity",
+            placementId: "test-parent-entity",
             position: SIMD3<Float>(0, 0, 0),
-            size: CGSize(width: 100, height: 100),
+            rotation: SIMD3<Float>(0, 0, 0),
+            scale: SIMD3<Float>(1, 1, 1),
+            frameSize: CGSize(width: 100, height: 100),
             webViewModel: SpatialWebViewModel(url: "http://localhost:5173/")
         )
         XCTAssertFalse(scene.attachmentManager.attachments.isEmpty)


### PR DESCRIPTION
## Summary

- update `NavigationCleanupTests` to call the current `AttachmentManager.create` signature
- provide neutral rotation and scale fixture values
- restore compilation and execution of the complete visionOS test target

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Tests or tooling
- [ ] Chore or maintenance

## Validation

- [ ] `pnpm test`
- [ ] `pnpm test:react-compat`
- [ ] `npm run ciTest`
- [x] Manual validation: targeted `NavigationCleanupTests` passed (1/1); full visionOS `xcodebuild test` passed (38/38) on Apple Vision Pro Simulator 26.2
- [x] Not run / not applicable: JavaScript and AVP e2e suites are unaffected by this test-only Swift fixture update

Commands:

```bash
xcodebuild test \
  -project packages/visionOS/web-spatial.xcodeproj \
  -scheme web-spatial \
  -destination "platform=visionOS Simulator,id=0F64EED5-1986-4260-A1DE-F47F9EECBBF8" \
  -only-testing:web-spatialTests/NavigationCleanupTests

xcodebuild test \
  -project packages/visionOS/web-spatial.xcodeproj \
  -scheme web-spatial \
  -destination "platform=visionOS Simulator,id=0F64EED5-1986-4260-A1DE-F47F9EECBBF8"
```

## Package release

- [ ] This PR does not change published packages under `packages/`.
- [ ] I added a `.changeset/*.md` file.
- [x] A maintainer should apply `skip-changeset`.

## Screenshots or recordings

Not applicable; no UI behavior changes.

## Checklist

- [x] I kept this PR focused and avoided unrelated refactors.
- [x] I preserved existing inline comments unless changing them was part of this PR.
- [x] I updated docs, demos, or tests when behavior changed.