### PR TITLE
feat(react): add WebSpatial inspector

### DIFF
--- a/.changeset/webspatial-inspector.md
+++ b/.changeset/webspatial-inspector.md
@@ -1,0 +1,22 @@
+---
+'@webspatial/react-sdk': minor
+'@webspatial/core-sdk': patch
+'@webspatial/platform-visionos': patch
+'web-content': patch
+---
+
+Add an experimental Ornament-based `WebSpatialInspector` for viewing native
+scene nodes, inspecting node state, highlighting DOM-backed placeholders, and
+editing supported placeholder layout properties.
+
+The inspector refreshes on WebSpatial tree-structure events and manual Refresh
+actions instead of polling continuously, ignores layout/property sync commands,
+sorts the displayed node tree with a stable order, and only displays nodes that
+are mounted in the page scene tree.
+
+Include Reality entity transforms in visionOS inspect payloads, and keep the
+Reality root inspect hierarchy synchronized when entities are added, removed,
+or reparented.
+
+Add a test-server page that exercises SpatialDiv, Model, Reality, and the
+Inspector edit/highlight workflow.

--- a/apps/test-server/index.tsx
+++ b/apps/test-server/index.tsx
@@ -75,6 +75,7 @@ import SpatialContentReadyThree from './src/pages/spatial-content-ready-three/in
 import DropdownMenuTest from './src/pages/dropdown-menu-test/index'
 import RuntimeCapabilitiesPage from './src/pages/runtime-capabilities/index'
 import OrnamentTestPage from './src/pages/ornament-test/index'
+import WebSpatialInspectorPage from './src/pages/webspatial-inspector/index'
 import EntityAnimationPage from './src/pages/entity-animation/index'
 import EntityAnimationEntrancePage from './src/pages/entity-animation/entrance'
 import EntityAnimationManualTriggerPage from './src/pages/entity-animation/manual-trigger'
