### PR TITLE
Support Attachment corner radius and background material

### DIFF
--- a/.changeset/attachment-corner-radius-material.md
+++ b/.changeset/attachment-corner-radius-material.md
@@ -1,0 +1,7 @@
+---
+'@webspatial/core-sdk': minor
+'@webspatial/react-sdk': minor
+'@webspatial/platform-visionos': minor
+---
+
+Add `cornerRadius` and `backgroundMaterial` to Attachment entities. The public API takes a single number radius (expanded internally to the four-corner shape) and the documented material values ('none' | 'transparent' | 'translucent' | 'thin' | 'regular' | 'thick'). Invalid radii normalize to 0, invalid materials to 'transparent', and both properties update in place without recreating the attachment WebView. visionOS applies the same material-and-corner surface modifier used by Ornaments.

--- a/.changeset/attachment-corner-radius-material.md
+++ b/.changeset/attachment-corner-radius-material.md
@@ -4,4 +4,4 @@
 '@webspatial/platform-visionos': minor
 ---
 
-Add `cornerRadius` and `backgroundMaterial` to Attachment entities. The public API takes a single number radius (expanded internally to the four-corner shape) and the documented material values ('none' | 'transparent' | 'translucent' | 'thin' | 'regular' | 'thick'). Invalid radii normalize to 0, invalid materials to 'transparent', and both properties update in place without recreating the attachment WebView. visionOS applies the same material-and-corner surface modifier used by Ornaments.
+Add `cornerRadius` and `backgroundMaterial` options to Attachment entities, applied in place without recreating the attachment WebView.

