### PR TITLE
Add `run-pico` command to launch WebSpatial apps on PICO OS 6 via ADB

### DIFF
--- a/.changeset/pico-os-six-cli.md
+++ b/.changeset/pico-os-six-cli.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/builder': minor
+---
+
+Add the `run-pico` command to launch WebSpatial app on a default PICO OS 6 device.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,12 +7,40 @@
 
 The build tool transforms websites into Packaged WebSpatial Apps for debugging and distributing on spatial computing platforms.
 
+## Run on PICO OS 6
+
+With a PICO OS 6 device connected through ADB, launch a hosted WebSpatial app
+using the default development URL:
+
+```sh
+webspatial-builder run-pico
+```
+
+Use `--base` when the app is hosted at a different URL. The URL must expose a
+Web Manifest:
+
+```sh
+webspatial-builder run-pico --base http://10.0.2.2:4173
+```
+
+The command loads and prepares the manifest itself, so only `adb` is
+required. It uses the default connected ADB device.
+
+Manifest lookup follows the same order as `run`:
+
+1. `--manifest-url <url>` downloads a remote manifest.
+2. `--manifest <path>` reads a path relative to the current directory.
+3. With neither option, the command checks `public/manifest.json`, then
+   `public/manifest.webmanifest`, and finally uses the development manifest.
+
 ## Documentation
 
 For WebSpatial Builder:
