### PR TITLE
fix(visionOS): support SpatialDiv horizontal scrolling

### DIFF
--- a/.changeset/fix-spatialdiv-horizontal-scroll.md
+++ b/.changeset/fix-spatialdiv-horizontal-scroll.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Forward horizontal drag deltas from SpatialDiv surfaces to the parent page scroll view.

--- a/apps/test-server/src/components/Sidebar.tsx
+++ b/apps/test-server/src/components/Sidebar.tsx
@@ -119,7 +119,7 @@ export const routes = [
       { path: '/display-test', label: 'Display Test' },
       { path: '/memory-stats', label: 'Memory Stats' },
       { path: '/nested-fix-position', label: 'Nested Fix Position' },
-      { path: '/nested-scroll', label: 'Nested Scroll' },
+      { path: '/nested-scroll', label: 'SpatialDiv Scroll Sync' },
       {
         path: '/nested-spatial-overflow',
         label: 'Nested Spatial Overflow',

--- a/apps/test-server/src/pages/nestedscroll/index.tsx
+++ b/apps/test-server/src/pages/nestedscroll/index.tsx
@@ -1,33 +1,303 @@
 import { enableDebugTool } from '@webspatial/react-sdk'
-import { CSSProperties } from 'react'
+import { CSSProperties, useEffect, useState } from 'react'
 
 enableDebugTool()
 
+type ScrollCheckpoint = {
+  label: string
+  x: number
+  y: number
+}
+
+const checkpoints: ScrollCheckpoint[] = [
+  { label: 'Origin', x: 0, y: 0 },
+  { label: 'Horizontal', x: 0.7, y: 0 },
+  { label: 'Vertical', x: 0, y: 0.7 },
+  { label: 'Diagonal', x: 0.7, y: 0.7 },
+]
+
+const pageStyle: CSSProperties = {
+  enableXr: true,
+  minHeight: '100vh',
+  color: '#e2e8f0',
+  background: '#020617',
+}
+
+const introStyle: CSSProperties = {
+  boxSizing: 'border-box',
+  width: '100vw',
+  minHeight: 360,
+  padding: '44px 48px 40px',
+  borderBottom: '1px solid rgba(148, 163, 184, 0.24)',
+  background:
+    'radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.22), transparent 34%), linear-gradient(135deg, #0f172a, #111827 60%, #172554)',
+}
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  color: '#38bdf8',
+  fontSize: 13,
+  fontWeight: 800,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+}
+
+const titleStyle: CSSProperties = {
+  maxWidth: 760,
+  margin: '12px 0 10px',
+  color: '#f8fafc',
+  fontSize: 'clamp(34px, 5vw, 62px)',
+  lineHeight: 1.02,
+  letterSpacing: '-0.04em',
+}
+
+const descriptionStyle: CSSProperties = {
+  maxWidth: 760,
+  margin: 0,
+  color: '#94a3b8',
+  fontSize: 17,
+  lineHeight: 1.6,
+}
+
+const toolbarStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: 10,
+  marginTop: 28,
+}
+
+const buttonStyle: CSSProperties = {
+  minHeight: 44,
+  padding: '10px 16px',
+  border: '1px solid rgba(125, 211, 252, 0.32)',
+  borderRadius: 999,
+  color: '#e0f2fe',
+  background: 'rgba(14, 116, 144, 0.28)',
+  fontSize: 14,
+  fontWeight: 700,
+  cursor: 'pointer',
+}
+
+const statusStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 14,
+  minHeight: 44,
+  marginLeft: 4,
+  padding: '9px 16px',
+  border: '1px solid rgba(148, 163, 184, 0.24)',
+  borderRadius: 999,
+  color: '#cbd5e1',
+  background: 'rgba(2, 6, 23, 0.68)',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 13,
+}
+
+const acceptanceStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))',
+  gap: 12,
+  maxWidth: 920,
+  margin: '24px 0 0',
+  padding: 0,
+  listStyle: 'none',
+}
+
+const acceptanceItemStyle: CSSProperties = {
+  padding: '13px 15px',
+  border: '1px solid rgba(148, 163, 184, 0.18)',
+  borderRadius: 12,
+  color: '#cbd5e1',
+  background: 'rgba(15, 23, 42, 0.62)',
+  fontSize: 14,
+  lineHeight: 1.45,
+}
+
+const surfaceStyle: CSSProperties = {
+  position: 'relative',
+  boxSizing: 'border-box',
+  width: '200vw',
+  height: '200vh',
+  minWidth: 1600,
+  minHeight: 1200,
+  overflow: 'visible',
+  color: '#f8fafc',
+  backgroundColor: '#0f172a',
+  backgroundImage:
+    'linear-gradient(rgba(148, 163, 184, 0.13) 1px, transparent 1px), linear-gradient(90deg, rgba(148, 163, 184, 0.13) 1px, transparent 1px), radial-gradient(circle at 15% 18%, rgba(14, 165, 233, 0.7), transparent 28%), radial-gradient(circle at 78% 24%, rgba(168, 85, 247, 0.62), transparent 30%), radial-gradient(circle at 72% 82%, rgba(249, 115, 22, 0.66), transparent 34%)',
+  backgroundSize: '64px 64px, 64px 64px, auto, auto, auto',
+  boxShadow: 'inset 0 1px rgba(255, 255, 255, 0.08)',
+  '--xr-back': 121,
+}
+
+const axisXStyle: CSSProperties = {
+  position: 'absolute',
+  top: 34,
+  left: 42,
+  right: 42,
+  height: 2,
+  background: 'linear-gradient(90deg, #38bdf8, #c084fc, #fb923c)',
+}
+
+const axisYStyle: CSSProperties = {
+  position: 'absolute',
+  top: 34,
+  bottom: 42,
+  left: 42,
+  width: 2,
+  background: 'linear-gradient(#38bdf8, #34d399, #fb923c)',
+}
+
+const axisLabelStyle: CSSProperties = {
+  position: 'absolute',
+  padding: '7px 11px',
+  border: '1px solid rgba(226, 232, 240, 0.24)',
+  borderRadius: 999,
+  color: '#e2e8f0',
+  background: 'rgba(2, 6, 23, 0.76)',
+  fontSize: 12,
+  fontWeight: 800,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+}
+
+const markerBaseStyle: CSSProperties = {
+  position: 'absolute',
+  width: 280,
+  padding: 22,
+  border: '1px solid rgba(255, 255, 255, 0.22)',
+  borderRadius: 20,
+  background: 'rgba(2, 6, 23, 0.72)',
+  boxShadow: '0 22px 70px rgba(2, 6, 23, 0.36)',
+  backdropFilter: 'blur(14px)',
+}
+
+const markerStyles: CSSProperties[] = [
+  { top: 90, left: 90 },
+  { top: 120, left: '112vw' },
+  { top: '112vh', left: 110 },
+  { top: '112vh', left: '112vw' },
+]
+
 function App() {
-  const styleContainer: CSSProperties = {
-    enableXr: true,
-  }
+  const [scrollPosition, setScrollPosition] = useState({ x: 0, y: 0 })
 
-  const styleHead = {
-    height: '200px',
-    fontSize: '50px',
-    color: 'white',
-    background: 'linear-gradient(to bottom, yellow, green)',
-  }
+  useEffect(() => {
+    const updatePosition = () => {
+      setScrollPosition({
+        x: Math.round(window.scrollX),
+        y: Math.round(window.scrollY),
+      })
+    }
 
-  const styleLongContent = {
-    height: '200vh',
-    fontSize: '50px',
-    color: 'white',
-    background: 'linear-gradient(to bottom, blue, green)',
-    '--xr-back': 121,
+    updatePosition()
+    window.addEventListener('scroll', updatePosition, { passive: true })
+    return () => window.removeEventListener('scroll', updatePosition)
+  }, [])
+
+  const goToCheckpoint = ({ x, y }: ScrollCheckpoint) => {
+    const root = document.documentElement
+    const maxX = Math.max(0, root.scrollWidth - window.innerWidth)
+    const maxY = Math.max(0, root.scrollHeight - window.innerHeight)
+
+    window.scrollTo({
+      left: Math.round(maxX * x),
+      top: Math.round(maxY * y),
+      behavior: 'auto',
+    })
   }
 
   return (
-    <div style={styleContainer}>
-      <div style={styleHead}> head </div>
-      <div style={styleLongContent} enable-xr>
-        long content
+    <div style={pageStyle} data-name="Nested Scroll Test Controls">
+      <section style={introStyle}>
+        <p style={eyebrowStyle}>SpatialDiv page-scroll regression</p>
+        <h1 style={titleStyle}>Two-axis nested scroll matrix</h1>
+        <p style={descriptionStyle}>
+          Drag directly on the colored SpatialDiv surface. The page and every
+          spatial layer should stay aligned while moving horizontally,
+          vertically, or diagonally. Use the checkpoints for deterministic
+          screenshots and DOM inspection.
+        </p>
+
+        <div style={toolbarStyle} aria-label="Scroll checkpoints">
+          {checkpoints.map(checkpoint => (
+            <button
+              key={checkpoint.label}
+              type="button"
+              style={buttonStyle}
+              data-testid={`nested-scroll-${checkpoint.label.toLowerCase()}`}
+              onClick={() => goToCheckpoint(checkpoint)}
+            >
+              {checkpoint.label}
+            </button>
+          ))}
+          <output
+            style={statusStyle}
+            data-testid="nested-scroll-status"
+            data-scroll-x={scrollPosition.x}
+            data-scroll-y={scrollPosition.y}
+            aria-live="polite"
+          >
+            <span>X {scrollPosition.x}px</span>
+            <span>Y {scrollPosition.y}px</span>
+          </output>
+        </div>
+
+        <ul style={acceptanceStyle}>
+          <li style={acceptanceItemStyle}>
+            <strong>Horizontal:</strong> X changes; Y stays stable.
+          </li>
+          <li style={acceptanceItemStyle}>
+            <strong>Vertical:</strong> Y changes; X stays stable.
+          </li>
+          <li style={acceptanceItemStyle}>
+            <strong>Diagonal:</strong> X and Y change together.
+          </li>
+          <li style={acceptanceItemStyle}>
+            <strong>Alignment:</strong> no spatial layer remains behind.
+          </li>
+        </ul>
+      </section>
+
+      <div
+        style={surfaceStyle}
+        enable-xr
+        data-name="Nested Scroll Test Surface"
+        data-testid="nested-scroll-surface"
+      >
+        <div style={axisXStyle} />
+        <div style={axisYStyle} />
+        <span style={{ ...axisLabelStyle, top: 52, right: 42 }}>X axis →</span>
+        <span style={{ ...axisLabelStyle, bottom: 42, left: 58 }}>
+          Y axis ↓
+        </span>
+
+        {checkpoints.map((checkpoint, index) => (
+          <article
+            key={checkpoint.label}
+            style={{ ...markerBaseStyle, ...markerStyles[index] }}
+            data-checkpoint={checkpoint.label.toLowerCase()}
+          >
+            <p style={{ ...eyebrowStyle, marginBottom: 9 }}>
+              Checkpoint {index + 1}
+            </p>
+            <h2 style={{ margin: 0, fontSize: 28, color: '#f8fafc' }}>
+              {checkpoint.label}
+            </h2>
+            <p
+              style={{
+                margin: '9px 0 0',
+                color: '#94a3b8',
+                fontSize: 14,
+                lineHeight: 1.5,
+              }}
+            >
+              Expected page ratio: X {Math.round(checkpoint.x * 100)}% · Y{' '}
+              {Math.round(checkpoint.y * 100)}%
+            </p>
+          </article>
+        ))}
       </div>
     </div>
   )

--- a/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
+++ b/packages/visionOS/web-spatial.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2B1008A22F0B000800000002 /* NavigationCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */; };
 		2B1008A52F0B000800000005 /* SpatializedElementMotionTimelineSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */; };
 		2B1008A72F0B000800000007 /* SpatializedElementAnimationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */; };