--- a/apps/test-server/src/pages/reality/attachments.tsx
+++ b/apps/test-server/src/pages/reality/attachments.tsx
@@ -732,7 +732,9 @@ function TestSurfaceStyle() {
           </div>
         </AttachmentAsset>
         <SceneGraph>
-          <Entity position={{ x: 0, y: 0, z: 0.1 }}>
+          {/* Offset right and down so the floating attachment doesn't cover
+              the slider/material controls above the Reality frame. */}
+          <Entity position={{ x: 0.08, y: -0.12, z: 0.1 }}>
             <BoxEntity
               width={0.1}
               height={0.1}
@@ -741,7 +743,7 @@ function TestSurfaceStyle() {
             />
             <AttachmentEntity
               attachment="surface-style"
-              position={{ x: 0, y: 0.17, z: 0 }}
+              position={{ x: 0, y: 0.16, z: 0 }}
               width={0.3}
               height={0.15}
               cornerRadius={cornerRadius}

--- a/apps/test-server/src/pages/reality/attachments.tsx
+++ b/apps/test-server/src/pages/reality/attachments.tsx
@@ -10,6 +10,7 @@ import {
   SceneGraph,
   UnlitMaterial,
 } from '@webspatial/react-sdk'
+import type { BackgroundMaterialType } from '@webspatial/react-sdk'
 import gsap from 'gsap'
 import React, { useRef } from 'react'
 
@@ -661,6 +662,98 @@ function TestSpatialDivHost() {
   )
 }
 
+const SURFACE_MATERIALS = [
+  'none',
+  'transparent',
+  'translucent',
+  'thin',
+  'regular',
+  'thick',
+  'invalid-material',
+] as const
+
+/** 8. Surface styling — cornerRadius + backgroundMaterial live updates. */
+function TestSurfaceStyle() {
+  const [cornerRadius, setCornerRadius] = React.useState(24)
+  const [material, setMaterial] = React.useState<string>('translucent')
+
+  return (
+    <TestCase title="8. Surface style (cornerRadius + backgroundMaterial)">
+      <p className="text-sm text-gray-600 mb-3">
+        Drag the slider and switch materials to restyle the attachment surface
+        in place — the WebView is not recreated. The HTML content is transparent
+        so the native material shows through; content is clipped to the rounded
+        corners. Selecting <code className="text-xs">invalid-material</code>{' '}
+        normalizes to <code className="text-xs">transparent</code> and logs a
+        dev warning.
+      </p>
+      <div className="mb-4 max-w-md space-y-2 rounded border border-gray-200 bg-gray-50 p-3">
+        <SliderRow
+          label="Corner radius"
+          value={cornerRadius}
+          min={0}
+          max={60}
+          step={1}
+          onChange={setCornerRadius}
+          unit=" pt"
+        />
+        <label className="flex items-center gap-3 text-sm">
+          <span className="w-28 shrink-0 text-gray-700">Material</span>
+          <select
+            value={material}
+            onChange={e => setMaterial(e.target.value)}
+            className="flex-1 min-w-0 rounded border border-gray-300 px-2 py-1"
+          >
+            {SURFACE_MATERIALS.map(m => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <Reality style={{ ...REALITY_FRAME, border: '1px solid #7c3aed' }}>
+        <UnlitMaterial id="matSurface" color="#7c3aed" />
+        <AttachmentAsset id="surface-style">
+          <div
+            style={{
+              color: 'white',
+              padding: 12,
+              textAlign: 'center',
+              minHeight: '100%',
+              boxSizing: 'border-box',
+              textShadow: '0 1px 2px rgba(0,0,0,0.6)',
+            }}
+          >
+            <p style={{ margin: 0, fontWeight: 600 }}>Surface style</p>
+            <p style={{ margin: '6px 0 0', fontSize: 12 }}>
+              radius {cornerRadius} pt · {material}
+            </p>
+          </div>
+        </AttachmentAsset>
+        <SceneGraph>
+          <Entity position={{ x: 0, y: 0, z: 0.1 }}>
+            <BoxEntity
+              width={0.1}
+              height={0.1}
+              depth={0.1}
+              materials={['matSurface']}
+            />
+            <AttachmentEntity
+              attachment="surface-style"
+              position={{ x: 0, y: 0.17, z: 0 }}
+              width={0.3}
+              height={0.15}
+              cornerRadius={cornerRadius}
+              backgroundMaterial={material as BackgroundMaterialType}
+            />
+          </Entity>
+        </SceneGraph>
+      </Reality>
+    </TestCase>
+  )
+}
+
 function App() {
   return (
     <div className="p-8">
@@ -673,6 +766,7 @@ function App() {
         <TestDuplicateAssetId />
         <TestGsapInAttachment />
         <TestSpatialDivHost />
+        <TestSurfaceStyle />
       </div>
     </div>
   )

--- a/docs/Attachments.md
+++ b/docs/Attachments.md
@@ -6,8 +6,8 @@ Attachments allow developers to render interactive 2D HTML/React content — but
 
 The API uses two components with a deliberate separation of concerns:
 
-- **`<AttachmentAsset>`** declares *what* to render (the React content template). Placed outside `<SceneGraph>`.
-- **`<AttachmentEntity>`** declares *where* to render it (transform, dimensions, parent entity). Placed inside `<SceneGraph>`.
+- **`<AttachmentAsset>`** declares _what_ to render (the React content template). Placed outside `<SceneGraph>`.
+- **`<AttachmentEntity>`** declares _where_ to render it (transform, dimensions, parent entity). Placed inside `<SceneGraph>`.
 
 This enables a 1→N pattern: one content template can be rendered into multiple 3D positions simultaneously, mirroring the existing asset-vs-entity pattern used by models and materials.
 
@@ -81,6 +81,28 @@ Optional width of the attachment frame in world-space meters. When omitted, the 
 
 Optional height of the attachment frame in world-space meters. When omitted, the native layer falls back to an internal default frame size.
 
+`cornerRadius`
+
+Optional `number` — a uniform corner radius in points applied to all four corners of the attachment surface. Defaults to `0` (square corners). The public API is a single number; internally it is expanded into the native four-corner shape (`topLeading` / `bottomLeading` / `topTrailing` / `bottomTrailing`) before serialization. Negative or non-finite values are normalized to `0`. The webview content is clipped to the rounded rectangle, so HTML that reaches the surface edge is cut at the corners.
+
+`backgroundMaterial`
+
+Optional background material for the attachment surface:
+
+```ts
+type BackgroundMaterialType =
+  | 'none'
+  | 'transparent'
+  | 'translucent'
+  | 'thin'
+  | 'regular'
+  | 'thick'
+```
+
+Defaults to `'transparent'`. `'none'` and `'transparent'` both render a fully transparent surface (the attachment shows only its HTML content). `'translucent'` renders the visionOS glass effect; `'thin'`, `'regular'`, and `'thick'` render the corresponding system materials behind the webview content, matching the Ornament material behavior. Any other value is normalized to `'transparent'`, and React warns in development builds when it receives an unsupported material.
+
+Both `cornerRadius` and `backgroundMaterial` can change at runtime. Changes are applied **in place** via `UpdateAttachmentEntityCommand` — the attachment WebView is not recreated. Updates that omit these properties preserve the attachment's current effective values.
+
 ### Usage Notes
 
 - `<AttachmentEntity>` must be placed inside `<SceneGraph>`, as a descendant of an `<Entity>`. It inherits the parent entity's transform — when the entity moves, the attachment follows.
@@ -91,10 +113,10 @@ Optional height of the attachment frame in world-space meters. When omitted, the
 
 ## Migration
 
-| Before | After |
-| --- | --- |
-| `<AttachmentAsset name="hud">` | `<AttachmentAsset id="hud">` |
-| `position={[x, y, z]}` | `position={{ x, y, z }}` |
+| Before                              | After                               |
+| ----------------------------------- | ----------------------------------- |
+| `<AttachmentAsset name="hud">`      | `<AttachmentAsset id="hud">`        |
+| `position={[x, y, z]}`              | `position={{ x, y, z }}`            |
 | `size={{ width, height }}` (points) | `width={m}` / `height={m}` (meters) |
 
 Add `rotation` and `scale` as optional `{ x, y, z }` props when you need orientation or non-uniform scaling. Tuple position and the `size` object are no longer accepted.
@@ -114,40 +136,38 @@ Inline styles set directly on elements inside the attachment work as expected.
 
 The following components detect when they are rendered inside an `<AttachmentAsset>` and degrade gracefully:
 
-| Component | Behavior Inside Attachment |
-|-----------|---------------------------|
-| `<Reality>` | Returns `null` with a console warning.  |
+| Component                               | Behavior Inside Attachment                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `<Reality>`                             | Returns `null` with a console warning.                                        |
 | `<SpatialDiv>` / `SpatializedContainer` | Renders as plain HTML (strips spatial props). Layout and Tailwind still work. |
-| `<Model>` | Renders as a plain `<model>` tag without spatialization. |
-
-
+| `<Model>`                               | Renders as a plain `<model>` tag without spatialization.                      |
 
 ## Technical Summary
 
-|||
-| --- | --- |
-| Permitted content for `<AttachmentAsset>` | Any valid React JSX. Spatial components (`<Reality>`, `<SpatialDiv>`, `<Model>`) will degrade to plain HTML. |
-| Permitted content for `<AttachmentEntity>` | None. Returns `null`. |
-| Permitted parents for `<AttachmentAsset>` | Direct child of `<Reality>`, outside `<SceneGraph>`. |
-| Permitted parents for `<AttachmentEntity>` | Any `<Entity>` descendant inside `<SceneGraph>`. |
-| Rendering mechanism | `createPortal` from the host React tree into each attachment WKWebView's `document.body`. |
-| Native backing | One `WKWebView` per `<AttachmentEntity>` instance, rendered as a RealityKit `ViewAttachmentEntity`. |
+|                                            |                                                                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Permitted content for `<AttachmentAsset>`  | Any valid React JSX. Spatial components (`<Reality>`, `<SpatialDiv>`, `<Model>`) will degrade to plain HTML. |
+| Permitted content for `<AttachmentEntity>` | None. Returns `null`.                                                                                        |
+| Permitted parents for `<AttachmentAsset>`  | Direct child of `<Reality>`, outside `<SceneGraph>`.                                                         |
+| Permitted parents for `<AttachmentEntity>` | Any `<Entity>` descendant inside `<SceneGraph>`.                                                             |
+| Rendering mechanism                        | `createPortal` from the host React tree into each attachment WKWebView's `document.body`.                    |
+| Native backing                             | One `WKWebView` per `<AttachmentEntity>` instance, rendered as a RealityKit `ViewAttachmentEntity`.          |
 
 ## Browser Compatibility
 
-| Feature | visionOS |
-| --- | --- |
-| `<AttachmentAsset>` |  WebSpatial April |
+| Feature              | visionOS         |
+| -------------------- | ---------------- |
+| `<AttachmentAsset>`  | WebSpatial April |
 | `<AttachmentEntity>` | WebSpatial April |
 
 ### Not Supported
 
-| Feature | Status |
-| --- | --- |
-| Nested `<Reality>` inside attachments | Blocked — returns null with warning |
-| Nested `<SpatialDiv>` inside attachments | Degrades to plain HTML |
-| 3D content inside attachments | Not supported — 2D surfaces only |
-| Billboard / camera-facing policy | Not in this PR |
+| Feature                                  | Status                              |
+| ---------------------------------------- | ----------------------------------- |
+| Nested `<Reality>` inside attachments    | Blocked — returns null with warning |
+| Nested `<SpatialDiv>` inside attachments | Degrades to plain HTML              |
+| 3D content inside attachments            | Not supported — 2D surfaces only    |
+| Billboard / camera-facing policy         | Not in this PR                      |
 
 ## High-Level Architecture
 
@@ -167,11 +187,11 @@ Attachment creation uses `window.open("webspatial://createAttachment?...")` inst
 
 ### Creation Protocol vs. Update/Destroy Protocol
 
-| Operation | Protocol | Reason |
-|-----------|----------|--------|
-| Create | `WebSpatialProtocolCommand` (`window.open`) | Must return `WindowProxy` synchronously |
-| Update | `JSBCommand` (JSB message) | Only sends data (position, rotation, scale, width, height) — no return value needed |
-| Destroy | `DestroyCommand` (JSB message) | Standard spatial object destroy pipeline |
+| Operation | Protocol                                    | Reason                                                                                                                |
+| --------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Create    | `WebSpatialProtocolCommand` (`window.open`) | Must return `WindowProxy` synchronously                                                                               |
+| Update    | `JSBCommand` (JSB message)                  | Only sends data (position, rotation, scale, width, height, cornerRadius, backgroundMaterial) — no return value needed |
+| Destroy   | `DestroyCommand` (JSB message)              | Standard spatial object destroy pipeline                                                                              |
 
 ## Constraints
 

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -28,6 +28,10 @@ import {
   SpatialTextureResourceOptions,
 } from './types/types'
 import type { OrnamentOptions } from './Ornament'
+import {
+  normalizeAttachmentBackgroundMaterial,
+  normalizeAttachmentCornerRadius,
+} from './reality/attachmentSurface'
 import type { AnimateTransformCommand } from './types/animation'
 import { composeSRT } from './utils'
 import type {
@@ -717,6 +721,10 @@ export class InitializeAttachmentCommand extends JSBCommand {
       width: this.options.width,
       height: this.options.height,
       ownerViewId: this.options.ownerViewId,
+      cornerRadius: normalizeAttachmentCornerRadius(this.options.cornerRadius),
+      backgroundMaterial: normalizeAttachmentBackgroundMaterial(
+        this.options.backgroundMaterial,
+      ),
     }
   }
 }
@@ -730,10 +738,23 @@ export class UpdateAttachmentEntityCommand extends JSBCommand {
     super()
   }
   protected getParams() {
-    return {
+    // Omitted fields stay omitted so the native side preserves the
+    // attachment's existing effective values on partial updates.
+    const params: Record<string, unknown> = {
       id: this.attachmentId,
       ...this.options,
     }
+    if (this.options.cornerRadius !== undefined) {
+      params.cornerRadius = normalizeAttachmentCornerRadius(
+        this.options.cornerRadius,
+      )
+    }
+    if (this.options.backgroundMaterial !== undefined) {
+      params.backgroundMaterial = normalizeAttachmentBackgroundMaterial(
+        this.options.backgroundMaterial,
+      )
+    }
+    return params
   }
 }
 

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -23,6 +23,8 @@ import {
   Vec3,
   AttachmentEntityOptions,
   AttachmentEntityUpdateOptions,
+  BackgroundMaterialType,
+  CornerRadius,
   ModelLoadingMode,
   ModelSource,
   SpatialTextureResourceOptions,
@@ -740,19 +742,24 @@ export class UpdateAttachmentEntityCommand extends JSBCommand {
   protected getParams() {
     // Omitted fields stay omitted so the native side preserves the
     // attachment's existing effective values on partial updates.
-    const params: Record<string, unknown> = {
+    const { cornerRadius, backgroundMaterial, ...rest } = this.options
+    const params: {
+      id: string
+      cornerRadius?: CornerRadius
+      backgroundMaterial?: BackgroundMaterialType
+    } & Omit<
+      AttachmentEntityUpdateOptions,
+      'cornerRadius' | 'backgroundMaterial'
+    > = {
       id: this.attachmentId,
-      ...this.options,
+      ...rest,
     }
-    if (this.options.cornerRadius !== undefined) {
-      params.cornerRadius = normalizeAttachmentCornerRadius(
-        this.options.cornerRadius,
-      )
+    if (cornerRadius !== undefined) {
+      params.cornerRadius = normalizeAttachmentCornerRadius(cornerRadius)
     }
-    if (this.options.backgroundMaterial !== undefined) {
-      params.backgroundMaterial = normalizeAttachmentBackgroundMaterial(
-        this.options.backgroundMaterial,
-      )
+    if (backgroundMaterial !== undefined) {
+      params.backgroundMaterial =
+        normalizeAttachmentBackgroundMaterial(backgroundMaterial)
     }
     return params
   }

--- a/packages/core/src/reality/Attachment.ts
+++ b/packages/core/src/reality/Attachment.ts
@@ -33,6 +33,10 @@ export class Attachment extends SpatialObject {
     if (options.scale) this.options.scale = options.scale
     if (options.width !== undefined) this.options.width = options.width
     if (options.height !== undefined) this.options.height = options.height
+    if (options.cornerRadius !== undefined)
+      this.options.cornerRadius = options.cornerRadius
+    if (options.backgroundMaterial !== undefined)
+      this.options.backgroundMaterial = options.backgroundMaterial
     return new UpdateAttachmentEntityCommand(this.id, options).execute()
   }
 }

--- a/packages/core/src/reality/attachment.coverage.test.ts
+++ b/packages/core/src/reality/attachment.coverage.test.ts
@@ -19,6 +19,15 @@ function ok(data: any = {}) {
   })
 }
 
+function cornerRadius(radius: number) {
+  return {
+    topLeading: radius,
+    bottomLeading: radius,
+    topTrailing: radius,
+    bottomTrailing: radius,
+  }
+}
+
 describe('Attachment entity wire format', () => {
   beforeEach(() => {
     platformSpy.callJSB.mockReset()
@@ -56,6 +65,8 @@ describe('Attachment entity wire format', () => {
         width: 0.4,
         height: 0.2,
         ownerViewId: 'reality-1',
+        cornerRadius: cornerRadius(0),
+        backgroundMaterial: 'transparent',
       }),
     )
   })
@@ -84,6 +95,176 @@ describe('Attachment entity wire format', () => {
         scale: { x: 1, y: 1, z: 1 },
         width: 0.5,
         height: 0.25,
+      }),
+    )
+  })
+
+  it('initializes with cornerRadius expanded to four corners and validated material', async () => {
+    const { createAttachmentEntity } = await import('./Attachment')
+
+    await createAttachmentEntity({
+      placement: { id: 'entity-1' },
+      width: 0.4,
+      height: 0.2,
+      cornerRadius: 12,
+      backgroundMaterial: 'translucent',
+      ownerViewId: 'reality-1',
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'InitializeAttachment',
+      JSON.stringify({
+        id: 'att-1',
+        placementId: 'entity-1',
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+        width: 0.4,
+        height: 0.2,
+        ownerViewId: 'reality-1',
+        cornerRadius: cornerRadius(12),
+        backgroundMaterial: 'translucent',
+      }),
+    )
+  })
+
+  it('initializes with an explicit zero cornerRadius', async () => {
+    const { createAttachmentEntity } = await import('./Attachment')
+
+    await createAttachmentEntity({
+      placement: { id: 'entity-1' },
+      cornerRadius: 0,
+      backgroundMaterial: 'thin',
+      ownerViewId: 'reality-1',
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'InitializeAttachment',
+      JSON.stringify({
+        id: 'att-1',
+        placementId: 'entity-1',
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+        ownerViewId: 'reality-1',
+        cornerRadius: cornerRadius(0),
+        backgroundMaterial: 'thin',
+      }),
+    )
+  })
+
+  it.each([
+    ['negative', -8],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('normalizes a %s cornerRadius to 0 on initialize', async (_label, bad) => {
+    const { createAttachmentEntity } = await import('./Attachment')
+
+    await createAttachmentEntity({
+      placement: { id: 'entity-1' },
+      cornerRadius: bad,
+      ownerViewId: 'reality-1',
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'InitializeAttachment',
+      JSON.stringify({
+        id: 'att-1',
+        placementId: 'entity-1',
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+        ownerViewId: 'reality-1',
+        cornerRadius: cornerRadius(0),
+        backgroundMaterial: 'transparent',
+      }),
+    )
+  })
+
+  it('normalizes an invalid backgroundMaterial to transparent on initialize', async () => {
+    const { createAttachmentEntity } = await import('./Attachment')
+
+    await createAttachmentEntity({
+      placement: { id: 'entity-1' },
+      backgroundMaterial: 'frosted' as any,
+      ownerViewId: 'reality-1',
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'InitializeAttachment',
+      JSON.stringify({
+        id: 'att-1',
+        placementId: 'entity-1',
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+        ownerViewId: 'reality-1',
+        cornerRadius: cornerRadius(0),
+        backgroundMaterial: 'transparent',
+      }),
+    )
+  })
+
+  it('updates cornerRadius and backgroundMaterial in place', async () => {
+    const { Attachment } = await import('./Attachment')
+    const attachment = new Attachment('att-1', {} as WindowProxy, {
+      placement: { id: 'entity-1' },
+      ownerViewId: 'reality-1',
+    })
+
+    await attachment.update({
+      cornerRadius: 24,
+      backgroundMaterial: 'thick',
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'UpdateAttachmentEntity',
+      JSON.stringify({
+        id: 'att-1',
+        cornerRadius: cornerRadius(24),
+        backgroundMaterial: 'thick',
+      }),
+    )
+  })
+
+  it('normalizes invalid cornerRadius and backgroundMaterial on update', async () => {
+    const { Attachment } = await import('./Attachment')
+    const attachment = new Attachment('att-1', {} as WindowProxy, {
+      placement: { id: 'entity-1' },
+      ownerViewId: 'reality-1',
+    })
+
+    await attachment.update({
+      cornerRadius: -4,
+      backgroundMaterial: 'frosted' as any,
+    })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'UpdateAttachmentEntity',
+      JSON.stringify({
+        id: 'att-1',
+        cornerRadius: cornerRadius(0),
+        backgroundMaterial: 'transparent',
+      }),
+    )
+  })
+
+  it('omits cornerRadius and backgroundMaterial from unrelated updates so existing values persist', async () => {
+    const { Attachment } = await import('./Attachment')
+    const attachment = new Attachment('att-1', {} as WindowProxy, {
+      placement: { id: 'entity-1' },
+      cornerRadius: 16,
+      backgroundMaterial: 'regular',
+      ownerViewId: 'reality-1',
+    })
+
+    await attachment.update({ position: { x: 7, y: 8, z: 9 } })
+
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'UpdateAttachmentEntity',
+      JSON.stringify({
+        id: 'att-1',
+        position: { x: 7, y: 8, z: 9 },
       }),
     )
   })

--- a/packages/core/src/reality/attachmentSurface.ts
+++ b/packages/core/src/reality/attachmentSurface.ts
@@ -1,6 +1,6 @@
 import type { BackgroundMaterialType, CornerRadius } from '../types/types'
 
-export const ATTACHMENT_BACKGROUND_MATERIAL_VALUES = new Set<string>([
+export const ATTACHMENT_BACKGROUND_MATERIAL_VALUES = new Set([
   'none',
   'transparent',
   'translucent',
@@ -12,12 +12,9 @@ export const ATTACHMENT_BACKGROUND_MATERIAL_VALUES = new Set<string>([
 export const DEFAULT_ATTACHMENT_BACKGROUND_MATERIAL: BackgroundMaterialType =
   'transparent'
 
-/**
- * Expands the public single-number attachment corner radius into the internal
- * four-corner CornerRadius command shape. Missing, negative, or non-finite
- * values fall back to 0 for all corners.
- */
-export function normalizeAttachmentCornerRadius(value: unknown): CornerRadius {
+export function normalizeAttachmentCornerRadius(
+  value: number | undefined,
+): CornerRadius {
   const radius =
     typeof value === 'number' && Number.isFinite(value) && value >= 0
       ? value
@@ -30,14 +27,11 @@ export function normalizeAttachmentCornerRadius(value: unknown): CornerRadius {
   }
 }
 
-/**
- * Missing or invalid materials fall back to 'transparent'.
- */
 export function normalizeAttachmentBackgroundMaterial(
-  value: unknown,
+  value: BackgroundMaterialType | undefined,
 ): BackgroundMaterialType {
   return typeof value === 'string' &&
     ATTACHMENT_BACKGROUND_MATERIAL_VALUES.has(value)
-    ? (value as BackgroundMaterialType)
+    ? value
     : DEFAULT_ATTACHMENT_BACKGROUND_MATERIAL
 }

--- a/packages/core/src/reality/attachmentSurface.ts
+++ b/packages/core/src/reality/attachmentSurface.ts
@@ -1,0 +1,43 @@
+import type { BackgroundMaterialType, CornerRadius } from '../types/types'
+
+export const ATTACHMENT_BACKGROUND_MATERIAL_VALUES = new Set<string>([
+  'none',
+  'transparent',
+  'translucent',
+  'thin',
+  'regular',
+  'thick',
+])
+
+export const DEFAULT_ATTACHMENT_BACKGROUND_MATERIAL: BackgroundMaterialType =
+  'transparent'
+
+/**
+ * Expands the public single-number attachment corner radius into the internal
+ * four-corner CornerRadius command shape. Missing, negative, or non-finite
+ * values fall back to 0 for all corners.
+ */
+export function normalizeAttachmentCornerRadius(value: unknown): CornerRadius {
+  const radius =
+    typeof value === 'number' && Number.isFinite(value) && value >= 0
+      ? value
+      : 0
+  return {
+    topLeading: radius,
+    bottomLeading: radius,
+    topTrailing: radius,
+    bottomTrailing: radius,
+  }
+}
+
+/**
+ * Missing or invalid materials fall back to 'transparent'.
+ */
+export function normalizeAttachmentBackgroundMaterial(
+  value: unknown,
+): BackgroundMaterialType {
+  return typeof value === 'string' &&
+    ATTACHMENT_BACKGROUND_MATERIAL_VALUES.has(value)
+    ? (value as BackgroundMaterialType)
+    : DEFAULT_ATTACHMENT_BACKGROUND_MATERIAL
+}

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -433,6 +433,16 @@ export interface AttachmentEntityOptions {
   scale?: Vec3
   width?: number
   height?: number
+  /**
+   * Uniform corner radius in points applied to all four corners of the
+   * attachment surface. Invalid values (negative or non-finite) fall back to 0.
+   */
+  cornerRadius?: number
+  /**
+   * Background material of the attachment surface. Invalid or missing values
+   * fall back to 'transparent'.
+   */
+  backgroundMaterial?: BackgroundMaterialType
   ownerViewId: string
 }
 
@@ -442,6 +452,8 @@ export interface AttachmentEntityUpdateOptions {
   scale?: Vec3
   width?: number
   height?: number
+  cornerRadius?: number
+  backgroundMaterial?: BackgroundMaterialType
 }
 
 // manifest

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -433,15 +433,7 @@ export interface AttachmentEntityOptions {
   scale?: Vec3
   width?: number
   height?: number
-  /**
-   * Uniform corner radius in points applied to all four corners of the
-   * attachment surface. Invalid values (negative or non-finite) fall back to 0.
-   */
   cornerRadius?: number
-  /**
-   * Background material of the attachment surface. Invalid or missing values
-   * fall back to 'transparent'.
-   */
   backgroundMaterial?: BackgroundMaterialType
   ownerViewId: string
 }

--- a/packages/react/src/facades/entities.tsx
+++ b/packages/react/src/facades/entities.tsx
@@ -2,6 +2,7 @@
 
 import { ComponentType, ForwardedRef, forwardRef } from 'react'
 import type {
+  BackgroundMaterialType,
   SpatialBoxGeometryOptions,
   SpatialConeGeometryOptions,
   SpatialCylinderGeometryOptions,
@@ -105,6 +106,8 @@ export type AttachmentEntityProps = {
   scale?: Vec3
   width?: number
   height?: number
+  cornerRadius?: number
+  backgroundMaterial?: BackgroundMaterialType
 }
 
 // `/* @__PURE__ */` annotations on each factory call: tells the consumer

--- a/packages/react/src/reality/components/AttachmentEntity.test.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.test.tsx
@@ -198,36 +198,23 @@ describe('AttachmentEntity', () => {
     )
   })
 
-  it('normalizes invalid values and warns about invalid materials in development', async () => {
+  it('normalizes invalid cornerRadius values to 0', async () => {
     const { session, ctx, parent } = makeHarness()
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    try {
-      render(
-        <RealityContext.Provider value={ctx}>
-          <ParentContext.Provider value={parent}>
-            <AttachmentEntity
-              attachment="panel"
-              cornerRadius={-5}
-              backgroundMaterial={'frosted' as any}
-            />
-          </ParentContext.Provider>
-        </RealityContext.Provider>,
-      )
+    render(
+      <RealityContext.Provider value={ctx}>
+        <ParentContext.Provider value={parent}>
+          <AttachmentEntity attachment="panel" cornerRadius={-5} />
+        </ParentContext.Provider>
+      </RealityContext.Provider>,
+    )
 
-      await act(async () => {})
+    await act(async () => {})
 
-      expect(session.createAttachmentEntity).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cornerRadius: 0,
-          backgroundMaterial: 'transparent',
-        }),
-      )
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('Invalid backgroundMaterial "frosted"'),
-      )
-    } finally {
-      warn.mockRestore()
-    }
+    expect(session.createAttachmentEntity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cornerRadius: 0,
+      }),
+    )
   })
 })

--- a/packages/react/src/reality/components/AttachmentEntity.test.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.test.tsx
@@ -12,6 +12,31 @@ function makeWindowProxy() {
   return { document } as unknown as WindowProxy
 }
 
+function makeHarness() {
+  const update = vi.fn()
+  const destroy = vi.fn()
+  const container = document.createElement('div')
+  const session = {
+    createAttachmentEntity: vi.fn(async () => ({
+      update,
+      destroy,
+      getWindowProxy: () => makeWindowProxy(),
+      getContainer: () => container,
+    })),
+  }
+  const ctx = {
+    session,
+    reality: { id: 'reality-1' },
+    resourceRegistry: {} as any,
+    attachmentRegistry: {
+      addContainer: vi.fn(),
+      removeContainer: vi.fn(),
+    },
+  } as any
+  const parent = { id: 'parent-1' } as any
+  return { session, update, destroy, ctx, parent }
+}
+
 describe('AttachmentEntity', () => {
   it('creates and updates with entity-like transforms and meter dimensions', async () => {
     const update = vi.fn()
@@ -94,5 +119,115 @@ describe('AttachmentEntity', () => {
       width: 0.5,
       height: 0.25,
     })
+  })
+
+  it('passes cornerRadius and backgroundMaterial through creation and in-place updates', async () => {
+    const { session, update, destroy, ctx, parent } = makeHarness()
+
+    const view = render(
+      <RealityContext.Provider value={ctx}>
+        <ParentContext.Provider value={parent}>
+          <AttachmentEntity
+            attachment="panel"
+            width={0.4}
+            height={0.2}
+            cornerRadius={12}
+            backgroundMaterial="translucent"
+          />
+        </ParentContext.Provider>
+      </RealityContext.Provider>,
+    )
+
+    await act(async () => {})
+
+    expect(session.createAttachmentEntity).toHaveBeenCalledTimes(1)
+    expect(session.createAttachmentEntity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cornerRadius: 12,
+        backgroundMaterial: 'translucent',
+      }),
+    )
+
+    view.rerender(
+      <RealityContext.Provider value={ctx}>
+        <ParentContext.Provider value={parent}>
+          <AttachmentEntity
+            attachment="panel"
+            width={0.4}
+            height={0.2}
+            cornerRadius={24}
+            backgroundMaterial="thick"
+          />
+        </ParentContext.Provider>
+      </RealityContext.Provider>,
+    )
+
+    expect(update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        cornerRadius: 24,
+        backgroundMaterial: 'thick',
+      }),
+    )
+    // In-place update: the attachment is neither destroyed nor recreated.
+    expect(session.createAttachmentEntity).toHaveBeenCalledTimes(1)
+    expect(destroy).not.toHaveBeenCalled()
+  })
+
+  it('passes an explicit zero cornerRadius through unchanged', async () => {
+    const { session, ctx, parent } = makeHarness()
+
+    render(
+      <RealityContext.Provider value={ctx}>
+        <ParentContext.Provider value={parent}>
+          <AttachmentEntity
+            attachment="panel"
+            cornerRadius={0}
+            backgroundMaterial="thin"
+          />
+        </ParentContext.Provider>
+      </RealityContext.Provider>,
+    )
+
+    await act(async () => {})
+
+    expect(session.createAttachmentEntity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cornerRadius: 0,
+        backgroundMaterial: 'thin',
+      }),
+    )
+  })
+
+  it('normalizes invalid values and warns about invalid materials in development', async () => {
+    const { session, ctx, parent } = makeHarness()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      render(
+        <RealityContext.Provider value={ctx}>
+          <ParentContext.Provider value={parent}>
+            <AttachmentEntity
+              attachment="panel"
+              cornerRadius={-5}
+              backgroundMaterial={'frosted' as any}
+            />
+          </ParentContext.Provider>
+        </RealityContext.Provider>,
+      )
+
+      await act(async () => {})
+
+      expect(session.createAttachmentEntity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cornerRadius: 0,
+          backgroundMaterial: 'transparent',
+        }),
+      )
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid backgroundMaterial "frosted"'),
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/packages/react/src/reality/components/AttachmentEntity.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.tsx
@@ -1,12 +1,45 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Attachment } from '@webspatial/core-sdk'
-import type { Vec3 } from '@webspatial/core-sdk'
+import type { BackgroundMaterialType, Vec3 } from '@webspatial/core-sdk'
 
 import { useRealityContext, useParentContext } from '../context'
 import { setOpenWindowStyle } from '../../utils/windowStyleSync'
 import { useSyncHeadStyles } from '../../utils/useSyncHeadStyles'
 
 let instanceCounter = 0
+
+const ATTACHMENT_BACKGROUND_MATERIALS = new Set<string>([
+  'none',
+  'transparent',
+  'translucent',
+  'thin',
+  'regular',
+  'thick',
+])
+
+function normalizeCornerRadiusProp(value: number | undefined) {
+  if (value === undefined) return undefined
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : 0
+}
+
+function normalizeBackgroundMaterialProp(
+  value: BackgroundMaterialType | undefined,
+): BackgroundMaterialType | undefined {
+  if (value === undefined) return undefined
+  if (typeof value === 'string' && ATTACHMENT_BACKGROUND_MATERIALS.has(value)) {
+    return value
+  }
+  if (typeof process === 'undefined' || process.env.NODE_ENV !== 'production') {
+    console.warn(
+      `[AttachmentEntity] Invalid backgroundMaterial "${String(value)}"; ` +
+        `falling back to "transparent". Supported values: ` +
+        `'none' | 'transparent' | 'translucent' | 'thin' | 'regular' | 'thick'.`,
+    )
+  }
+  return 'transparent'
+}
 
 type AttachmentEntityProps = {
   attachment: string
@@ -15,6 +48,8 @@ type AttachmentEntityProps = {
   scale?: Vec3
   width?: number
   height?: number
+  cornerRadius?: number
+  backgroundMaterial?: BackgroundMaterialType
 }
 
 export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
@@ -24,6 +59,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
   scale,
   width,
   height,
+  cornerRadius,
+  backgroundMaterial,
 }) => {
   const ctx = useRealityContext()
   const parent = useParentContext()
@@ -32,6 +69,12 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
   const instanceIdRef = useRef(`att_${++instanceCounter}`)
   const attachmentNameRef = useRef(attachmentName)
   const [childWindow, setChildWindow] = useState<WindowProxy | null>(null)
+
+  const normalizedCornerRadius = normalizeCornerRadiusProp(cornerRadius)
+  const normalizedBackgroundMaterial = React.useMemo(
+    () => normalizeBackgroundMaterialProp(backgroundMaterial),
+    [backgroundMaterial],
+  )
 
   // Create the attachment when the parent entity is ready
   useEffect(() => {
@@ -53,6 +96,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
           scale,
           width,
           height,
+          cornerRadius: normalizedCornerRadius,
+          backgroundMaterial: normalizedBackgroundMaterial,
           ownerViewId: ctx.reality.id,
         })
         if (cancelled) {
@@ -136,10 +181,19 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
 
   useSyncHeadStyles(childWindow)
 
-  // Update transform and meter dimensions when they change
+  // Update transform, meter dimensions, and surface styling when they change.
+  // These are in-place updates — the native WebView is never recreated.
   useEffect(() => {
     if (!attachmentRef.current) return
-    attachmentRef.current.update({ position, rotation, scale, width, height })
+    attachmentRef.current.update({
+      position,
+      rotation,
+      scale,
+      width,
+      height,
+      cornerRadius: normalizedCornerRadius,
+      backgroundMaterial: normalizedBackgroundMaterial,
+    })
   }, [
     position?.x,
     position?.y,
@@ -152,6 +206,8 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
     scale?.z,
     width,
     height,
+    normalizedCornerRadius,
+    normalizedBackgroundMaterial,
   ])
 
   return null

--- a/packages/react/src/reality/components/AttachmentEntity.tsx
+++ b/packages/react/src/reality/components/AttachmentEntity.tsx
@@ -8,37 +8,9 @@ import { useSyncHeadStyles } from '../../utils/useSyncHeadStyles'
 
 let instanceCounter = 0
 
-const ATTACHMENT_BACKGROUND_MATERIALS = new Set<string>([
-  'none',
-  'transparent',
-  'translucent',
-  'thin',
-  'regular',
-  'thick',
-])
-
 function normalizeCornerRadiusProp(value: number | undefined) {
   if (value === undefined) return undefined
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0
-    ? value
-    : 0
-}
-
-function normalizeBackgroundMaterialProp(
-  value: BackgroundMaterialType | undefined,
-): BackgroundMaterialType | undefined {
-  if (value === undefined) return undefined
-  if (typeof value === 'string' && ATTACHMENT_BACKGROUND_MATERIALS.has(value)) {
-    return value
-  }
-  if (typeof process === 'undefined' || process.env.NODE_ENV !== 'production') {
-    console.warn(
-      `[AttachmentEntity] Invalid backgroundMaterial "${String(value)}"; ` +
-        `falling back to "transparent". Supported values: ` +
-        `'none' | 'transparent' | 'translucent' | 'thin' | 'regular' | 'thick'.`,
-    )
-  }
-  return 'transparent'
+  return Number.isFinite(value) && value >= 0 ? value : 0
 }
 
 type AttachmentEntityProps = {
@@ -71,10 +43,6 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
   const [childWindow, setChildWindow] = useState<WindowProxy | null>(null)
 
   const normalizedCornerRadius = normalizeCornerRadiusProp(cornerRadius)
-  const normalizedBackgroundMaterial = React.useMemo(
-    () => normalizeBackgroundMaterialProp(backgroundMaterial),
-    [backgroundMaterial],
-  )
 
   // Create the attachment when the parent entity is ready
   useEffect(() => {
@@ -97,7 +65,7 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
           width,
           height,
           cornerRadius: normalizedCornerRadius,
-          backgroundMaterial: normalizedBackgroundMaterial,
+          backgroundMaterial,
           ownerViewId: ctx.reality.id,
         })
         if (cancelled) {
@@ -192,7 +160,7 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
       width,
       height,
       cornerRadius: normalizedCornerRadius,
-      backgroundMaterial: normalizedBackgroundMaterial,
+      backgroundMaterial,
     })
   }, [
     position?.x,
@@ -207,7 +175,7 @@ export const AttachmentEntity: React.FC<AttachmentEntityProps> = ({
     width,
     height,
     normalizedCornerRadius,
-    normalizedBackgroundMaterial,
+    backgroundMaterial,
   ])
 
   return null

--- a/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
+++ b/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2B1008A22F0B000800000002 /* NavigationCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */; };
 		2B1008A52F0B000800000005 /* SpatializedElementMotionTimelineSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */; };
 		2B1008A72F0B000800000007 /* SpatializedElementAnimationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */; };
+		2B1008A92F0B000800000009 /* AttachmentSurfaceNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A82F0B000800000008 /* AttachmentSurfaceNormalizationTests.swift */; };
 		2B2F1D712BEBFAAC006897EE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D702BEBFAAC006897EE /* Assets.xcassets */; };
 		2B2F1D742BEBFAAC006897EE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D732BEBFAAC006897EE /* Preview Assets.xcassets */; };
 		2B89E38C2E699104004079AA /* WebMsgCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B89E38B2E699104004079AA /* WebMsgCommand.swift */; };