+
 - [Add Build Tool for Packaged WebSpatial Apps](https://webspatial.dev/docs/development-guide/enabling-webspatial-in-web-projects/step-2-add-build-tool-for-packaged-webspatial-apps)
 
 For WebSpatial:
+
 - [Introduction](https://webspatial.dev/docs/introduction)
 - [Quick Example](https://webspatial.dev/docs/quick-example)
 - [Core Concepts](https://webspatial.dev/docs/core-concepts)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webspatial/builder",
   "version": "2.0.0",
-  "description": "Client CLI tool to Generate XRApp project for Apple Vision Pro",
+  "description": "Client CLI tool to build and run WebSpatial apps",
   "type": "commonjs",
   "engines": {
     "node": ">=22"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { launch } from './lib/cmds/launch'
 import { shutdown } from './lib/cmds/shutdown'
 import { test } from './lib/cmds/test'
+import { DEFAULT_PICO_BASE, runPico } from './lib/cmds/runPico'
 
 const MIN_SUPPORTED_NODE_MAJOR = 22
 
@@ -55,6 +56,21 @@ async function setupCommands(program: Command) {
     .option('--tryWithoutBuild <tryWithoutBuild>', 'run without build')
     .action(async options => {
       await run(options)
+    })
+
+  // run-pico command
+  program
+    .command('run-pico')
+    .description('Launch a WebSpatial App on PICO OS 6')
+    .option('--manifest <manifest>', 'manifest path')
+    .option('--manifest-url <manifestUrl>', 'manifest url')
+    .option(
+      '--base <base>',
+      'base URL hosting the WebSpatial App',
+      DEFAULT_PICO_BASE,
+    )
+    .action(async options => {
+      await runPico(options)
     })
 
   // build command

--- a/packages/cli/src/lib/cmds/runPico.ts
+++ b/packages/cli/src/lib/cmds/runPico.ts
@@ -1,0 +1,165 @@
+import { execFile } from 'child_process'
+import * as fs from 'fs'
+import { join } from 'path'
+import { loadJsonFromDisk, loadJsonFromNet } from '../resource/load'
+
+export const DEFAULT_PICO_BASE = 'http://10.0.2.2:5173/'
+
+const PICO_WEB_ROUTER_ACTIVITY =
+  'com.picoxr.browser/com.picoxr.webappservice.feature.router.ui.WebRouterActivity'
+
+interface RunPicoArgs {
+  base?: string
+  manifest?: string
+  manifestUrl?: string
+}
+
+interface RunPicoDependencies {
+  loadManifest: (args: RunPicoArgs) => Promise<Record<string, any>>
+  executeAdbShell: (command: string) => Promise<void>
+}
+
+interface ManifestDependencies {
+  existsSync: (path: string) => boolean
+  loadJsonFromDisk: (path: string) => Promise<Record<string, any>>
+  loadJsonFromNet: (url: string) => Promise<Record<string, any>>
+}
+
+const defaultManifest = {
+  name: 'WebSpatialTest',
+  display: 'minimal-ui',
+  start_url: '/',
+  scope: '/',
+}
+
+const defaultManifestDependencies: ManifestDependencies = {
+  existsSync: fs.existsSync,
+  loadJsonFromDisk: path => loadJsonFromDisk(path),
+  loadJsonFromNet: url => loadJsonFromNet(url),
+}
+
+export async function loadPicoManifest(
+  args: RunPicoArgs,
+  dependencies: ManifestDependencies = defaultManifestDependencies,
+): Promise<Record<string, any>> {
+  if (args.manifest && args.manifestUrl) {
+    throw new Error(
+      '--manifest and --manifest-url cannot be used at the same time',
+    )
+  }
+
+  if (args.manifestUrl) {
+    return dependencies.loadJsonFromNet(args.manifestUrl)
+  }
+
+  if (args.manifest) {
+    return dependencies.loadJsonFromDisk(join(process.cwd(), args.manifest))
+  }
+
+  const manifestJsonPath = join(process.cwd(), 'public/manifest.json')
+  if (dependencies.existsSync(manifestJsonPath)) {
+    return dependencies.loadJsonFromDisk(manifestJsonPath)
+  }
+
+  const manifestWebmanifestPath = join(
+    process.cwd(),
+    'public/manifest.webmanifest',
+  )
+  if (dependencies.existsSync(manifestWebmanifestPath)) {
+    return dependencies.loadJsonFromDisk(manifestWebmanifestPath)
+  }
+
+  return { ...defaultManifest }
+}
+
+export function normalizePicoBase(base: string): string {
+  let parsedBase: URL
+  try {
+    parsedBase = new URL(base)
+  } catch {
+    throw new Error('--base must be a valid HTTP or HTTPS URL')
+  }
+
+  if (!['http:', 'https:'].includes(parsedBase.protocol)) {
+    throw new Error('--base must be a valid HTTP or HTTPS URL')
+  }
+  if (parsedBase.search || parsedBase.hash) {
+    throw new Error('--base cannot contain query parameters or a hash')
+  }
+
+  if (!parsedBase.pathname.endsWith('/')) {
+    parsedBase.pathname += '/'
+  }
+  return parsedBase.href
+}
+
+export function createPicoManifest(
+  manifest: Record<string, any>,
+  base: string,
+): Record<string, any> {
+  const icons = manifest.icons
+  if (icons !== undefined && !Array.isArray(icons)) {
+    throw new Error('The Web Manifest icons property must be an array')
+  }
+
+  return {
+    ...manifest,
+    start_url: base,
+    scope: base,
+    ...(icons === undefined
+      ? {}
+      : {
+          icons: icons.map((icon: Record<string, any>) => {
+            if (!icon || typeof icon.src !== 'string') {
+              throw new Error('Each Web Manifest icon must have a string src')
+            }
+            return {
+              ...icon,
+              src: new URL(icon.src, base).href
+            }
+          }),
+        }),
+  }
+}
+
+function quoteAdbShellArgument(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+export function createPicoLaunchCommand(manifest: Record<string, any>): string {
+  return [
+    'am start',
+    `-n ${PICO_WEB_ROUTER_ACTIVITY}`,
+    `--es extra_manifest_json ${quoteAdbShellArgument(JSON.stringify(manifest))}`,
+    '--es extra_install_type TEMPORARY',
+  ].join(' ')
+}
+
+function executeAdbShell(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('adb', ['shell', command], error => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+const defaultDependencies: RunPicoDependencies = {
+  loadManifest: args => loadPicoManifest(args),
+  executeAdbShell,
+}
+
+export async function runPico(
+  args: RunPicoArgs,
+  dependencies: RunPicoDependencies = defaultDependencies,
+): Promise<void> {
+  const base = normalizePicoBase(args.base ?? DEFAULT_PICO_BASE)
+  const manifest = await dependencies.loadManifest(args)
+  const picoManifest = createPicoManifest(manifest, base)
+
+  await dependencies.executeAdbShell(createPicoLaunchCommand(picoManifest))
+  console.log(`Launched WebSpatial App on PICO OS 6 from ${base}`)
+}

--- a/packages/cli/test/runPico.test.js
+++ b/packages/cli/test/runPico.test.js
@@ -1,0 +1,174 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  createPicoLaunchCommand,
+  createPicoManifest,
+  loadPicoManifest,
+  normalizePicoBase,
+  runPico,
+} = require('../dist/lib/cmds/runPico')
+
+function createManifestDependencies({ existingPaths = [] } = {}) {
+  const diskLoads = []
+  const existsChecks = []
+  const networkLoads = []
+  return {
+    diskLoads,
+    existsChecks,
+    networkLoads,
+    dependencies: {
+      existsSync: path => {
+        existsChecks.push(path)
+        return existingPaths.includes(path)
+      },
+      loadJsonFromDisk: async path => {
+        diskLoads.push(path)
+        return { source: 'disk' }
+      },
+      loadJsonFromNet: async url => {
+        networkLoads.push(url)
+        return { source: 'network' }
+      },
+    },
+  }
+}
+
+test('normalizePicoBase: normalizes a base URL with a trailing slash', () => {
+  assert.equal(
+    normalizePicoBase('http://10.0.2.2:5173/app'),
+    'http://10.0.2.2:5173/app/',
+  )
+  assert.throws(
+    () => normalizePicoBase('http://10.0.2.2:5173/?debug=true'),
+    /cannot contain query parameters/,
+  )
+})
+
+test('createPicoManifest: points the app and its icons at the base URL', () => {
+  const manifest = createPicoManifest(
+    {
+      name: 'PICO Test',
+      start_url: '/old',
+      scope: '/old',
+      icons: [{ src: '/icons/app.png', sizes: '192x192' }],
+    },
+    'http://10.0.2.2:5173/',
+  )
+
+  assert.deepEqual(manifest, {
+    name: 'PICO Test',
+    start_url: 'http://10.0.2.2:5173/',
+    scope: 'http://10.0.2.2:5173/',
+    icons: [
+      {
+        src: 'http://10.0.2.2:5173/icons/app.png',
+        sizes: '192x192',
+      },
+    ],
+  })
+})
+
+test('loadPicoManifest: loads --manifest-url from the network', async () => {
+  const fixture = createManifestDependencies()
+
+  const manifest = await loadPicoManifest(
+    { manifestUrl: 'https://example.com/app.webmanifest' },
+    fixture.dependencies,
+  )
+
+  assert.deepEqual(manifest, { source: 'network' })
+  assert.deepEqual(fixture.networkLoads, [
+    'https://example.com/app.webmanifest',
+  ])
+  assert.deepEqual(fixture.diskLoads, [])
+})
+
+test('loadPicoManifest: resolves --manifest from the current directory', async () => {
+  const fixture = createManifestDependencies()
+
+  const manifest = await loadPicoManifest(
+    { manifest: 'config/manifest.json' },
+    fixture.dependencies,
+  )
+
+  assert.deepEqual(manifest, { source: 'disk' })
+  assert.deepEqual(fixture.diskLoads, [`${process.cwd()}/config/manifest.json`])
+  assert.deepEqual(fixture.networkLoads, [])
+})
+
+test('loadPicoManifest: checks default manifest names in order', async () => {
+  const manifestJson = `${process.cwd()}/public/manifest.json`
+  const manifestWebmanifest = `${process.cwd()}/public/manifest.webmanifest`
+  const fixture = createManifestDependencies({
+    existingPaths: [manifestWebmanifest],
+  })
+
+  await loadPicoManifest({}, fixture.dependencies)
+
+  assert.deepEqual(fixture.existsChecks, [manifestJson, manifestWebmanifest])
+  assert.deepEqual(fixture.diskLoads, [manifestWebmanifest])
+})
+
+test('loadPicoManifest: uses the run default when no manifest exists', async () => {
+  const fixture = createManifestDependencies()
+
+  const manifest = await loadPicoManifest({}, fixture.dependencies)
+
+  assert.deepEqual(manifest, {
+    name: 'WebSpatialTest',
+    display: 'minimal-ui',
+    start_url: '/',
+    scope: '/',
+  })
+  assert.deepEqual(fixture.diskLoads, [])
+})
+
+test('loadPicoManifest: rejects conflicting manifest options', async () => {
+  const fixture = createManifestDependencies()
+
+  await assert.rejects(
+    loadPicoManifest(
+      {
+        manifest: 'manifest.json',
+        manifestUrl: 'https://example.com/manifest',
+      },
+      fixture.dependencies,
+    ),
+    /cannot be used at the same time/,
+  )
+})
+
+test('createPicoLaunchCommand: safely quotes manifest JSON for adb shell', () => {
+  const command = createPicoLaunchCommand({ name: "Developer's App" })
+
+  assert.match(command, /^am start -n com\.picoxr\.browser\//)
+  assert.match(command, /--es extra_manifest_json/)
+  assert.match(command, /Developer'"'"'s App/)
+  assert.match(command, /--es extra_install_type TEMPORARY$/)
+})
+
+test('runPico: downloads the manifest and launches it on the default device', async () => {
+  let manifestUrl
+  let adbCommand
+
+  await runPico(
+    {
+      base: 'https://example.com/spatial',
+      manifestUrl: 'https://example.com/app.webmanifest',
+    },
+    {
+      loadManifest: async args => {
+        manifestUrl = args.manifestUrl
+        return { name: 'Test', icons: [{ src: '/icon.png' }] }
+      },
+      executeAdbShell: async command => {
+        adbCommand = command
+      },
+    },
+  )
+
+  assert.equal(manifestUrl, 'https://example.com/app.webmanifest')
+  assert.match(adbCommand, /https:\/\/example\.com\/spatial\/icon\.png/)
+  assert.doesNotMatch(adbCommand, /adb -s/)
+})


### PR DESCRIPTION
### Motivation

- Enable launching a hosted WebSpatial app directly on a connected PICO OS 6 device via `adb` for faster development iteration. 
- Reuse manifest lookup behavior from the existing `run` command so hosted and local apps resolve consistently. 
- Provide a sensible default base URL and manifest handling so only `adb` is required for most local workflows.

### Description

- Introduces a new CLI command `run-pico` in `packages/cli/src/index.ts` that calls the new `runPico` handler. 
- Adds `packages/cli/src/lib/cmds/runPico.ts` implementing manifest discovery (`loadPicoManifest`), base normalization (`normalizePicoBase`), Web Manifest transformation (`createPicoManifest`), adb launch command generation (`createPicoLaunchCommand`), and remote execution via `adb`. 
- Updates `packages/cli/README.md` with usage docs for `run-pico`, updates package description in `packages/cli/package.json`, and adds a changeset `.changeset/pico-os-six-cli.md`. 
- Adds unit tests `packages/cli/test/runPico.test.js` covering base normalization, manifest loading resolution, manifest transformation, adb command quoting, and the overall `runPico` flow.

### Testing

- Ran the package build and unit tests using the project test scripts (e.g. `npm run build` then `npm run test:unit`), and the new `runPico` unit tests passed. 
- The test suite includes assertions for `normalizePicoBase`, `createPicoManifest`, `loadPicoManifest`, `createPicoLaunchCommand`, and `runPico`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7a56d91bb4832a93ed6bf74904b186)