@@ -219,6 +220,10 @@ function App() {
                 <Route
                   path="/scene/ornament-test"
                   element={<OrnamentTestPage />}
+                />
+                <Route
+                  path="/scene/webspatial-inspector"
+                  element={<WebSpatialInspectorPage />}
                 />
                 <Route
                   path="/entity-animation"

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -85,6 +85,10 @@ export const routes = [
     children: [
       { path: '/scene', label: 'Scene Landing' },
       { path: '/scene/volume', label: 'Volume' },
+      {
+        path: '/scene/webspatial-inspector',
+        label: 'WebSpatial Inspector',
+      },
       { path: '/scene/xrapp', label: 'XR App' },
       { path: '/scene/nosdk', label: 'No SDK' },
     ],

--- a/apps/test-server/src/pages/webspatial-inspector/index.tsx
+++ b/apps/test-server/src/pages/webspatial-inspector/index.tsx
@@ -1,0 +1,130 @@
+import {
+  BoxEntity,
+  Entity,
+  Model,
+  Reality,
+  SceneGraph,
+  UnlitMaterial,
+} from '@webspatial/react-sdk'
+import { WebSpatialInspector } from '@webspatial/react-sdk/experimental'
+import { useState } from 'react'
+
+export default function WebSpatialInspectorPage() {
+  const [showInspector, setShowInspector] = useState(true)
+  const [showEntity, setShowEntity] = useState(true)
+
+  return (
+    <div className="min-h-screen bg-[#0b1014] p-10 text-slate-100">
+      <div className="mx-auto max-w-5xl space-y-8">
+        <header className="flex items-end justify-between gap-6 border-b border-slate-700 pb-6">
+          <div>
+            <div className="mb-2 font-mono text-xs uppercase tracking-[0.2em] text-cyan-300">
+              Native scene diagnostics
+            </div>
+            <h1 className="text-3xl font-semibold">WebSpatial Inspector</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
+              Open the Ornament inspector, select a native node, and verify that
+              DOM-backed SpatialDiv, Model, and Reality placeholders are
+              highlighted on this page.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              className="rounded-md border border-cyan-700 bg-cyan-950 px-4 py-2 font-mono text-xs text-cyan-200"
+              onClick={() => setShowInspector(value => !value)}
+            >
+              {showInspector ? 'Close inspector' : 'Open inspector'}
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-slate-600 bg-slate-800 px-4 py-2 font-mono text-xs text-slate-200"
+              onClick={() => setShowEntity(value => !value)}
+            >
+              {showEntity ? 'Remove entity' : 'Add entity'}
+            </button>
+          </div>
+        </header>
+
+        <section className="grid grid-cols-2 gap-6">
+          <div
+            enable-xr
+            data-name="Inspector SpatialDiv"
+            className="rounded-xl border border-cyan-700/60 bg-cyan-950/40 p-6"
+            style={{
+              width: 420,
+              minHeight: 190,
+              '--xr-depth': 36,
+              '--xr-back': 28,
+              '--xr-background-material': 'thin',
+            }}
+          >
+            <div className="font-mono text-xs uppercase tracking-widest text-cyan-300">
+              SpatialDiv
+            </div>
+            <h2 className="mt-4 text-xl font-medium">DOM-backed content</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              Inspector edits update this placeholder&apos;s CSS so the existing
+              layout synchronization remains authoritative.
+            </p>
+          </div>
+
+          <Model
+            enable-xr
+            data-name="Inspector Model"
+            src="/assets/vehicle-speedster.usdz"
+            className="rounded-xl border border-amber-700/60 bg-amber-950/30"
+            style={{
+              width: 420,
+              height: 260,
+              '--xr-depth': 120,
+              '--xr-back': 64,
+            }}
+          />
+        </section>
+
+        <Reality
+          data-name="Inspector Reality"
+          className="rounded-xl border border-slate-700 bg-slate-900"
+          style={{
+            width: 866,
+            height: 330,
+            '--xr-depth': 180,
+            '--xr-back': 90,
+          }}
+        >
+          <UnlitMaterial id="inspector-cyan" color="#58d4df" />
+          <SceneGraph>
+            {showEntity ? (
+              <Entity
+                id="inspector-parent"
+                name="Inspector parent"
+                position={{ x: -0.12, y: 0.04, z: 0 }}
+              >
+                <BoxEntity
+                  id="inspector-box"
+                  name="Inspectable box"
+                  width={0.18}
+                  height={0.12}
+                  depth={0.08}
+                  materials={['inspector-cyan']}
+                  position={{ x: 0.08, y: 0, z: 0.03 }}
+                />
+              </Entity>
+            ) : null}
+          </SceneGraph>
+        </Reality>
+      </div>
+
+      {showInspector ? (
+        <WebSpatialInspector
+          editable
+          width={760}
+          height={560}
+          attachmentAnchor="trailing"
+          contentAlignment="leading"
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -5,6 +5,7 @@ import { SpatialMaterial } from './reality/material/SpatialMaterial'
 import { SpatializedDynamic3DElement } from './SpatializedDynamic3DElement'
 import { SpatializedElement } from './SpatializedElement'
 import { SpatialObject } from './SpatialObject'
+import { emitWebSpatialInspectChange } from './inspectEvents'
 
 import {
   Spatialized2DElementProperties,
@@ -43,9 +44,22 @@ abstract class JSBCommand {
     const param = this.getParams()
     const msg = param ? JSON.stringify(param) : ''
     const platform = await getPlatform()
-    return platform.callJSB(this.commandType, msg)
+    const result = await platform.callJSB(this.commandType, msg)
+    if (result.success && INSPECT_CHANGE_COMMANDS.has(this.commandType)) {
+      emitWebSpatialInspectChange()
+    }
+    return result
   }
 }
+
+const INSPECT_CHANGE_COMMANDS = new Set([
+  'AddSpatializedElementToSpatialScene',
+  'AddSpatializedElementToSpatialized2DElement',
+  'AddOrnamentToScene',
+  'SetParentToEntity',
+  'RemoveEntityFromParent',
+  'Destroy',
+])
 
 export class UpdateEntityPropertiesCommand extends JSBCommand {
   commandType = 'UpdateEntityProperties'

--- a/packages/core/src/inspectEvents.ts
+++ b/packages/core/src/inspectEvents.ts
@@ -1,0 +1,6 @@
+const WEBSPATIAL_INSPECT_CHANGE_EVENT = 'webspatialinspectchange'
+
+export function emitWebSpatialInspectChange() {
+  if (typeof document === 'undefined') return
+  document.dispatchEvent(new Event(WEBSPATIAL_INSPECT_CHANGE_EVENT))
+}

--- a/packages/core/src/jsbcommand.coverage.test.ts
+++ b/packages/core/src/jsbcommand.coverage.test.ts
@@ -130,6 +130,70 @@ describe('JSBCommand', () => {
     )
   })
 
+  it('emits inspect-change events for structural commands only', async () => {
+    const mod = await import('./JSBCommand')
+    const {
+      InspectCommand,
+      DestroyCommand,
+      AddSpatializedElementToSpatialScene,
+      AddSpatializedElementToSpatialized2DElement,
+      AddOrnamentToSceneCommand,
+      AddComponentToEntityCommand,
+      SetParentForEntityCommand,
+      RemoveEntityFromParentCommand,
+      UpdateSpatialized2DElementProperties,
+    } = mod
+    const listener = vi.fn()
+    document.addEventListener('webspatialinspectchange', listener)
+
+    await new InspectCommand().execute()
+    expect(listener).not.toHaveBeenCalled()
+
+    await new UpdateSpatialized2DElementProperties(
+      { id: 'obj-1' } as any,
+      {
+        width: 100,
+      } as any,
+    ).execute()
+    expect(listener).not.toHaveBeenCalled()
+
+    await new AddComponentToEntityCommand(
+      { id: 'entity-1' } as any,
+      { id: 'component-1' } as any,
+    ).execute()
+    expect(listener).not.toHaveBeenCalled()
+
+    const spatialObject = { id: 'parent-1' } as any
+    const element = { id: 'element-1' } as any
+    const entity = { id: 'entity-1' } as any
+    const structuralCommands = [
+      new AddSpatializedElementToSpatialScene(element),
+      new AddSpatializedElementToSpatialized2DElement(spatialObject, element),
+      new AddOrnamentToSceneCommand('ornament-1'),
+      new SetParentForEntityCommand('entity-1', 'parent-1'),
+      new RemoveEntityFromParentCommand(entity),
+      new DestroyCommand('obj-1'),
+    ]
+
+    for (const command of structuralCommands) {
+      await command.execute()
+    }
+    expect(listener).toHaveBeenCalledTimes(structuralCommands.length)
+
+    platformSpy.callJSB.mockImplementationOnce(() =>
+      Promise.resolve({
+        success: false,
+        data: undefined,
+        errorCode: 'E_TEST',
+        errorMessage: 'failed',
+      }),
+    )
+    await new DestroyCommand('obj-2').execute()
+    expect(listener).toHaveBeenCalledTimes(structuralCommands.length)
+
+    document.removeEventListener('webspatialinspectchange', listener)
+  })
+
   it('builds element commands payloads', async () => {
     const mod = await import('./JSBCommand')
     const {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -180,6 +180,37 @@ mount after spatial readiness, such as children of `<SpatialBoot>` or a tree
 rendered after an explicit `await bootSpatial()`. Calling it before readiness
 throws `WebSpatialRuntimeError` with capability `useAnimation`.
 
+### Experimental WebSpatial Inspector
+
+`WebSpatialInspector` renders the current native scene inspect data in an
+Ornament. It includes SpatialDiv, Model, Reality entity trees, and Ornaments.
+Detached runtime objects that are not mounted in the page scene tree are not
+shown. Selecting a DOM-backed node highlights its page placeholder; native-only
+nodes remain inspectable without claiming a DOM association.
+
+```tsx
+import { SpatialBoot } from '@webspatial/react-sdk'
+import { WebSpatialInspector } from '@webspatial/react-sdk/experimental'
+
+function Root() {
+  return (
+    <SpatialBoot>
+      <App />
+      <WebSpatialInspector editable />
+    </SpatialBoot>
+  )
+}
+```
+
+The inspector runs one inspect request when it mounts, then refreshes after
+WebSpatial tree-structure commands complete or when you press Refresh. It does
+not poll continuously, and layout/property sync commands do not auto-refresh
+the panel. The inspector is read-only unless `editable` is enabled. Edit mode is
+limited to DOM-backed layout properties already supported by the normal spatial
+update path: width, height, opacity, visibility, depth, back offset, and z-index.
+Entity and Ornament state is not mutated through the inspector. Unsupported
+runtimes render no inspector because the component requires Ornament support.
+
 ### RSC, server requests, and runtime detection
 
 The default entry carries `'use client'` at the top of its emitted `dist/index.js`. Frameworks that support React Server Components treat imports from `@webspatial/react-sdk` as a **client boundary**: you can still **render** facade components from a Server Component file (they become client components), but you cannot **call** hook-style APIs from server-only modules.

--- a/packages/react/src/__tests__/experimental-entry-shape.test.ts
+++ b/packages/react/src/__tests__/experimental-entry-shape.test.ts
@@ -7,6 +7,11 @@ describe('experimental-entry public surface', () => {
       expect(ExperimentalEntry.Ornament).toBeDefined()
       expect(typeof ExperimentalEntry.Ornament).toBe('function')
     })
+
+    it('exports `WebSpatialInspector` as a defined runtime value', () => {
+      expect(ExperimentalEntry.WebSpatialInspector).toBeDefined()
+      expect(typeof ExperimentalEntry.WebSpatialInspector).toBe('function')
+    })
   })
 
   describe('Does not accidentally re-export stable entry internals', () => {

--- a/packages/react/src/experimental.ts
+++ b/packages/react/src/experimental.ts
@@ -10,6 +10,8 @@ registerReactSdkEntry('lazy')
 
 export { Ornament } from './facades/Ornament'
 export type { OrnamentProps } from './facades/Ornament'
+export { WebSpatialInspector } from './facades/WebSpatialInspector'
+export type { WebSpatialInspectorProps } from './facades/WebSpatialInspector'
 export { useAnimation } from './hooks-web/useAnimation'
 export { useEntityAnimation } from './hooks-web/useEntityAnimation'
 export type {

--- a/packages/react/src/facades/WebSpatialInspector.tsx
+++ b/packages/react/src/facades/WebSpatialInspector.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import { requireSpatialImpl } from '../runtime/bridge'
+import { useSpatialReady } from '../runtime/useSpatialReady'
+import { WebSpatialRuntime } from '../webSpatialRuntime'
+import { warnBootForgotten } from './shared/warnBootForgotten'
+import type { WebSpatialInspectorProps } from '../inspector'
+
+export type { WebSpatialInspectorProps }
+
+export function WebSpatialInspector(
+  props: WebSpatialInspectorProps,
+): React.ReactElement | null {
+  const ready = useSpatialReady()
+
+  if (!WebSpatialRuntime.supports('Ornament')) {
+    return null
+  }
+
+  if (!ready) {
+    warnBootForgotten('WebSpatialInspector')
+    return null
+  }
+
+  const RealWebSpatialInspector = requireSpatialImpl()
+    .WebSpatialInspector as ComponentType<WebSpatialInspectorProps>
+  return <RealWebSpatialInspector {...props} />
+}
+
+WebSpatialInspector.displayName = 'WebSpatialInspector'

--- a/packages/react/src/inspector/WebSpatialInspector.test.tsx
+++ b/packages/react/src/inspector/WebSpatialInspector.test.tsx
@@ -1,0 +1,247 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSpatialInspector } from './WebSpatialInspector'
+
+const mocks = vi.hoisted(() => ({
+  inspect: vi.fn(),
+}))
+
+vi.mock('../ornament', () => ({
+  Ornament: ({ children }: { children: ReactNode }) => (
+    <div data-testid="ornament">{children}</div>
+  ),
+}))
+
+vi.mock('../utils/getSession', () => ({
+  getSession: () => ({
+    getSpatialScene: () => ({
+      inspect: mocks.inspect,
+    }),
+  }),
+}))
+
+class TestResizeObserver {
+  observe() {}
+  disconnect() {}
+}
+
+function scenePayload(width = 320) {
+  return {
+    id: 'scene-1',
+    children: {
+      div: {
+        id: 'native-div-1',
+        name: 'Card',
+        type: 'Spatialized2DElement',
+        width,
+        height: 180,
+        depth: 24,
+        backOffset: 8,
+        opacity: 1,
+        visible: true,
+        zIndex: 0,
+      },
+    },
+    ornaments: {},
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(inResolve => {
+    resolve = inResolve
+  })
+  return { promise, resolve }
+}
+
+describe('WebSpatialInspector', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    mocks.inspect.mockReset()
+    mocks.inspect.mockResolvedValue(scenePayload())
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.title = ''
+    document
+      .querySelectorAll('[data-webspatial-inspector-highlight]')
+      .forEach(element => element.remove())
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the normalized native scene tree inside an Ornament', async () => {
+    render(<WebSpatialInspector />)
+
+    expect(await screen.findByText('WebSpatial Inspector')).toBeDefined()
+    expect(await screen.findByText('Card')).toBeDefined()
+    expect(document.title).toBe('WebSpatial Inspector')
+    expect(mocks.inspect).toHaveBeenCalledTimes(1)
+
+    await new Promise(resolve => window.setTimeout(resolve, 180))
+    expect(mocks.inspect).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes once when WebSpatial state changes', async () => {
+    render(<WebSpatialInspector />)
+    expect(await screen.findByText('Card')).toBeDefined()
+    expect(mocks.inspect).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(new CustomEvent('webspatialinspectchange'))
+    document.dispatchEvent(new CustomEvent('webspatialinspectchange'))
+
+    await waitFor(() => {
+      expect(mocks.inspect).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('runs a pending refresh after an in-flight inspect completes', async () => {
+    const firstInspect = deferred<ReturnType<typeof scenePayload>>()
+    mocks.inspect
+      .mockReturnValueOnce(firstInspect.promise)
+      .mockResolvedValue(scenePayload(640))
+
+    render(<WebSpatialInspector />)
+    await waitFor(() => expect(mocks.inspect).toHaveBeenCalledTimes(1))
+
+    document.dispatchEvent(new Event('webspatialinspectchange'))
+    await new Promise(resolve => window.setTimeout(resolve, 160))
+    expect(mocks.inspect).toHaveBeenCalledTimes(1)
+
+    firstInspect.resolve(scenePayload())
+    await waitFor(() => expect(mocks.inspect).toHaveBeenCalledTimes(2))
+  })
+
+  it('links a selected native node to its DOM placeholder and applies supported edits', async () => {
+    const placeholder = document.createElement('div')
+    placeholder.setAttribute('data-spatial-id', 'root_container')
+    const sync = deferred<void>()
+    const syncSpatializedElement = vi.fn(() => sync.promise)
+    Object.assign(placeholder, {
+      __innerSpatializedElement: () => ({ id: 'native-div-1' }),
+      __syncSpatializedElement: syncSpatializedElement,
+    })
+    document.body.appendChild(placeholder)
+    mocks.inspect
+      .mockResolvedValueOnce(scenePayload())
+      .mockResolvedValue(scenePayload(480))
+
+    render(<WebSpatialInspector editable />)
+    fireEvent.click(await screen.findByText('Card'))
+
+    expect(await screen.findByText('DOM placeholder linked')).toBeDefined()
+    expect(
+      document.querySelector('[data-webspatial-inspector-highlight]'),
+    ).not.toBeNull()
+
+    fireEvent.change(screen.getByLabelText('Width'), {
+      target: { value: '480' },
+    })
+    fireEvent.click(screen.getByText('Apply to page'))
+
+    expect(placeholder.style.width).toBe('480px')
+    expect(syncSpatializedElement).toHaveBeenCalledTimes(1)
+    expect(mocks.inspect).toHaveBeenCalledTimes(1)
+
+    sync.resolve()
+    await waitFor(() => expect(mocks.inspect).toHaveBeenCalledTimes(2))
+    expect(
+      (screen.getByLabelText('Width') as HTMLInputElement).valueAsNumber,
+    ).toBe(480)
+
+    placeholder.remove()
+  })
+
+  it('repositions the highlight after surrounding page layout changes', async () => {
+    const placeholder = document.createElement('div')
+    placeholder.setAttribute('data-spatial-id', 'root_container')
+    let left = 12
+    placeholder.getBoundingClientRect = () => new DOMRect(left, 20, 100, 50)
+    Object.assign(placeholder, {
+      __innerSpatializedElement: () => ({ id: 'native-div-1' }),
+    })
+    document.body.appendChild(placeholder)
+
+    render(<WebSpatialInspector />)
+    fireEvent.click(await screen.findByText('Card'))
+
+    const highlight = document.querySelector<HTMLElement>(
+      '[data-webspatial-inspector-highlight]',
+    )!
+    await waitFor(() => expect(highlight.style.left).toBe('12px'))
+
+    left = 84
+    const sibling = document.createElement('div')
+    document.body.insertBefore(sibling, placeholder)
+
+    await waitFor(() => expect(highlight.style.left).toBe('84px'))
+
+    sibling.remove()
+    placeholder.remove()
+  })
+
+  it('updates the editor draft when the selected node is refreshed', async () => {
+    const placeholder = document.createElement('div')
+    placeholder.setAttribute('data-spatial-id', 'root_container')
+    Object.assign(placeholder, {
+      __innerSpatializedElement: () => ({ id: 'native-div-1' }),
+    })
+    document.body.appendChild(placeholder)
+
+    mocks.inspect
+      .mockResolvedValueOnce(scenePayload())
+      .mockResolvedValue(scenePayload(640))
+
+    render(<WebSpatialInspector editable />)
+    fireEvent.click(await screen.findByText('Card'))
+    expect(
+      (screen.getByLabelText('Width') as HTMLInputElement).valueAsNumber,
+    ).toBe(320)
+
+    fireEvent.click(screen.getByText('Refresh'))
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText('Width') as HTMLInputElement).valueAsNumber,
+      ).toBe(640),
+    )
+
+    placeholder.remove()
+  })
+
+  it('renders selected node properties in a stable order', async () => {
+    mocks.inspect.mockResolvedValue({
+      ...scenePayload(),
+      children: {
+        div: {
+          zIndex: 3,
+          width: 320,
+          position: { z: 3, x: 1, y: 2 },
+          parent: 'scene-1',
+          id: 'native-div-1',
+          visible: true,
+          type: 'Spatialized2DElement',
+          name: 'Card',
+          height: 180,
+        },
+      },
+    })
+
+    render(<WebSpatialInspector />)
+    fireEvent.click(await screen.findByText('Card'))
+
+    const details = screen.getByLabelText('Selected node details').textContent!
+    expect(details.indexOf('id')).toBeLessThan(details.indexOf('name'))
+    expect(details.indexOf('name')).toBeLessThan(details.indexOf('type'))
+    expect(details.indexOf('type')).toBeLessThan(details.indexOf('parent'))
+    expect(details.indexOf('width')).toBeLessThan(details.indexOf('height'))
+    expect(details.indexOf('height')).toBeLessThan(details.indexOf('zIndex'))
+    expect(details).toContain('{"x":1,"y":2,"z":3}')
+  })
+})

--- a/packages/react/src/inspector/WebSpatialInspector.tsx
+++ b/packages/react/src/inspector/WebSpatialInspector.tsx
@@ -1,0 +1,1097 @@
+'use client'
+
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { OrnamentPoint3D } from '@webspatial/core-sdk'
+
+import { Ornament } from '../ornament'
+import { getSession } from '../utils/getSession'
+import {
+  applySpatialDomStylePatch,
+  findSpatialDomBinding,
+  normalizeSpatialSceneInspect,
+  type SpatialDomBinding,
+  type SpatialDomStylePatch,
+  type WebSpatialInspectorNode,
+  type WebSpatialInspectorSnapshot,
+} from './sceneGraph'
+
+const WEBSPATIAL_INSPECT_CHANGE_EVENT = 'webspatialinspectchange'
+const INSPECT_REFRESH_DEBOUNCE_MS = 120
+
+export type WebSpatialInspectorProps = {
+  editable?: boolean
+  width?: number
+  height?: number
+  attachmentAnchor?: OrnamentPoint3D
+  contentAlignment?: OrnamentPoint3D
+}
+
+type EditorDraft = Required<SpatialDomStylePatch>
+
+const palette = {
+  canvas: '#081015',
+  raised: '#12222b',
+  line: '#24404b',
+  lineStrong: '#315967',
+  text: '#e8f1f3',
+  muted: '#8ca2aa',
+  cyan: '#58d4df',
+  cyanDim: '#163b42',
+  amber: '#f6bd60',
+  amberDim: '#49391f',
+  red: '#ff7a78',
+} as const
+
+const mono =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+
+const buttonStyle: CSSProperties = {
+  border: `1px solid ${palette.lineStrong}`,
+  borderRadius: 6,
+  background: palette.raised,
+  color: palette.text,
+  fontFamily: mono,
+  fontSize: 11,
+  lineHeight: '28px',
+  minHeight: 28,
+  padding: '0 10px',
+  cursor: 'pointer',
+}
+
+function numberValue(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function booleanValue(value: unknown, fallback = true): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function editorDraftFromNode(node: WebSpatialInspectorNode): EditorDraft {
+  return {
+    width: numberValue(node.raw.width),
+    height: numberValue(node.raw.height),
+    opacity: numberValue(node.raw.opacity, 1),
+    visible: booleanValue(node.raw.visible),
+    depth: numberValue(node.raw.depth),
+    backOffset: numberValue(node.raw.backOffset),
+    zIndex: numberValue(node.raw.zIndex),
+  }
+}
+
+function findNode(
+  node: WebSpatialInspectorNode,
+  id: string | null,
+): WebSpatialInspectorNode | null {
+  if (!id) return null
+  if (node.id === id) return node
+  for (const child of node.children) {
+    const match = findNode(child, id)
+    if (match) return match
+  }
+  return null
+}
+
+function nodeGlyph(node: WebSpatialInspectorNode): string {
+  switch (node.kind) {
+    case 'scene':
+      return 'SC'
+    case 'spatial-div':
+      return '2D'
+    case 'model':
+      return '3D'
+    case 'reality':
+      return 'RV'
+    case 'entity':
+      return 'EN'
+    case 'ornament':
+      return 'OR'
+    case 'group':
+      return 'GR'
+    default:
+      return '??'
+  }
+}
+
+function compareText(left: string, right: string): number {
+  const displayOrder = left.localeCompare(right, 'en', {
+    numeric: true,
+    sensitivity: 'base',
+  })
+  return displayOrder || (left < right ? -1 : left > right ? 1 : 0)
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableValue)
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([leftKey], [rightKey]) => compareText(leftKey, rightKey))
+        .map(([key, child]) => [key, stableValue(child)]),
+    )
+  }
+  return value
+}
+
+function valuePreview(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'string') return value
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    return String(value)
+  }
+  try {
+    const serialized = JSON.stringify(stableValue(value))
+    return serialized.length > 180
+      ? `${serialized.slice(0, 177)}...`
+      : serialized
+  } catch {
+    return String(value)
+  }
+}
+
+const PROPERTY_ORDER = [
+  'id',
+  'name',
+  'type',
+  'parent',
+  'position',
+  'rotation',
+  'scale',
+  'transform',
+  'width',
+  'height',
+  'depth',
+  'clientX',
+  'clientY',
+  'backOffset',
+  'zIndex',
+  'opacity',
+  'visible',
+  'scrollWithParent',
+  'scrollPageEnabled',
+  'scrollOffset',
+  'cornerRadius',
+  'backgroundMaterial',
+  'options',
+  'modelURL',
+  'model',
+  'enableGesture',
+  'enableInteractive',
+  'enableTap',
+  'enableTapGesture',
+  'enableDrag',
+  'enableDragStartGesture',
+  'enableDragGesture',
+  'enableDragEndGesture',
+  'enableRotate',
+  'enableRotateGesture',
+  'enableRotateEndGesture',
+  'enableMagnify',
+  'enableMagnifyGesture',
+  'enableMagnifyEndGesture',
+] as const
+
+const PROPERTY_ORDER_INDEX = new Map<string, number>(
+  PROPERTY_ORDER.map((name, index) => [name, index]),
+)
+
+function comparePropertyEntries(
+  [leftKey]: [string, unknown],
+  [rightKey]: [string, unknown],
+): number {
+  const leftIndex = PROPERTY_ORDER_INDEX.get(leftKey) ?? Number.MAX_SAFE_INTEGER
+  const rightIndex =
+    PROPERTY_ORDER_INDEX.get(rightKey) ?? Number.MAX_SAFE_INTEGER
+  return leftIndex - rightIndex || compareText(leftKey, rightKey)
+}
+
+function InspectorTreeNode({
+  node,
+  depth,
+  selectedId,
+  expandedIds,
+  onToggle,
+  onSelect,
+}: {
+  node: WebSpatialInspectorNode
+  depth: number
+  selectedId: string | null
+  expandedIds: Set<string>
+  onToggle: (id: string) => void
+  onSelect: (id: string) => void
+}) {
+  const hasChildren = node.children.length > 0
+  const expanded = expandedIds.has(node.id)
+  const selected = selectedId === node.id
+
+  return (
+    <div>
+      <div
+        style={{
+          alignItems: 'center',
+          background: selected ? palette.amberDim : 'transparent',
+          borderLeft: `2px solid ${
+            selected ? palette.amber : depth > 0 ? palette.line : 'transparent'
+          }`,
+          display: 'grid',
+          gap: 6,
+          gridTemplateColumns: '18px 24px minmax(0, 1fr)',
+          marginLeft: depth * 13,
+          minHeight: 30,
+          padding: '2px 6px 2px 3px',
+        }}
+      >
+        <button
+          type="button"
+          aria-label={
+            hasChildren
+              ? `${expanded ? 'Collapse' : 'Expand'} ${node.label}`
+              : undefined
+          }
+          onClick={() => {
+            if (hasChildren) onToggle(node.id)
+          }}
+          style={{
+            border: 0,
+            background: 'transparent',
+            color: hasChildren ? palette.muted : palette.lineStrong,
+            cursor: hasChildren ? 'pointer' : 'default',
+            fontFamily: mono,
+            fontSize: 11,
+            height: 24,
+            padding: 0,
+          }}
+        >
+          {hasChildren ? (expanded ? 'v' : '>') : '-'}
+        </button>
+        <span
+          style={{
+            alignItems: 'center',
+            background: node.synthetic ? palette.raised : palette.cyanDim,
+            border: `1px solid ${
+              selected ? palette.amber : palette.lineStrong
+            }`,
+            borderRadius: 4,
+            color: selected ? palette.amber : palette.cyan,
+            display: 'inline-flex',
+            fontFamily: mono,
+            fontSize: 9,
+            height: 18,
+            justifyContent: 'center',
+          }}
+        >
+          {nodeGlyph(node)}
+        </span>
+        <button
+          type="button"
+          onClick={() => onSelect(node.id)}
+          style={{
+            border: 0,
+            background: 'transparent',
+            color: palette.text,
+            cursor: 'pointer',
+            minWidth: 0,
+            padding: '4px 0',
+            textAlign: 'left',
+          }}
+        >
+          <span
+            style={{
+              display: 'block',
+              fontSize: 12,
+              lineHeight: '14px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {node.label}
+          </span>
+          <span
+            style={{
+              color: palette.muted,
+              display: 'block',
+              fontFamily: mono,
+              fontSize: 9,
+              lineHeight: '12px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {node.type} · {node.id}
+          </span>
+        </button>
+      </div>
+      {hasChildren && expanded
+        ? node.children.map(child => (
+            <InspectorTreeNode
+              key={`${node.id}:${child.id}`}
+              node={child}
+              depth={depth + 1}
+              selectedId={selectedId}
+              expandedIds={expandedIds}
+              onToggle={onToggle}
+              onSelect={onSelect}
+            />
+          ))
+        : null}
+    </div>
+  )
+}
+
+function PropertyTable({ node }: { node: WebSpatialInspectorNode }) {
+  const entries = Object.entries(node.raw)
+    .filter(
+      ([key]) =>
+        key !== 'children' &&
+        key !== 'root' &&
+        key !== 'components' &&
+        key !== 'spatialObjectList',
+    )
+    .sort(comparePropertyEntries)
+
+  if (entries.length === 0) {
+    return (
+      <div style={{ color: palette.muted, fontSize: 11 }}>
+        This grouping node has no native properties.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${palette.line}`,
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
+      {entries.map(([key, value], index) => (
+        <div
+          key={key}
+          style={{
+            borderTop: index === 0 ? 0 : `1px solid ${palette.line}`,
+            display: 'grid',
+            gap: 8,
+            gridTemplateColumns: '110px minmax(0, 1fr)',
+            padding: '7px 8px',
+          }}
+        >
+          <span
+            style={{
+              color: palette.muted,
+              fontFamily: mono,
+              fontSize: 10,
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {key}
+          </span>
+          <span
+            title={valuePreview(value)}
+            style={{
+              color: palette.text,
+              fontFamily: mono,
+              fontSize: 10,
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {valuePreview(value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function NumberEditor({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+}: {
+  label: string
+  value: number
+  onChange: (value: number) => void
+  min?: number
+  max?: number
+  step?: number
+}) {
+  return (
+    <label style={{ display: 'grid', gap: 4 }}>
+      <span
+        style={{
+          color: palette.muted,
+          fontFamily: mono,
+          fontSize: 9,
+          textTransform: 'uppercase',
+        }}
+      >
+        {label}
+      </span>
+      <input
+        type="number"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={event => onChange(Number(event.target.value))}
+        style={{
+          background: palette.canvas,
+          border: `1px solid ${palette.lineStrong}`,
+          borderRadius: 5,
+          boxSizing: 'border-box',
+          color: palette.text,
+          fontFamily: mono,
+          fontSize: 11,
+          height: 30,
+          outline: 'none',
+          padding: '0 7px',
+          width: '100%',
+        }}
+      />
+    </label>
+  )
+}
+
+function Editor({
+  node,
+  binding,
+  refresh,
+}: {
+  node: WebSpatialInspectorNode
+  binding: SpatialDomBinding
+  refresh: () => Promise<void>
+}) {
+  const [draft, setDraft] = useState<EditorDraft>(() =>
+    editorDraftFromNode(node),
+  )
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    setDraft(editorDraftFromNode(node))
+  }, [
+    node.id,
+    node.raw.backOffset,
+    node.raw.depth,
+    node.raw.height,
+    node.raw.opacity,
+    node.raw.visible,
+    node.raw.width,
+    node.raw.zIndex,
+  ])
+
+  const update = <K extends keyof EditorDraft>(
+    key: K,
+    value: EditorDraft[K],
+  ) => {
+    setDraft(current => ({ ...current, [key]: value }))
+  }
+
+  return (
+    <section
+      style={{
+        background: palette.raised,
+        border: `1px solid ${palette.lineStrong}`,
+        borderRadius: 7,
+        padding: 10,
+      }}
+    >
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: 9,
+        }}
+      >
+        <strong style={{ fontFamily: mono, fontSize: 10 }}>
+          DOM-backed edits
+        </strong>
+        <span style={{ color: palette.muted, fontSize: 9 }}>
+          page CSS remains authoritative
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gap: 8,
+          gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+        }}
+      >
+        <NumberEditor
+          label="Width"
+          value={draft.width}
+          min={0}
+          onChange={value => update('width', value)}
+        />
+        <NumberEditor
+          label="Height"
+          value={draft.height}
+          min={0}
+          onChange={value => update('height', value)}
+        />
+        <NumberEditor
+          label="Opacity"
+          value={draft.opacity}
+          min={0}
+          max={1}
+          step={0.05}
+          onChange={value => update('opacity', value)}
+        />
+        <NumberEditor
+          label="Depth"
+          value={draft.depth}
+          onChange={value => update('depth', value)}
+        />
+        <NumberEditor
+          label="Back"
+          value={draft.backOffset}
+          onChange={value => update('backOffset', value)}
+        />
+        <NumberEditor
+          label="Z index"
+          value={draft.zIndex}
+          onChange={value => update('zIndex', value)}
+        />
+      </div>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'space-between',
+          marginTop: 9,
+        }}
+      >
+        <label
+          style={{
+            alignItems: 'center',
+            color: palette.text,
+            display: 'flex',
+            fontFamily: mono,
+            fontSize: 10,
+            gap: 6,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={draft.visible}
+            onChange={event => update('visible', event.target.checked)}
+          />
+          Visible
+        </label>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={async () => {
+            setSaving(true)
+            applySpatialDomStylePatch(binding.element, draft)
+            try {
+              if (binding.syncSpatializedElement) {
+                await binding.syncSpatializedElement()
+                await refresh()
+              }
+            } finally {
+              setSaving(false)
+            }
+          }}
+          style={{
+            ...buttonStyle,
+            background: palette.cyanDim,
+            borderColor: palette.cyan,
+            color: palette.cyan,
+            opacity: saving ? 0.6 : 1,
+          }}
+        >
+          {saving ? 'Applying...' : 'Apply to page'}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        color: palette.muted,
+        display: 'flex',
+        fontFamily: mono,
+        fontSize: 11,
+        height: '100%',
+        justifyContent: 'center',
+        padding: 24,
+        textAlign: 'center',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function createHighlightOverlay(): {
+  overlay: HTMLDivElement
+  label: HTMLDivElement
+} {
+  const overlay = document.createElement('div')
+  const label = document.createElement('div')
+  overlay.dataset.webspatialInspectorHighlight = ''
+  Object.assign(overlay.style, {
+    border: `2px solid ${palette.amber}`,
+    boxShadow: `0 0 0 1px ${palette.canvas}, 0 0 22px rgba(246, 189, 96, 0.42)`,
+    boxSizing: 'border-box',
+    pointerEvents: 'none',
+    position: 'fixed',
+    zIndex: '2147483647',
+  })
+  Object.assign(label.style, {
+    background: palette.amber,
+    borderRadius: '3px 3px 0 0',
+    bottom: '100%',
+    color: palette.canvas,
+    fontFamily: mono,
+    fontSize: '10px',
+    fontWeight: '700',
+    left: '-2px',
+    lineHeight: '20px',
+    maxWidth: '320px',
+    overflow: 'hidden',
+    padding: '0 6px',
+    position: 'absolute',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  })
+  overlay.appendChild(label)
+  return { overlay, label }
+}
+
+export function WebSpatialInspector({
+  editable = false,
+  width = 760,
+  height = 560,
+  attachmentAnchor = 'trailing',
+  contentAlignment = 'leading',
+}: WebSpatialInspectorProps): React.ReactElement {
+  const [snapshot, setSnapshot] = useState<WebSpatialInspectorSnapshot | null>(
+    null,
+  )
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [error, setError] = useState<string | null>(null)
+  const [binding, setBinding] = useState<SpatialDomBinding | null>(null)
+  const requestInFlightRef = useRef(false)
+  const refreshPendingRef = useRef(false)
+  const mountedRef = useRef(true)
+  const refreshTimerRef = useRef<number>()
+  const inspectorRootRef = useCallback((element: HTMLDivElement | null) => {
+    if (element) {
+      element.ownerDocument.title = 'WebSpatial Inspector'
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (refreshTimerRef.current !== undefined) {
+        window.clearTimeout(refreshTimerRef.current)
+      }
+    }
+  }, [])
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (requestInFlightRef.current) {
+      refreshPendingRef.current = true
+      return
+    }
+    requestInFlightRef.current = true
+    try {
+      do {
+        refreshPendingRef.current = false
+        try {
+          const scene = getSession()?.getSpatialScene()
+          if (!scene) {
+            throw new Error('No active WebSpatial session')
+          }
+          const next = normalizeSpatialSceneInspect(await scene.inspect())
+          if (!mountedRef.current) break
+          setSnapshot(next)
+          setError(null)
+          setExpandedIds(current => {
+            if (current.size > 0) return current
+            return new Set([
+              next.root.id,
+              ...next.root.children.map(child => child.id),
+            ])
+          })
+          setSelectedId(current =>
+            current && findNode(next.root, current) ? current : next.root.id,
+          )
+        } catch (cause) {
+          if (mountedRef.current) {
+            setError(cause instanceof Error ? cause.message : String(cause))
+          }
+        }
+      } while (mountedRef.current && refreshPendingRef.current)
+    } finally {
+      requestInFlightRef.current = false
+    }
+  }, [])
+
+  const scheduleRefresh = useCallback(() => {
+    if (refreshTimerRef.current !== undefined) {
+      window.clearTimeout(refreshTimerRef.current)
+    }
+    refreshTimerRef.current = window.setTimeout(() => {
+      refreshTimerRef.current = undefined
+      void refresh()
+    }, INSPECT_REFRESH_DEBOUNCE_MS)
+  }, [refresh])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    document.addEventListener(WEBSPATIAL_INSPECT_CHANGE_EVENT, scheduleRefresh)
+    return () => {
+      document.removeEventListener(
+        WEBSPATIAL_INSPECT_CHANGE_EVENT,
+        scheduleRefresh,
+      )
+    }
+  }, [scheduleRefresh])
+
+  const selectedNode = useMemo(
+    () => (snapshot ? findNode(snapshot.root, selectedId) : null),
+    [selectedId, snapshot],
+  )
+
+  useEffect(() => {
+    if (!selectedNode?.canHaveDomHost) {
+      setBinding(null)
+      return
+    }
+    setBinding(findSpatialDomBinding(selectedNode.id))
+  }, [selectedNode])
+
+  useEffect(() => {
+    if (!selectedNode || !binding) return
+    const { overlay, label } = createHighlightOverlay()
+    label.textContent = `${selectedNode.label} · ${selectedNode.id}`
+    document.body.appendChild(overlay)
+
+    let animationFrame = 0
+    const update = () => {
+      if (!binding.element.isConnected) {
+        overlay.style.display = 'none'
+      } else {
+        const rect = binding.element.getBoundingClientRect()
+        overlay.style.display = 'block'
+        overlay.style.left = `${rect.left}px`
+        overlay.style.top = `${rect.top}px`
+        overlay.style.width = `${Math.max(rect.width, 2)}px`
+        overlay.style.height = `${Math.max(rect.height, 2)}px`
+      }
+    }
+    const scheduleUpdate = () => {
+      window.cancelAnimationFrame(animationFrame)
+      animationFrame = window.requestAnimationFrame(update)
+    }
+    const resizeObserver = new ResizeObserver(scheduleUpdate)
+    resizeObserver.observe(binding.element)
+    const mutationObserver = new MutationObserver(mutations => {
+      if (mutations.some(mutation => !overlay.contains(mutation.target))) {
+        scheduleUpdate()
+      }
+    })
+    mutationObserver.observe(binding.element.ownerDocument.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+      characterData: true,
+      childList: true,
+      subtree: true,
+    })
+    window.addEventListener('resize', scheduleUpdate)
+    window.addEventListener('scroll', scheduleUpdate, true)
+    scheduleUpdate()
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame)
+      resizeObserver.disconnect()
+      mutationObserver.disconnect()
+      window.removeEventListener('resize', scheduleUpdate)
+      window.removeEventListener('scroll', scheduleUpdate, true)
+      overlay.remove()
+    }
+  }, [binding, selectedNode])
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds(current => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  return (
+    <Ornament
+      attachmentAnchor={attachmentAnchor}
+      contentAlignment={contentAlignment}
+      width={width}
+      height={height}
+      cornerRadius={{
+        topLeading: 12,
+        bottomLeading: 12,
+        topTrailing: 12,
+        bottomTrailing: 12,
+      }}
+      style={{
+        '--xr-background-material': 'thin',
+        background: palette.canvas,
+        color: palette.text,
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
+      <div
+        ref={inspectorRootRef}
+        style={{
+          background: palette.canvas,
+          boxSizing: 'border-box',
+          color: palette.text,
+          display: 'grid',
+          gridTemplateRows: '48px minmax(0, 1fr) 26px',
+          height: '100vh',
+          overflow: 'hidden',
+          width: '100vw',
+        }}
+      >
+        <header
+          style={{
+            alignItems: 'center',
+            borderBottom: `1px solid ${palette.line}`,
+            display: 'flex',
+            gap: 12,
+            justifyContent: 'space-between',
+            padding: '0 12px',
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            <div
+              style={{
+                alignItems: 'baseline',
+                display: 'flex',
+                gap: 8,
+              }}
+            >
+              <strong
+                style={{
+                  fontSize: 13,
+                  letterSpacing: '0.04em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                WebSpatial Inspector
+              </strong>
+              <span
+                style={{
+                  color: palette.cyan,
+                  fontFamily: mono,
+                  fontSize: 9,
+                }}
+              >
+                native
+              </span>
+            </div>
+            <div
+              style={{
+                color: palette.muted,
+                fontFamily: mono,
+                fontSize: 9,
+                marginTop: 2,
+              }}
+            >
+              {snapshot
+                ? `${snapshot.nodeCount} nodes · ${new Date(
+                    snapshot.capturedAt,
+                  ).toLocaleTimeString()}`
+                : 'Waiting for scene snapshot'}
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              style={buttonStyle}
+            >
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        <main
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(250px, 0.9fr) minmax(300px, 1.1fr)',
+            minHeight: 0,
+          }}
+        >
+          <section
+            aria-label="WebSpatial node tree"
+            style={{
+              borderRight: `1px solid ${palette.line}`,
+              minHeight: 0,
+              overflow: 'auto',
+              padding: '8px 7px 16px',
+            }}
+          >
+            {snapshot ? (
+              <InspectorTreeNode
+                node={snapshot.root}
+                depth={0}
+                selectedId={selectedId}
+                expandedIds={expandedIds}
+                onToggle={toggleExpanded}
+                onSelect={setSelectedId}
+              />
+            ) : (
+              <EmptyState>{error ?? 'Inspecting native scene...'}</EmptyState>
+            )}
+          </section>
+
+          <section
+            aria-label="Selected node details"
+            style={{
+              minHeight: 0,
+              overflow: 'auto',
+              padding: 12,
+            }}
+          >
+            {selectedNode ? (
+              <div style={{ display: 'grid', gap: 10 }}>
+                <div>
+                  <div
+                    style={{
+                      alignItems: 'center',
+                      display: 'flex',
+                      gap: 8,
+                    }}
+                  >
+                    <span
+                      style={{
+                        background: palette.cyanDim,
+                        border: `1px solid ${palette.lineStrong}`,
+                        borderRadius: 4,
+                        color: palette.cyan,
+                        fontFamily: mono,
+                        fontSize: 9,
+                        padding: '3px 5px',
+                      }}
+                    >
+                      {nodeGlyph(selectedNode)}
+                    </span>
+                    <strong style={{ fontSize: 16 }}>
+                      {selectedNode.label}
+                    </strong>
+                  </div>
+                  <div
+                    style={{
+                      color: palette.muted,
+                      fontFamily: mono,
+                      fontSize: 9,
+                      marginTop: 5,
+                      overflowWrap: 'anywhere',
+                    }}
+                  >
+                    {selectedNode.type} · {selectedNode.id}
+                  </div>
+                </div>
+
+                <div
+                  style={{
+                    alignItems: 'center',
+                    background: binding ? palette.cyanDim : palette.raised,
+                    border: `1px solid ${
+                      binding ? palette.cyan : palette.line
+                    }`,
+                    borderRadius: 6,
+                    color: binding ? palette.cyan : palette.muted,
+                    display: 'flex',
+                    fontFamily: mono,
+                    fontSize: 10,
+                    justifyContent: 'space-between',
+                    padding: '7px 9px',
+                  }}
+                >
+                  <span>
+                    {binding
+                      ? 'DOM placeholder linked'
+                      : selectedNode.canHaveDomHost
+                        ? 'DOM placeholder not available'
+                        : 'Native-only node'}
+                  </span>
+                  <span>{binding ? 'highlighting page' : 'no highlight'}</span>
+                </div>
+
+                {editable && binding ? (
+                  <Editor
+                    node={selectedNode}
+                    binding={binding}
+                    refresh={refresh}
+                  />
+                ) : null}
+
+                <PropertyTable node={selectedNode} />
+              </div>
+            ) : (
+              <EmptyState>
+                Select a node to inspect its native state.
+              </EmptyState>
+            )}
+          </section>
+        </main>
+
+        <footer
+          style={{
+            alignItems: 'center',
+            borderTop: `1px solid ${palette.line}`,
+            color: error ? palette.red : palette.muted,
+            display: 'flex',
+            fontFamily: mono,
+            fontSize: 9,
+            justifyContent: 'space-between',
+            padding: '0 10px',
+          }}
+        >
+          <span>
+            {error
+              ? `Inspect failed: ${error}`
+              : 'Updates when the mounted tree changes'}
+          </span>
+          <span>{editable ? 'Edit mode' : 'Read only'}</span>
+        </footer>
+      </div>
+    </Ornament>
+  )
+}

--- a/packages/react/src/inspector/index.ts
+++ b/packages/react/src/inspector/index.ts
@@ -1,0 +1,2 @@
+export { WebSpatialInspector } from './WebSpatialInspector'
+export type { WebSpatialInspectorProps } from './WebSpatialInspector'

--- a/packages/react/src/inspector/sceneGraph.test.ts
+++ b/packages/react/src/inspector/sceneGraph.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applySpatialDomStylePatch,
+  findSpatialDomBinding,
+  normalizeSpatialSceneInspect,
+} from './sceneGraph'
+
+describe('normalizeSpatialSceneInspect', () => {
+  it('builds one tree from mounted spatial children, Reality entities, and ornaments', () => {
+    const snapshot = normalizeSpatialSceneInspect({
+      id: 'scene-1',
+      children: {
+        div: {
+          id: 'div-1',
+          name: 'Card',
+          type: 'Spatialized2DElement',
+          children: {
+            model: {
+              id: 'model-1',
+              type: 'SpatializedStatic3DElement',
+              modelURL: '/car.usdz',
+            },
+          },
+        },
+        reality: {
+          id: 'reality-1',
+          type: 'SpatializedDynamic3DElement',
+          root: {
+            id: 'root-1',
+            children: {
+              entity: {
+                id: 'entity-1',
+                name: 'Vehicle',
+                type: 'SpatialModelEntity',
+                position: { x: 1, y: 2, z: 3 },
+              },
+            },
+          },
+        },
+      },
+      ornaments: {
+        ornament: {
+          id: 'ornament-1',
+          type: 'Ornament',
+          options: { width: 620, height: 520 },
+        },
+      },
+      spatialObjectList: [
+        { id: 'div-1', type: 'Spatialized2DElement' },
+        { id: 'asset-1', type: 'SpatialModelResource' },
+      ],
+    })
+
+    expect(snapshot.root.children.map(node => node.kind)).toEqual([
+      'spatial-div',
+      'reality',
+      'group',
+    ])
+    expect(snapshot.root.children[0].children[0]).toMatchObject({
+      id: 'model-1',
+      kind: 'model',
+      canHaveDomHost: true,
+    })
+    expect(snapshot.root.children[1].children[0].children[0]).toMatchObject({
+      id: 'entity-1',
+      label: 'Vehicle',
+      type: 'SpatialModelEntity',
+    })
+    expect(snapshot.root.children[2].children[0]).toMatchObject({
+      id: 'ornament-1',
+      kind: 'ornament',
+    })
+    expect(snapshot.root.children.map(node => node.id)).not.toContain('asset-1')
+    expect(snapshot.nodeCount).toBe(7)
+  })
+
+  it('accepts Android-style entity child arrays', () => {
+    const snapshot = normalizeSpatialSceneInspect({
+      children: {
+        reality: {
+          id: 'reality-1',
+          type: 'SpatializedDynamic3DElement',
+          root: {
+            id: 'root-1',
+            children: [{ id: 'entity-1', name: 'Box' }],
+          },
+        },
+      },
+    })
+
+    expect(snapshot.root.children[0].children[0].children[0]).toMatchObject({
+      id: 'entity-1',
+      label: 'Box',
+      kind: 'entity',
+    })
+  })
+
+  it('sorts native dictionaries into a stable tree order', () => {
+    const snapshot = normalizeSpatialSceneInspect({
+      id: 'scene-1',
+      children: {
+        zReality: {
+          id: 'z-reality',
+          type: 'SpatializedDynamic3DElement',
+          root: {
+            id: 'root',
+            children: {
+              z: { id: 'z-entity', name: 'zeta' },
+              a: { id: 'a-entity', name: 'alpha' },
+            },
+          },
+        },
+        aModel: {
+          id: 'a-model',
+          type: 'SpatializedStatic3DElement',
+        },
+        bDiv: {
+          id: 'b-div',
+          name: 'Beta Div',
+          type: 'Spatialized2DElement',
+        },
+        aDiv: {
+          id: 'a-div',
+          name: 'Alpha Div',
+          type: 'Spatialized2DElement',
+        },
+        upperCaseId: {
+          id: 'A',
+          name: 'Same',
+          type: 'Spatialized2DElement',
+        },
+        lowerCaseId: {
+          id: 'a',
+          name: 'Same',
+          type: 'Spatialized2DElement',
+        },
+      },
+      ornaments: {
+        z: { id: 'z-ornament', type: 'Ornament' },
+        a: { id: 'a-ornament', type: 'Ornament' },
+      },
+      spatialObjectList: [
+        { id: 'z-resource', type: 'Texture' },
+        { id: 'a-resource', type: 'Geometry' },
+      ],
+    })
+
+    expect(snapshot.root.children.map(node => node.id)).toEqual([
+      'a-div',
+      'b-div',
+      'A',
+      'a',
+      'a-model',
+      'z-reality',
+      'scene-1:ornaments',
+    ])
+    expect(
+      snapshot.root.children
+        .find(node => node.id === 'z-reality')
+        ?.children[0].children.map(node => node.id),
+    ).toEqual(['a-entity', 'z-entity'])
+    expect(
+      snapshot.root.children
+        .find(node => node.id === 'scene-1:ornaments')
+        ?.children.map(node => node.id),
+    ).toEqual(['a-ornament', 'z-ornament'])
+    expect(snapshot.root.children.map(node => node.id)).not.toContain(
+      'scene-1:resources',
+    )
+  })
+})
+
+describe('spatial DOM bindings', () => {
+  it('matches a native id through the placeholder runtime handle', () => {
+    const element = document.createElement('div')
+    element.setAttribute('data-spatial-id', 'root_container')
+    const syncSpatializedElement = async () => {}
+    Object.assign(element, {
+      __innerSpatializedElement: () => ({ id: 'native-1' }),
+      __syncSpatializedElement: syncSpatializedElement,
+    })
+    document.body.appendChild(element)
+
+    expect(findSpatialDomBinding('native-1')?.element).toBe(element)
+    expect(findSpatialDomBinding('native-1')?.syncSpatializedElement).toBe(
+      syncSpatializedElement,
+    )
+    expect(findSpatialDomBinding('root_container')).toBeNull()
+
+    element.remove()
+  })
+
+  it('applies only the supported DOM-backed edit fields', () => {
+    const element = document.createElement('div')
+    applySpatialDomStylePatch(element, {
+      width: 320,
+      height: 180,
+      opacity: 2,
+      visible: false,
+      depth: 64,
+      backOffset: 12,
+      zIndex: 3,
+    })
+
+    expect(element.style.width).toBe('320px')
+    expect(element.style.height).toBe('180px')
+    expect(element.style.opacity).toBe('1')
+    expect(element.style.visibility).toBe('hidden')
+    expect(element.style.getPropertyValue('--xr-depth')).toBe('64')
+    expect(element.style.getPropertyValue('--xr-back')).toBe('12')
+    expect(element.style.getPropertyValue('--xr-z-index')).toBe('3')
+  })
+})

--- a/packages/react/src/inspector/sceneGraph.ts
+++ b/packages/react/src/inspector/sceneGraph.ts
@@ -1,0 +1,338 @@
+import type { SpatializedElement } from '@webspatial/core-sdk'
+
+type InspectRecord = Record<string, unknown>
+
+export type WebSpatialInspectorNodeKind =
+  | 'scene'
+  | 'spatial-div'
+  | 'model'
+  | 'reality'
+  | 'entity'
+  | 'ornament'
+  | 'group'
+  | 'unknown'
+
+export type WebSpatialInspectorNode = {
+  id: string
+  label: string
+  type: string
+  kind: WebSpatialInspectorNodeKind
+  raw: InspectRecord
+  children: WebSpatialInspectorNode[]
+  canHaveDomHost: boolean
+  synthetic?: boolean
+}
+
+export type WebSpatialInspectorSnapshot = {
+  capturedAt: number
+  root: WebSpatialInspectorNode
+  nodeCount: number
+}
+
+export type SpatialDomBinding = {
+  element: HTMLElement
+  syncSpatializedElement?: () => Promise<void>
+}
+
+export type SpatialDomStylePatch = Partial<{
+  width: number
+  height: number
+  opacity: number
+  visible: boolean
+  depth: number
+  backOffset: number
+  zIndex: number
+}>
+
+type SpatialDomElement = HTMLElement & {
+  __spatializedElement?: SpatializedElement
+  __innerSpatializedElement?: () => SpatializedElement | undefined
+  __syncSpatializedElement?: () => Promise<void>
+}
+
+function isRecord(value: unknown): value is InspectRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asRecord(value: unknown): InspectRecord {
+  return isRecord(value) ? value : {}
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function collectionEntries(
+  value: unknown,
+): Array<[fallbackId: string, value: InspectRecord]> {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) =>
+      isRecord(item) ? [[String(index), item]] : [],
+    )
+  }
+  if (!isRecord(value)) return []
+  return Object.entries(value).flatMap(([key, item]) =>
+    isRecord(item) ? [[key, item]] : [],
+  )
+}
+
+function nodeId(raw: InspectRecord, fallbackId: string): string {
+  return asString(raw.id) ?? fallbackId
+}
+
+function nativeType(raw: InspectRecord, fallback: string): string {
+  return asString(raw.type) ?? fallback
+}
+
+const NODE_KIND_ORDER: Record<WebSpatialInspectorNodeKind, number> = {
+  scene: 0,
+  'spatial-div': 10,
+  model: 20,
+  reality: 30,
+  entity: 40,
+  ornament: 60,
+  group: 70,
+  unknown: 90,
+}
+
+function compareText(left: string, right: string): number {
+  const displayOrder = left.localeCompare(right, 'en', {
+    numeric: true,
+    sensitivity: 'base',
+  })
+  return displayOrder || (left < right ? -1 : left > right ? 1 : 0)
+}
+
+function compareNodes(
+  left: WebSpatialInspectorNode,
+  right: WebSpatialInspectorNode,
+): number {
+  return (
+    NODE_KIND_ORDER[left.kind] - NODE_KIND_ORDER[right.kind] ||
+    compareText(left.label, right.label) ||
+    compareText(left.type, right.type) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function sortNodeTree(node: WebSpatialInspectorNode): WebSpatialInspectorNode {
+  return {
+    ...node,
+    children: node.children.map(sortNodeTree).sort(compareNodes),
+  }
+}
+
+function parseEntity(
+  raw: InspectRecord,
+  fallbackId: string,
+  isRoot = false,
+): WebSpatialInspectorNode {
+  const id = nodeId(raw, fallbackId)
+  const type = nativeType(
+    raw,
+    isRoot
+      ? 'SpatialRootEntity'
+      : raw.model !== undefined
+        ? 'SpatialModelEntity'
+        : 'SpatialEntity',
+  )
+  const name = asString(raw.name)
+  const children = collectionEntries(raw.children).map(([key, child]) =>
+    parseEntity(child, key),
+  )
+
+  return {
+    id,
+    label: name ?? (isRoot ? 'Reality root' : type),
+    type,
+    kind: 'entity',
+    raw,
+    children,
+    canHaveDomHost: false,
+  }
+}
+
+function spatializedKind(type: string): WebSpatialInspectorNodeKind {
+  if (type.includes('Spatialized2DElement')) return 'spatial-div'
+  if (type.includes('SpatializedStatic3DElement')) return 'model'
+  if (type.includes('SpatializedDynamic3DElement')) return 'reality'
+  return 'unknown'
+}
+
+function spatializedLabel(
+  kind: WebSpatialInspectorNodeKind,
+  raw: InspectRecord,
+): string {
+  const name = asString(raw.name)
+  if (name) return name
+  if (kind === 'spatial-div') return 'SpatialDiv'
+  if (kind === 'model') return 'Model'
+  if (kind === 'reality') return 'Reality'
+  return 'Spatial object'
+}
+
+function parseSpatializedElement(
+  raw: InspectRecord,
+  fallbackId: string,
+): WebSpatialInspectorNode {
+  const id = nodeId(raw, fallbackId)
+  const type = nativeType(raw, 'SpatializedElement')
+  const kind = spatializedKind(type)
+  const children = collectionEntries(raw.children).map(([key, child]) =>
+    parseSpatializedElement(child, key),
+  )
+  const root = isRecord(raw.root)
+    ? [parseEntity(raw.root, `${id}:root`, true)]
+    : []
+
+  return {
+    id,
+    label: spatializedLabel(kind, raw),
+    type,
+    kind,
+    raw,
+    children: [...children, ...root],
+    canHaveDomHost:
+      kind === 'spatial-div' || kind === 'model' || kind === 'reality',
+  }
+}
+
+function parseOrnament(
+  raw: InspectRecord,
+  fallbackId: string,
+): WebSpatialInspectorNode {
+  return {
+    id: nodeId(raw, fallbackId),
+    label: asString(raw.name) ?? 'Ornament',
+    type: nativeType(raw, 'Ornament'),
+    kind: 'ornament',
+    raw,
+    children: [],
+    canHaveDomHost: false,
+  }
+}
+
+function groupNode(
+  id: string,
+  label: string,
+  children: WebSpatialInspectorNode[],
+): WebSpatialInspectorNode {
+  return {
+    id,
+    label,
+    type: 'Group',
+    kind: 'group',
+    raw: {},
+    children,
+    canHaveDomHost: false,
+    synthetic: true,
+  }
+}
+
+function countNodes(node: WebSpatialInspectorNode): number {
+  return node.children.reduce(
+    (total, child) => total + countNodes(child),
+    node.synthetic ? 0 : 1,
+  )
+}
+
+export function normalizeSpatialSceneInspect(
+  value: unknown,
+): WebSpatialInspectorSnapshot {
+  const raw = asRecord(value)
+  const sceneId = asString(raw.id) ?? 'spatial-scene'
+  const sceneChildren = collectionEntries(raw.children).map(([key, child]) =>
+    parseSpatializedElement(child, key),
+  )
+  const ornaments = collectionEntries(raw.ornaments).map(([key, ornament]) =>
+    parseOrnament(ornament, key),
+  )
+
+  const root: WebSpatialInspectorNode = {
+    id: sceneId,
+    label: asString(raw.name) ?? 'SpatialScene',
+    type: 'SpatialScene',
+    kind: 'scene',
+    raw,
+    children: [...sceneChildren],
+    canHaveDomHost: false,
+  }
+
+  if (ornaments.length > 0) {
+    root.children.push(
+      groupNode(`${sceneId}:ornaments`, 'Ornaments', ornaments),
+    )
+  }
+  const sortedRoot = sortNodeTree(root)
+
+  return {
+    capturedAt: Date.now(),
+    root: sortedRoot,
+    nodeCount: countNodes(sortedRoot),
+  }
+}
+
+function spatialObjectFromElement(
+  element: HTMLElement,
+): SpatializedElement | undefined {
+  const candidate = element as SpatialDomElement
+  try {
+    return (
+      candidate.__spatializedElement ?? candidate.__innerSpatializedElement?.()
+    )
+  } catch {
+    return undefined
+  }
+}
+
+export function findSpatialDomBinding(
+  nativeId: string,
+  root: Document = document,
+): SpatialDomBinding | null {
+  const elements = root.querySelectorAll<HTMLElement>('[data-spatial-id]')
+  for (const element of elements) {
+    const spatialObject = spatialObjectFromElement(element)
+    if (spatialObject?.id === nativeId) {
+      return {
+        element,
+        syncSpatializedElement: (element as SpatialDomElement)
+          .__syncSpatializedElement,
+      }
+    }
+  }
+  return null
+}
+
+function finiteNumber(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+export function applySpatialDomStylePatch(
+  element: HTMLElement,
+  patch: SpatialDomStylePatch,
+): void {
+  if (finiteNumber(patch.width) && patch.width >= 0) {
+    element.style.width = `${patch.width}px`
+  }
+  if (finiteNumber(patch.height) && patch.height >= 0) {
+    element.style.height = `${patch.height}px`
+  }
+  if (finiteNumber(patch.opacity)) {
+    element.style.opacity = String(Math.min(1, Math.max(0, patch.opacity)))
+  }
+  if (typeof patch.visible === 'boolean') {
+    element.style.setProperty(
+      'visibility',
+      patch.visible ? 'visible' : 'hidden',
+    )
+  }
+  if (finiteNumber(patch.depth)) {
+    element.style.setProperty('--xr-depth', String(patch.depth))
+  }
+  if (finiteNumber(patch.backOffset)) {
+    element.style.setProperty('--xr-back', String(patch.backOffset))
+  }
+  if (finiteNumber(patch.zIndex)) {
+    element.style.setProperty('--xr-z-index', String(patch.zIndex))
+  }
+}

--- a/packages/react/src/spatial/index.ts
+++ b/packages/react/src/spatial/index.ts
@@ -36,6 +36,7 @@ import '@webspatial/core-sdk/install-polyfills'
 import { initPolyfill } from '../spatialized-container'
 
 export * from '../Model'
+export * from '../inspector'
 export * from '../ornament'
 export * from '../reality'
 export { useMetrics } from '../useMetrics'

--- a/packages/react/src/spatialized-container/context/PortalInstanceContext.coverage.test.ts
+++ b/packages/react/src/spatialized-container/context/PortalInstanceContext.coverage.test.ts
@@ -53,6 +53,14 @@ function makeComputedStyle(map: Record<string, string>) {
   } as any as CSSStyleDeclaration
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(inResolve => {
+    resolve = inResolve
+  })
+  return { promise, resolve }
+}
+
 describe('PortalInstanceObject', () => {
   it('updates spatialized element props from dom and transform/visibility', async () => {
     const { PortalInstanceObject } = await import('./PortalInstanceContext')
@@ -100,7 +108,7 @@ describe('PortalInstanceObject', () => {
       visibility: 'visible',
     })
 
-    portal.notify2DFrameChange()
+    await portal.notify2DFrameChange()
 
     expect(spatializedElement.updateProperties).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -123,6 +131,39 @@ describe('PortalInstanceObject', () => {
 
     expect((dom as any).__spatializedElement).toBe(spatializedElement)
     expect(typeof (dom as any).__innerSpatializedElement).toBe('function')
+    expect(typeof (dom as any).__syncSpatializedElement).toBe('function')
+
+    const propertiesUpdate = deferred<void>()
+    const transformUpdate = deferred<void>()
+    spatializedElement.updateProperties
+      .mockClear()
+      .mockReturnValueOnce(propertiesUpdate.promise)
+    spatializedElement.updateTransform
+      .mockClear()
+      .mockReturnValueOnce(transformUpdate.promise)
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback(0)
+        return 1
+      })
+
+    let synchronized = false
+    const synchronization = (dom as any).__syncSpatializedElement().then(() => {
+      synchronized = true
+    })
+    await Promise.resolve()
+
+    expect(spatializedElement.updateProperties).toHaveBeenCalledTimes(1)
+    expect(spatializedElement.updateTransform).toHaveBeenCalledTimes(1)
+    propertiesUpdate.resolve()
+    await Promise.resolve()
+    expect(synchronized).toBe(false)
+
+    transformUpdate.resolve()
+    await synchronization
+    expect(synchronized).toBe(true)
+    requestAnimationFrame.mockRestore()
   })
 
   it('adds fixed or root portal elements to scene', async () => {

--- a/packages/react/src/spatialized-container/context/PortalInstanceContext.ts
+++ b/packages/react/src/spatialized-container/context/PortalInstanceContext.ts
@@ -117,11 +117,11 @@ export class PortalInstanceObject {
       transformMatrix: new DOMMatrix(spatialTransform.transform),
       visibility: spatialTransform.visibility,
     }
-    this.updateSpatializedElementProperties()
+    void this.updateSpatializedElementProperties()
   }
 
   // called when 2D frame change
-  notify2DFrameChange() {
+  async notify2DFrameChange() {
     const dom = this.spatializedContainerObject.querySpatialDomBySpatialId(
       this.spatialId,
     )
@@ -135,13 +135,22 @@ export class PortalInstanceObject {
       isFixedPosition: computedStyle.getPropertyValue('position') === 'fixed',
     }
 
-    this.updateSpatializedElementProperties()
-
     const __innerSpatializedElement = () => this.spatializedElement
+    const __syncSpatializedElement = () => this.syncSpatializedElement()
 
     Object.assign(dom, {
       __innerSpatializedElement,
+      __syncSpatializedElement,
     })
+
+    await this.updateSpatializedElementProperties()
+  }
+
+  private syncSpatializedElement = async () => {
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => resolve())
+    })
+    await this.notify2DFrameChange()
   }
 
   private async getSpatializedElement() {
@@ -155,7 +164,7 @@ export class PortalInstanceObject {
     this.addToParent(spatializedElement)
     this.spatializedElementResolver?.(spatializedElement)
 
-    this.updateSpatializedElementProperties()
+    void this.updateSpatializedElementProperties()
   }
 
   private inAddingToParent: boolean = false
@@ -179,7 +188,7 @@ export class PortalInstanceObject {
     this.inAddingToParent = false
   }
 
-  private updateSpatializedElementProperties() {
+  private async updateSpatializedElementProperties() {
     // console.log('updateSpatializedElement', this.spatializedElement)
     // read from spatializedContainerContext
     const dom = this.dom
@@ -249,28 +258,27 @@ export class PortalInstanceObject {
     const extraProperties =
       this.getExtraSpatializedElementProperties?.(computedStyle) || {}
 
-    spatializedElement.updateProperties({
-      clientX: x,
-      clientY: y,
-      width,
-      height,
-      depth,
-      opacity,
-      scrollWithParent,
-      zIndex,
-      visible,
-      backOffset,
-      rotationAnchor,
-      ...extraProperties,
-    })
-
-    // update transform
-    spatializedElement.updateTransform(this.transformMatrix!)
-
-    // assign spatializedElement to dom
-    Object.assign(this.dom, {
+    Object.assign(dom, {
       __spatializedElement: spatializedElement,
     })
+
+    await Promise.all([
+      spatializedElement.updateProperties({
+        clientX: x,
+        clientY: y,
+        width,
+        height,
+        depth,
+        opacity,
+        scrollWithParent,
+        zIndex,
+        visible,
+        backOffset,
+        rotationAnchor,
+        ...extraProperties,
+      }),
+      spatializedElement.updateTransform(this.transformMatrix!),
+    ])
   }
 }
 

--- a/packages/visionOS/web-spatial/model/SpatialScene.swift
+++ b/packages/visionOS/web-spatial/model/SpatialScene.swift
@@ -1626,7 +1626,10 @@ class SpatialScene: SpatialObject, ScrollAbleSpatialElementContainer, WebMsgSend
         try container.encode(childrenIds, forKey: .childrenIds)
         let sceneSpatialObjectIds = spatialObjects.map { $0.key }
         try container.encode(sceneSpatialObjectIds, forKey: .sceneSpatialObjectIds)
-        try container.encode(ornamentManager.ornaments, forKey: .ornaments)
+        let activeOrnaments = Dictionary(
+            uniqueKeysWithValues: ornamentManager.activeOrnaments.map { ($0.id, $0) }
+        )
+        try container.encode(activeOrnaments, forKey: .ornaments)
         try container.encode(spatialWebViewModel.getController().webview?.isOpaque, forKey: .webviewIsOpaque)
         try container.encode(SpatialObject.objects.count, forKey: .spatialObjectCount)
 

--- a/packages/visionOS/web-spatial/model/SpatializedDynamic3DElement.swift
+++ b/packages/visionOS/web-spatial/model/SpatializedDynamic3DElement.swift
@@ -5,7 +5,7 @@ import RealityKit
 @Observable
 class SpatializedDynamic3DElement: SpatializedElement {
     private var rootEntity = SpatialRootEntity()
-    private var viewContent: RealityViewContent? = nil
+    private var viewContent: RealityViewContent?
 
     override init() {
         super.init()
@@ -17,11 +17,11 @@ class SpatializedDynamic3DElement: SpatializedElement {
     }
 
     func addEntity(_ entity: SpatialEntity) {
-        rootEntity.addChild(entity)
+        rootEntity.addChild(entity: entity)
     }
 
     func removeEntity(_ entity: SpatialEntity) {
-        rootEntity.removeChild(entity)
+        rootEntity.removeChild(id: entity.spatialId)
     }
 
     func getViewContent() -> RealityViewContent? {

--- a/packages/visionOS/web-spatial/model/dynamic3d/SpatialEntity.swift
+++ b/packages/visionOS/web-spatial/model/dynamic3d/SpatialEntity.swift
@@ -1,6 +1,32 @@
 import RealityKit
 import SwiftUI
 
+private struct SpatialEntityInspectVector3: Encodable {
+    let x: Float
+    let y: Float
+    let z: Float
+
+    init(_ value: SIMD3<Float>) {
+        x = value.x
+        y = value.y
+        z = value.z
+    }
+}
+
+private struct SpatialEntityInspectQuaternion: Encodable {
+    let x: Float
+    let y: Float
+    let z: Float
+    let w: Float
+
+    init(_ value: simd_quatf) {
+        x = value.imag.x
+        y = value.imag.y
+        z = value.imag.z
+        w = value.real
+    }
+}
+
 @Observable
 class SpatialEntity: Entity, SpatialObjectProtocol {
     let spatialId: String
@@ -77,6 +103,11 @@ class SpatialEntity: Entity, SpatialObjectProtocol {
     }
 
     func addChild(entity: SpatialEntity) {
+        if let previousParent = entity.parent as? SpatialEntity,
+           previousParent !== self
+        {
+            previousParent.spatialChildren.removeValue(forKey: entity.spatialId)
+        }
         spatialChildren[entity.spatialId] = entity
         super.addChild(entity)
     }
@@ -92,7 +123,7 @@ class SpatialEntity: Entity, SpatialObjectProtocol {
 
     func removeFromParent() {
         if let parent = parent as? SpatialEntity {
-            parent.removeChild(self)
+            parent.removeChild(id: spatialId)
         }
     }
 
@@ -167,16 +198,26 @@ class SpatialEntity: Entity, SpatialObjectProtocol {
 
     /// Encodable
     enum CodingKeys: String, CodingKey {
-        case id, name, isDestroyed, children, components
+        case id, name, type, isDestroyed, position, rotation, scale, children, components
+        case enableTap, enableRotate, enableDrag, enableMagnify, enableInteractive
     }
 
     func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(spatialId, forKey: .id)
         try container.encode(name, forKey: .name)
+        try container.encode(String(describing: Swift.type(of: self)), forKey: .type)
         try container.encode(isDestroyed, forKey: .isDestroyed)
+        try container.encode(SpatialEntityInspectVector3(transform.translation), forKey: .position)
+        try container.encode(SpatialEntityInspectQuaternion(transform.rotation), forKey: .rotation)
+        try container.encode(SpatialEntityInspectVector3(transform.scale), forKey: .scale)
         try container.encode(spatialChildren, forKey: .children)
         try container.encode(spatialComponents, forKey: .components)
+        try container.encode(enableTap, forKey: .enableTap)
+        try container.encode(enableRotate, forKey: .enableRotate)
+        try container.encode(enableDrag, forKey: .enableDrag)
+        try container.encode(enableMagnify, forKey: .enableMagnify)
+        try container.encode(enableInteractive, forKey: .enableInteractive)
     }
 
     /// Equatable
@@ -204,14 +245,16 @@ class SpatialEntity: Entity, SpatialObjectProtocol {
             removeFromParent()
         }
         components.removeAll()
-        for (id, child) in spatialChildren {
+        let children = Array(spatialChildren.values)
+        for child in children {
             child.destroy()
         }
-        spatialChildren = [:]
-        for (id, components) in spatialComponents {
-            components.destroy()
+        spatialChildren.removeAll()
+        let ownedComponents = Array(spatialComponents.values)
+        for component in ownedComponents {
+            component.destroy()
         }
-        spatialComponents = [:]
+        spatialComponents.removeAll()
     }
 
     deinit {

--- a/packages/visionOS/web-spatial/model/dynamic3d/SpatialModelEntity.swift
+++ b/packages/visionOS/web-spatial/model/dynamic3d/SpatialModelEntity.swift
@@ -61,16 +61,12 @@ class SpatialModelEntity: SpatialEntity {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, isDestroyed, children, components, model
+        case model
     }
 
     override func encode(to encoder: any Encoder) throws {
+        try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(spatialId, forKey: .id)
-        try container.encode(name, forKey: .name)
-        try container.encode(isDestroyed, forKey: .isDestroyed)
-        try container.encode(spatialChildren, forKey: .children)
-        try container.encode(spatialComponents, forKey: .components)
         try container.encode(modelEntity?.id, forKey: .model)
     }
 }

--- a/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
+++ b/packages/visionOS/web-spatialTests/NavigationCleanupTests.swift
@@ -16,9 +16,11 @@ final class NavigationCleanupTests: XCTestCase {
 
         _ = scene.attachmentManager.create(
             id: "test-attachment",
-            parentEntityId: "test-parent-entity",
+            placementId: "test-parent-entity",
             position: SIMD3<Float>(0, 0, 0),
-            size: CGSize(width: 100, height: 100),
+            rotation: SIMD3<Float>(0, 0, 0),
+            scale: SIMD3<Float>(1, 1, 1),
+            frameSize: CGSize(width: 100, height: 100),
             webViewModel: SpatialWebViewModel(url: "http://localhost:5173/")
         )
         XCTAssertFalse(scene.attachmentManager.attachments.isEmpty)
@@ -30,5 +32,108 @@ final class NavigationCleanupTests: XCTestCase {
         XCTAssertNil(scene.findSpatialObject(panel.id) as Spatialized2DElement?)
         XCTAssertTrue(scene.attachmentManager.attachments.isEmpty)
         XCTAssertNil(SpatialObject.get(panel.id))
+    }
+}
+final class SpatializedDynamic3DElementInspectTests: XCTestCase {
+    func test_addAndRemoveEntityKeepsInspectHierarchyInSync() throws {
+        let reality = SpatializedDynamic3DElement()
+        let entity = SpatialEntity("Inspectable entity")
+        entity.transform.translation = SIMD3<Float>(1, 2, 3)
+        defer {
+            if !entity.isDestroyed {
+                entity.destroy()
+            }
+            if !reality.isDestroyed {
+                reality.destroy()
+            }
+        }
+
+        reality.addEntity(entity)
+
+        XCTAssertEqual(reality.getRoot().spatialChildren[entity.spatialId], entity)
+
+        let encoded = try JSONEncoder().encode(reality)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let root = try XCTUnwrap(json["root"] as? [String: Any])
+        let children = try XCTUnwrap(root["children"] as? [String: Any])
+        let child = try XCTUnwrap(children[entity.spatialId] as? [String: Any])
+        let position = try XCTUnwrap(child["position"] as? [String: Any])
+
+        XCTAssertEqual(child["type"] as? String, "SpatialEntity")
+        XCTAssertEqual(position["x"] as? Double, 1)
+        XCTAssertEqual(position["y"] as? Double, 2)
+        XCTAssertEqual(position["z"] as? Double, 3)
+
+        reality.removeEntity(entity)
+
+        XCTAssertNil(reality.getRoot().spatialChildren[entity.spatialId])
+    }
+
+    func test_reparentAndRemoveEntityKeepsInspectHierarchyInSync() {
+        let reality = SpatializedDynamic3DElement()
+        let firstParent = SpatialEntity("First parent")
+        let secondParent = SpatialEntity("Second parent")
+        let child = SpatialEntity("Child")
+        defer {
+            if !child.isDestroyed {
+                child.destroy()
+            }
+            if !reality.isDestroyed {
+                reality.destroy()
+            }
+        }
+
+        reality.addEntity(firstParent)
+        reality.addEntity(secondParent)
+        firstParent.addChild(entity: child)
+        secondParent.addChild(entity: child)
+
+        XCTAssertNil(firstParent.spatialChildren[child.spatialId])
+        XCTAssertEqual(secondParent.spatialChildren[child.spatialId], child)
+
+        child.removeFromParent()
+
+        XCTAssertNil(secondParent.spatialChildren[child.spatialId])
+        XCTAssertNil(child.parent)
+    }
+}
+
+final class SpatialSceneInspectTests: XCTestCase {
+    func test_encodeIncludesOnlyActiveOrnaments() throws {
+        let scene = SpatialApp.Instance.createScene(
+            "http://localhost:5173/",
+            .window,
+            .visible
+        )
+        let detached = OrnamentElement(
+            id: "detached-ornament",
+            webViewModel: SpatialWebViewModel(url: nil),
+            options: .default
+        )
+        let active = OrnamentElement(
+            id: "active-ornament",
+            webViewModel: SpatialWebViewModel(url: nil),
+            options: .default
+        )
+        defer {
+            if !scene.isDestroyed {
+                scene.destroy()
+            }
+        }
+
+        scene.ornamentManager.register(detached)
+        scene.ornamentManager.register(active)
+        XCTAssertTrue(scene.ornamentManager.add(id: active.id))
+
+        let encoded = try JSONEncoder().encode(scene)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let ornaments = try XCTUnwrap(json["ornaments"] as? [String: Any])
+
+        XCTAssertNil(ornaments[detached.id])
+        XCTAssertNotNil(ornaments[active.id])
     }
 }


### PR DESCRIPTION
## Summary

Add an experimental `WebSpatialInspector` for WebSpatial debugging.

The inspector renders native scene inspect data inside an Ornament panel, showing the currently mounted WebSpatial tree such as SpatialDiv, Model, Reality entity trees, and active Ornaments. It supports selecting nodes, viewing native properties, highlighting DOM-backed placeholders on the page, and editing supported DOM-backed layout properties.

## What Changed

- Added experimental `WebSpatialInspector` export under `@webspatial/react-sdk/experimental`.
- Added an Ornament-based inspector UI with:
  - mounted native scene tree
  - stable node/property ordering
  - selected-node details panel
  - DOM placeholder highlight
  - editable DOM-backed fields: width, height, opacity, visibility, depth, back offset, z-index
- Added event-driven refresh for mounted-tree structural changes.
  - No continuous polling.
  - Layout/property sync commands do not auto-refresh the panel.
  - Manual Refresh remains available.
- Updated native visionOS inspect payloads for Reality entity hierarchy and transforms.
- Limited inspector scope to mounted scene-tree nodes.
  - Detached runtime registry objects are intentionally hidden.
  - Active Ornaments are shown; created-but-not-mounted Ornaments are not.
- Added a test-server demo page for verifying Inspector behavior with SpatialDiv, Model, Reality, and edit/highlight flows.
- Added tests for:
  - structural refresh events
  - in-flight refresh coalescing
  - stable sorting
  - editor draft refresh behavior
  - active Ornament inspect filtering
  - Reality entity add/remove/reparent inspect consistency

## Validation

- `@webspatial/core-sdk`: 435 tests passed
- `@webspatial/react-sdk`: 615 tests passed
- `apps/test-server`: typecheck and production build passed
- visionOS simulator focused tests passed:
  - `SpatializedDynamic3DElementInspectTests`
  - `SpatialSceneInspectTests`
- SwiftFormat lint passed
- `git diff --check` passed

<img width="1280" height="760" alt="WebSpatial inspector" src="https://github.com/user-attachments/assets/bd57d63b-c60f-44a2-bd57-7c3b13b377f9" />