+		2B1008A92F0B000800000009 /* SpatialScrollDragDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1008A82F0B000800000008 /* SpatialScrollDragDeltaTests.swift */; };
 		2B2F1D712BEBFAAC006897EE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D702BEBFAAC006897EE /* Assets.xcassets */; };
 		2B2F1D742BEBFAAC006897EE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B2F1D732BEBFAAC006897EE /* Preview Assets.xcassets */; };
 		2B89E38C2E699104004079AA /* WebMsgCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B89E38B2E699104004079AA /* WebMsgCommand.swift */; };
@@ -42,6 +43,7 @@
 		2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCleanupTests.swift; sourceTree = "<group>"; };
 		2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatializedElementMotionTimelineSamplerTests.swift; sourceTree = "<group>"; };
 		2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatializedElementAnimationManagerTests.swift; sourceTree = "<group>"; };
+		2B1008A82F0B000800000008 /* SpatialScrollDragDeltaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpatialScrollDragDeltaTests.swift; sourceTree = "<group>"; };
 		2B2F1D632BEBFAAA006897EE /* WebSpatial.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WebSpatial.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B2F1D672BEBFAAA006897EE /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 		2B2F1D702BEBFAAC006897EE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				2B1008A12F0B000800000001 /* NavigationCleanupTests.swift */,
 				2B1008A42F0B000800000004 /* SpatializedElementMotionTimelineSamplerTests.swift */,
 				2B1008A62F0B000800000006 /* SpatializedElementAnimationManagerTests.swift */,