@@ -42,6 +43,7 @@
 		2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCleanupTests.swift; sourceTree = "<group>"; };
 		2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatializedElementMotionTimelineSamplerTests.swift; sourceTree = "<group>"; };
 		2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatializedElementAnimationManagerTests.swift; sourceTree = "<group>"; };
+		2B1008A82F0B000800000008 /* AttachmentSurfaceNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentSurfaceNormalizationTests.swift; sourceTree = "<group>"; };
 		2B2F1D632BEBFAAA006897EE /* WebSpatial.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WebSpatial.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B2F1D672BEBFAAA006897EE /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 		2B2F1D702BEBFAAC006897EE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */,
 				2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */,
 				2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */,
+				2B1008A82F0B000800000008 /* AttachmentSurfaceNormalizationTests.swift */,
 			);
 			path = "web-spatialTests";
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				2B1008A22F0B000800000002 /* NavigationCleanupTests.swift in Sources */,
 				2B1008A52F0B000800000005 /* SpatializedElementMotionTimelineSamplerTests.swift in Sources */,
 				2B1008A72F0B000800000007 /* SpatializedElementAnimationManagerTests.swift in Sources */,
+				2B1008A92F0B000800000009 /* AttachmentSurfaceNormalizationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/visionOS/web-spatial/JSBCommand.swift
+++ b/packages/visionOS/web-spatial/JSBCommand.swift
@@ -424,6 +424,8 @@ struct InitializeAttachmentCommand: CommandDataProtocol {
     let width: Double?
     let height: Double?
     let ownerViewId: String
+    let cornerRadius: CornerRadius?
+    let backgroundMaterial: BackgroundMaterial?
 }
 
 struct UpdateAttachmentEntityCommand: CommandDataProtocol {
@@ -434,4 +436,6 @@ struct UpdateAttachmentEntityCommand: CommandDataProtocol {
     let scale: JSBVec3?
     let width: Double?
     let height: Double?
+    let cornerRadius: CornerRadius?
+    let backgroundMaterial: BackgroundMaterial?
 }

--- a/packages/visionOS/web-spatial/manager/AttachmentManager.swift
+++ b/packages/visionOS/web-spatial/manager/AttachmentManager.swift
@@ -8,10 +8,35 @@ struct AttachmentInfo: Identifiable, Equatable {
     var rotation: SIMD3<Float>
     var scale: SIMD3<Float>
     var frameSize: CGSize
+    var cornerRadius: CornerRadius
+    var backgroundMaterial: BackgroundMaterial
     var webViewModel: SpatialWebViewModel
 
     static func == (lhs: AttachmentInfo, rhs: AttachmentInfo) -> Bool {
         lhs.id == rhs.id
+    }
+
+    /// Missing corner radii fall back to 0; individual invalid values
+    /// (negative or non-finite) are clamped to 0.
+    static func clampedCornerRadius(_ value: CornerRadius?) -> CornerRadius {
+        guard let value else { return CornerRadius() }
+        return CornerRadius(
+            topLeading: clampRadiusValue(value.topLeading),
+            bottomLeading: clampRadiusValue(value.bottomLeading),
+            topTrailing: clampRadiusValue(value.topTrailing),
+            bottomTrailing: clampRadiusValue(value.bottomTrailing)
+        )
+    }
+
+    static func clampRadiusValue(_ value: CGFloat) -> CGFloat {
+        value.isFinite && value >= 0 ? value : 0
+    }
+
+    /// Missing materials fall back to transparent. Invalid raw values decode
+    /// to `.None`, which renders with the same transparent surface behavior
+    /// as `.Transparent` (mirroring Ornament's material handling).
+    static func effectiveBackgroundMaterial(_ value: BackgroundMaterial?) -> BackgroundMaterial {
+        value ?? .Transparent
     }
 }
 
@@ -34,6 +59,8 @@ class AttachmentManager {
         rotation: SIMD3<Float>,
         scale: SIMD3<Float>,
         frameSize: CGSize,
+        cornerRadius: CornerRadius = CornerRadius(),
+        backgroundMaterial: BackgroundMaterial = .Transparent,
         webViewModel: SpatialWebViewModel
     ) -> AttachmentInfo {
         webViewModel.setBackgroundTransparent(true)
@@ -46,6 +73,8 @@ class AttachmentManager {
             rotation: rotation,
             scale: scale,
             frameSize: frameSize,
+            cornerRadius: cornerRadius,
+            backgroundMaterial: backgroundMaterial,
             webViewModel: webViewModel
         )
         attachments[id] = info
@@ -57,7 +86,9 @@ class AttachmentManager {
         position: SIMD3<Float>?,
         rotation: SIMD3<Float>?,
         scale: SIMD3<Float>?,
-        frameSize: CGSize?
+        frameSize: CGSize?,
+        cornerRadius: CornerRadius? = nil,
+        backgroundMaterial: BackgroundMaterial? = nil
     ) {
         guard var info = attachments[id] else { return }
 
@@ -72,6 +103,12 @@ class AttachmentManager {
         }
         if let frameSize = frameSize {
             info.frameSize = frameSize
+        }
+        if let cornerRadius = cornerRadius {
+            info.cornerRadius = cornerRadius
+        }
+        if let backgroundMaterial = backgroundMaterial {
+            info.backgroundMaterial = backgroundMaterial
         }
 
         attachments[id] = info

--- a/packages/visionOS/web-spatial/manager/AttachmentManager.swift
+++ b/packages/visionOS/web-spatial/manager/AttachmentManager.swift
@@ -16,8 +16,6 @@ struct AttachmentInfo: Identifiable, Equatable {
         lhs.id == rhs.id
     }
 
-    /// Missing corner radii fall back to 0; individual invalid values
-    /// (negative or non-finite) are clamped to 0.
     static func clampedCornerRadius(_ value: CornerRadius?) -> CornerRadius {
         guard let value else { return CornerRadius() }
         return CornerRadius(
@@ -32,9 +30,6 @@ struct AttachmentInfo: Identifiable, Equatable {
         value.isFinite && value >= 0 ? value : 0
     }
 
-    /// Missing materials fall back to transparent. Invalid raw values decode
-    /// to `.None`, which renders with the same transparent surface behavior
-    /// as `.Transparent` (mirroring Ornament's material handling).
     static func effectiveBackgroundMaterial(_ value: BackgroundMaterial?) -> BackgroundMaterial {
         value ?? .Transparent
     }

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -499,6 +499,8 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             rotation: rotation,
             scale: scale,
             frameSize: frameSize,
+            cornerRadius: AttachmentInfo.clampedCornerRadius(command.cornerRadius),
+            backgroundMaterial: AttachmentInfo.effectiveBackgroundMaterial(command.backgroundMaterial),
             webViewModel: webViewModel
         )
 
@@ -1387,7 +1389,9 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
             position: newPosition,
             rotation: newRotation,
             scale: newScale,
-            frameSize: newFrameSize
+            frameSize: newFrameSize,
+            cornerRadius: command.cornerRadius.map { AttachmentInfo.clampedCornerRadius($0) },
+            backgroundMaterial: command.backgroundMaterial
         )
         resolve(.success(baseReplyData))
     }

--- a/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedDynamic3DView.swift
@@ -173,6 +173,11 @@ struct SpatializedDynamic3DView: View {
             ForEach(Array(spatialScene.attachmentManager.attachments.values)) { info in
                 Attachment(id: info.id) {
                     info.webViewModel.getView()
+                        .materialWithBorderCorner(
+                            info.backgroundMaterial,
+                            info.cornerRadius,
+                            spatialScene.windowStyle
+                        )
                         .frame(
                             width: info.frameSize.width,
                             height: info.frameSize.height

--- a/packages/visionOS/web-spatialTests/AttachmentSurfaceNormalizationTests.swift
+++ b/packages/visionOS/web-spatialTests/AttachmentSurfaceNormalizationTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import WebSpatial
+import XCTest
+
+final class AttachmentSurfaceNormalizationTests: XCTestCase {
+    /// A missing corner radius payload falls back to 0 for all four corners.
+    func test_missingCornerRadiusFallsBackToZero() {
+        let radius = AttachmentInfo.clampedCornerRadius(nil)
+        XCTAssertEqual(radius, CornerRadius())
+    }
+
+    /// Valid radii pass through unchanged.
+    func test_validCornerRadiusIsPreserved() {
+        let radius = AttachmentInfo.clampedCornerRadius(
+            CornerRadius(topLeading: 12, bottomLeading: 12, topTrailing: 12, bottomTrailing: 12)
+        )
+        XCTAssertEqual(radius.topLeading, 12)
+        XCTAssertEqual(radius.bottomLeading, 12)
+        XCTAssertEqual(radius.topTrailing, 12)
+        XCTAssertEqual(radius.bottomTrailing, 12)
+    }
+
+    /// Negative and non-finite radii clamp to 0 without touching valid corners.
+    func test_invalidCornerRadiusValuesClampToZero() {
+        let radius = AttachmentInfo.clampedCornerRadius(
+            CornerRadius(
+                topLeading: -8,
+                bottomLeading: .nan,
+                topTrailing: .infinity,
+                bottomTrailing: 24
+            )
+        )
+        XCTAssertEqual(radius.topLeading, 0)
+        XCTAssertEqual(radius.bottomLeading, 0)
+        XCTAssertEqual(radius.topTrailing, 0)
+        XCTAssertEqual(radius.bottomTrailing, 24)
+    }
+
+    /// A missing material falls back to transparent surface behavior.
+    func test_missingBackgroundMaterialFallsBackToTransparent() {
+        XCTAssertEqual(AttachmentInfo.effectiveBackgroundMaterial(nil), .Transparent)
+    }
+
+    /// A provided material passes through unchanged.
+    func test_providedBackgroundMaterialIsPreserved() {
+        XCTAssertEqual(AttachmentInfo.effectiveBackgroundMaterial(.GlassMaterial), .GlassMaterial)
+    }
+
+    /// Unknown raw material strings decode to .None, which shares the
+    /// transparent (clip-only) rendering branch of the surface modifier.
+    func test_unknownMaterialStringDecodesToNone() throws {
+        let decoded = try JSONDecoder().decode(BackgroundMaterial.self, from: Data("\"frosted\"".utf8))
+        XCTAssertEqual(decoded, .None)
+    }
+
+    /// Documented material strings decode to their matching cases.
+    func test_documentedMaterialStringsDecode() throws {
+        let pairs: [(String, BackgroundMaterial)] = [
+            ("none", .None),
+            ("transparent", .Transparent),
+            ("translucent", .GlassMaterial),
+            ("thin", .ThinMaterial),
+            ("regular", .RegularMaterial),
+            ("thick", .ThickMaterial),
+        ]
+        for (raw, expected) in pairs {
+            let decoded = try JSONDecoder().decode(BackgroundMaterial.self, from: Data("\"\(raw)\"".utf8))
+            XCTAssertEqual(decoded, expected, "Material \(raw) decoded unexpectedly")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for WebSpatial Attachment `cornerRadius` and `backgroundMaterial`.

## Changes

* Parse both properties from Attachment initialize and update JSB commands.
* Store the properties in the spatial scene Attachment model.
* Apply corner radius and background material during Attachment creation and updates.
* Update the WebCore dependency required by the new Attachment API.
* Preserve existing Attachment behavior when the properties are omitted.

## Root cause

Attachment commands and runtime models did not propagate corner radius or background material to native rendering.