+				2B1008A82F0B000800000008 /* SpatialScrollDragDeltaTests.swift */,
 			);
 			path = "web-spatialTests";
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				2B1008A22F0B000800000002 /* NavigationCleanupTests.swift in Sources */,
 				2B1008A52F0B000800000005 /* SpatializedElementMotionTimelineSamplerTests.swift in Sources */,
 				2B1008A72F0B000800000007 /* SpatializedElementAnimationManagerTests.swift in Sources */,
+				2B1008A92F0B000800000009 /* SpatialScrollDragDeltaTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
+++ b/packages/visionOS/web-spatial/view/Spatialized2DElementView.swift
@@ -14,8 +14,15 @@ extension View {
 
 class Spatialized2DViewGestureData {
     var dragStarted = false
-    var dragStart: CGFloat = 0.0
+    var dragStart: CGSize = .zero
     var dragVelocity: CGFloat = 0.0
+}
+
+func spatialScrollDelta(from previousTranslation: CGSize, to currentTranslation: CGSize) -> Vec2 {
+    Vec2(
+        x: previousTranslation.width - currentTranslation.width,
+        y: previousTranslation.height - currentTranslation.height
+    )
 }
 
 struct Spatialized2DElementView: View {
@@ -71,13 +78,16 @@ struct Spatialized2DElementView: View {
                 if spatialized2DElement.scrollPageEnabled {
                     if !gestureData.dragStarted {
                         gestureData.dragStarted = true
-                        gestureData.dragStart = (gesture.translation.height)
+                        gestureData.dragStart = gesture.translation
                     }
 
                     // TODO: this should have velocity
-                    let delta = gestureData.dragStart - gesture.translation.height
-                    gestureData.dragStart = gesture.translation.height
-                    spatialScene.updateDeltaScrollOffset(Vec2(x: 0, y: delta))
+                    let delta = spatialScrollDelta(
+                        from: gestureData.dragStart,
+                        to: gesture.translation
+                    )
+                    gestureData.dragStart = gesture.translation
+                    spatialScene.updateDeltaScrollOffset(delta)
                 }
             }
             .onEnded { _ in
@@ -87,7 +97,7 @@ struct Spatialized2DElementView: View {
                 }
                 if spatialized2DElement.scrollPageEnabled {
                     gestureData.dragStarted = false
-                    gestureData.dragStart = 0
+                    gestureData.dragStart = .zero
                     spatialScene.stopScrolling()
                 }
             }

--- a/packages/visionOS/web-spatialTests/SpatialScrollDragDeltaTests.swift
+++ b/packages/visionOS/web-spatialTests/SpatialScrollDragDeltaTests.swift
@@ -1,0 +1,34 @@
+@testable import WebSpatial
+import XCTest
+
+final class SpatialScrollDragDeltaTests: XCTestCase {
+    func test_horizontalDragProducesHorizontalScrollDelta() {
+        let delta = spatialScrollDelta(
+            from: CGSize(width: 40, height: 25),
+            to: CGSize(width: 10, height: 25)
+        )
+
+        XCTAssertEqual(delta.x, 30)
+        XCTAssertEqual(delta.y, 0)
+    }
+
+    func test_verticalDragBehaviorIsPreserved() {
+        let delta = spatialScrollDelta(
+            from: CGSize(width: 10, height: 40),
+            to: CGSize(width: 10, height: 15)
+        )
+
+        XCTAssertEqual(delta.x, 0)
+        XCTAssertEqual(delta.y, 25)
+    }
+
+    func test_diagonalDragProducesBothScrollDeltas() {
+        let delta = spatialScrollDelta(
+            from: CGSize(width: 50, height: 80),
+            to: CGSize(width: 20, height: 35)
+        )
+
+        XCTAssertEqual(delta.x, 30)
+        XCTAssertEqual(delta.y, 45)
+    }
+}


### PR DESCRIPTION
## Summary

- forward both horizontal and vertical drag deltas from SpatialDiv surfaces to the parent page scroll view
- add native regression coverage for horizontal, vertical, and diagonal drag deltas
- expand the test-server `#/nested-scroll` route into a deterministic two-axis scroll matrix
- add a patch changeset for `@webspatial/platform-visionos`

## Root cause

`Spatialized2DElementView` stored only `gesture.translation.height` and always sent `Vec2(x: 0, y: delta)` to `SpatialScene`. The downstream scroll state already supports both axes, but the horizontal component was discarded at the gesture boundary.

## User impact

Dragging a SpatialDiv horizontally or diagonally now updates the parent page scroll offset on both axes, so the SpatialDiv remains aligned with the page during horizontal movement.

The test-server page includes Origin, Horizontal, Vertical, and Diagonal checkpoints plus live X/Y scroll coordinates for repeatable simulator and browser verification.

## Validation

- Apple Vision Pro simulator (visionOS 26.5): 3 native scroll-delta tests passed
- `pnpm exec tsc -p apps/test-server/tsconfig.json --noEmit`
- `pnpm exec prettier --check apps/test-server/src/pages/nestedscroll/index.tsx apps/test-server/src/components/Sidebar.tsx`
- browser regression: Horizontal reached `X=1126, Y=0`; Diagonal reached `X=1126, Y=935`
- `git diff --check`

Closes #715