### PR TITLE
feat: Model support blob URLs web changes

### DIFF
--- a/.changeset/cool-towns-hug.md
+++ b/.changeset/cool-towns-hug.md
@@ -1,0 +1,6 @@
+---
+'web-content': minor
+'@webspatial/core-sdk': minor
+---
+
+Model add blob URL support

--- a/apps/test-server/esbuild.mjs
+++ b/apps/test-server/esbuild.mjs
@@ -194,6 +194,10 @@ if (isBuild) {
     cache: -1, // Disable caching
     port: port, // Define the port
     before: [spaFallback],
+    mimetypes: {
+      'model/vnd.usdz+zip': ['usdz'],
+      'model/gltf-binary': ['glb'],
+    },
   })
   staticServer.server.on('error', err => {
     if (err?.code === 'EADDRINUSE') {

--- a/apps/test-server/src/pages/static-3d-model/Logger.tsx
+++ b/apps/test-server/src/pages/static-3d-model/Logger.tsx
@@ -24,8 +24,8 @@ export function Logger({ logs, clearLog }: LoggerProps) {
         <h2 className="m-0">Console</h2>
         <button onClick={clearLog}>Clear Log</button>
         <div className="mockup-code max-w-2xl not-prose">
-          {logs.map(log => (
-            <pre data-prefix="">
+          {logs.map((log, index) => (
+            <pre key={index} data-prefix="">
               <code>{log}</code>
             </pre>
           ))}

--- a/apps/test-server/src/pages/static-3d-model/index.tsx
+++ b/apps/test-server/src/pages/static-3d-model/index.tsx
@@ -185,7 +185,7 @@ function App() {
         }}
       >
         <source
-          src="https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz"
+          src="https://developer.apple.com/quick-look-gallery/models/drummertoy/toy_drummer.usdz"
           type="model/vnd.usdz+zip"
         />
         <img

--- a/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
+++ b/apps/test-server/src/pages/static-3d-model/nested-ready.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Logger, useLogger } from './Logger'
 
 const MODEL_SRC =
-  'https://developer.apple.com/augmented-reality/quick-look/models/drummertoy/toy_drummer.usdz'
+  'https://developer.apple.com/quick-look-gallery/models/drummertoy/toy_drummer.usdz'
 
 function describeCurrentTarget(event: ModelLoadEvent) {
   return {
@@ -143,6 +143,56 @@ export default function NestedStatic3DModelReady() {
       </div>
 
       <Logger logs={logs} clearLog={clearLog} />
+      <h1>Model with blob URL</h1>
+      <BlobModel src="/modelasset/cone.usdz">
+        <source
+          src="/modelasset/MaterialsVariantsShoe.glb"
+          type="model/gltf-binary"
+        />
+      </BlobModel>
     </div>
+  )
+}
+
+type BlobModelProps = React.PropsWithChildren<{
+  src: string
+  poster?: string
+  type?: string
+}>
+function BlobModel({ src, poster, type, children }: BlobModelProps) {
+  const [blobSrc, setBlobSrc] = useState<string>()
+  const [isFetching, setIsFetching] = useState(false)
+  useEffect(() => {
+    let objectURL: string | undefined
+    let cancelled = false
+    setIsFetching(true)
+    fetch(src)
+      .then(res => res.blob())
+      .then(blob => {
+        if (cancelled) return
+        objectURL = URL.createObjectURL(blob)
+        setBlobSrc(objectURL)
+        setIsFetching(false)
+      })
+    return () => {
+      cancelled = true
+      if (objectURL) URL.revokeObjectURL(objectURL)
+    }
+  }, [])
+  return isFetching ? (
+    <p style={{ height: 200 }}>Is fetching {`${isFetching}`}</p>
+  ) : (
+    <Model
+      poster={poster}
+      enable-xr
+      style={{
+        height: '200px',
+        '--xr-depth': '100px',
+        '--xr-back': '50px',
+      }}
+    >
+      <source src={blobSrc} type={type} />
+      {children}
+    </Model>
   )
 }

--- a/packages/core/src/JSBCommand.ts
+++ b/packages/core/src/JSBCommand.ts
@@ -768,3 +768,86 @@ export class ControlSpatializedElementAnimationJSBCommand extends JSBCommand {
     }
   }
 }
+
+export interface StartBlobTransferParams {
+  requestId: string
+  src: string
+  mimeType: string
+  size: number
+}
+
+export class StartBlobTransferCommand extends SpatializedElementCommand {
+  commandType = 'StartBlobTransfer'
+
+  constructor(
+    spatialObject: SpatialObject,
+    private params: StartBlobTransferParams,
+  ) {
+    super(spatialObject)
+  }
+
+  protected getExtraParams() {
+    return { ...this.params }
+  }
+}
+
+export interface TransferBlobChunkParams {
+  requestId: string
+  /** Byte offset of this base64-encoded chunk in the Blob. */
+  offset: number
+  data: string
+}
+
+export class TransferBlobChunkCommand extends SpatializedElementCommand {
+  commandType = 'TransferBlobChunk'
+
+  constructor(
+    spatialObject: SpatialObject,
+    private params: TransferBlobChunkParams,
+  ) {
+    super(spatialObject)
+  }
+
+  protected getExtraParams() {
+    return { ...this.params }
+  }
+}
+
+export interface CompleteBlobTransferParams {
+  requestId: string
+}
+
+export class CompleteBlobTransferCommand extends SpatializedElementCommand {
+  commandType = 'CompleteBlobTransfer'
+
+  constructor(
+    spatialObject: SpatialObject,
+    private params: CompleteBlobTransferParams,
+  ) {
+    super(spatialObject)
+  }
+
+  protected getExtraParams() {
+    return { ...this.params }
+  }
+}
+
+export interface FailBlobTransferParams {
+  requestId: string
+  message?: string
+}
+
+export class FailBlobTransferCommand extends SpatializedElementCommand {
+  commandType = 'FailBlobTransfer'
+
+  constructor(
+    spatialObject: SpatialObject,
+    private params: FailBlobTransferParams,
+  ) {
+    super(spatialObject)
+  }
+
+  protected getExtraParams() {
+    return { ...this.params }
+  }
+}

--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -9,11 +9,13 @@ import {
 import {
   ModelLoadSuccess,
   ModelLoadFailure,
+  ModelBlobRequestMsg,
   SpatialWebMsgType,
   AnimationStateChangeDetail,
   AnimationStateChangeMsg,
   EntityTransformChangeMsg,
 } from './WebMsgCommand'
+import { transferBlob } from './blob/blobTransfer'
 
 /**
  * Represents a static 3D model element in the spatial environment.
@@ -309,6 +311,14 @@ export class SpatializedStatic3DElement extends SpatializedElement {
       this._onAnimationStateChangeCallback?.(data.detail)
     } else if (data.type === SpatialWebMsgType.entitytransformchange) {
       this._entityTransform = new DOMMatrixReadOnly(data.detail.transform)
+    } else if (data.type === SpatialWebMsgType.modelblobrequest) {
+      // Ship the blob bytes to native on demand. Fire-and-forget: the transfer
+      // reports progress and errors over its own JSB channel.
+      void transferBlob({
+        element: this,
+        requestId: data.detail.requestId,
+        src: data.detail.src,
+      })
     } else {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data)
@@ -415,6 +425,7 @@ function clamp(num: number, min: number, max: number) {
 type Static3DReceiveEventData =
   | ModelLoadSuccess
   | ModelLoadFailure
+  | ModelBlobRequestMsg
   | ReceiveEventData
   | AnimationStateChangeMsg
   | EntityTransformChangeMsg

--- a/packages/core/src/WebMsgCommand.ts
+++ b/packages/core/src/WebMsgCommand.ts
@@ -30,6 +30,9 @@ export enum SpatialWebMsgType {
   animationfailed = 'animationfailed',
 
   objectdestroy = 'objectdestroy',
+
+  // Native asks JS to ship a `blob:` source's bytes (native cannot fetch blobs).
+  modelblobrequest = 'modelblobrequest',
 }
 
 export interface ObjectDestroyMsg {
@@ -84,6 +87,18 @@ export interface ModelLoadSuccess {
 
 export interface ModelLoadFailure {
   type: SpatialWebMsgType.modelloadfailed
+}
+
+export interface ModelBlobRequestDetail {
+  /** Unique, non-reused identifier for this source attempt. */
+  requestId: string
+  /** The `blob:` URL native wants the bytes for. */
+  src: string
+}
+
+export interface ModelBlobRequestMsg {
+  type: SpatialWebMsgType.modelblobrequest
+  detail: ModelBlobRequestDetail
 }
 
 export interface AnimationStateChangeDetail {

--- a/packages/core/src/blob/blobTransfer.test.ts
+++ b/packages/core/src/blob/blobTransfer.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { transferBlob } from './blobTransfer'
+
+interface CommandResult {
+  success: boolean
+  errorMessage?: string
+}
+
+const commandState = vi.hoisted(() => ({
+  calls: [] as Array<Record<string, unknown>>,
+  chunkResult: { success: true } as CommandResult,
+  deferChunkAcknowledgements: false,
+  chunkResolvers: [] as Array<(result: CommandResult) => void>,
+}))
+
+vi.mock('../JSBCommand', () => ({
+  StartBlobTransferCommand: class {
+    constructor(
+      private element: { id: string },
+      private params: Record<string, unknown>,
+    ) {}
+
+    execute() {
+      commandState.calls.push({
+        command: 'StartBlobTransfer',
+        id: this.element.id,
+        ...this.params,
+      })
+      return Promise.resolve({ success: true })
+    }
+  },
+  TransferBlobChunkCommand: class {
+    constructor(
+      private element: { id: string },
+      private params: Record<string, unknown>,
+    ) {}
+
+    execute() {
+      commandState.calls.push({
+        command: 'TransferBlobChunk',
+        id: this.element.id,
+        ...this.params,
+      })
+      if (!commandState.deferChunkAcknowledgements) {
+        return Promise.resolve(commandState.chunkResult)
+      }
+      return new Promise<CommandResult>(resolve => {
+        commandState.chunkResolvers.push(resolve)
+      })
+    }
+  },
+  CompleteBlobTransferCommand: class {
+    constructor(
+      private element: { id: string },
+      private params: Record<string, unknown>,
+    ) {}
+
+    execute() {
+      commandState.calls.push({
+        command: 'CompleteBlobTransfer',
+        id: this.element.id,
+        ...this.params,
+      })
+      return Promise.resolve({ success: true })
+    }
+  },
+  FailBlobTransferCommand: class {
+    constructor(
+      private element: { id: string },
+      private params: Record<string, unknown>,
+    ) {}
+
+    execute() {
+      commandState.calls.push({
+        command: 'FailBlobTransfer',
+        id: this.element.id,
+        ...this.params,
+      })
+      return Promise.resolve({ success: true })
+    }
+  },
+}))
+
+const element = { id: 'model-1' } as any
+const requestId = 'request-1'
+const src = 'blob:https://example.com/model'
+const success = (): CommandResult => ({ success: true })
+
+function fetchBlob(blob: Blob) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) }),
+  )
+}
+
+describe('transferBlob', () => {
+  beforeEach(() => {
+    commandState.calls.length = 0
+    commandState.chunkResult = success()
+    commandState.deferChunkAcknowledgements = false
+    commandState.chunkResolvers.length = 0
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps at most four chunks in flight through native acknowledgement', async () => {
+    fetchBlob(new Blob([new Uint8Array(10 * 1024 * 1024)]))
+    commandState.deferChunkAcknowledgements = true
+    const encodeChunk = vi.fn(async () => '')
+
+    const transfer = transferBlob({ element, requestId, src }, { encodeChunk })
+
+    await vi.waitFor(() => {
+      expect(commandState.chunkResolvers).toHaveLength(4)
+    })
+    expect(
+      commandState.calls
+        .filter(call => call.command === 'TransferBlobChunk')
+        .map(call => call.offset),
+    ).toEqual([0, 2 * 1024 * 1024, 4 * 1024 * 1024, 6 * 1024 * 1024])
+
+    commandState.chunkResolvers.shift()!(success())
+    await vi.waitFor(() => {
+      expect(
+        commandState.calls.filter(call => call.command === 'TransferBlobChunk'),
+      ).toHaveLength(5)
+    })
+    expect(commandState.chunkResolvers).toHaveLength(4)
+
+    for (const resolve of commandState.chunkResolvers.splice(0)) {
+      resolve(success())
+    }
+    await transfer
+
+    expect(commandState.calls.at(-1)).toEqual({
+      command: 'CompleteBlobTransfer',
+      id: 'model-1',
+      requestId,
+    })
+  })
+
+  it('starts and immediately completes a zero-byte blob', async () => {
+    fetchBlob(new Blob([], { type: 'model/vnd.usdz+zip' }))
+    const encodeChunk = vi.fn(async () => '')
+
+    await transferBlob({ element, requestId, src }, { encodeChunk })
+
+    expect(commandState.calls).toEqual([
+      {
+        command: 'StartBlobTransfer',
+        id: 'model-1',
+        requestId,
+        src,
+        mimeType: 'model/vnd.usdz+zip',
+        size: 0,
+      },
+      {
+        command: 'CompleteBlobTransfer',
+        id: 'model-1',
+        requestId,
+      },
+    ])
+    expect(encodeChunk).not.toHaveBeenCalled()
+  })
+
+  it('stops scheduling when native rejects an in-flight chunk', async () => {
+    fetchBlob(new Blob([new Uint8Array(10 * 1024 * 1024)]))
+    commandState.chunkResult = {
+      success: false,
+      errorMessage: 'native cancelled',
+    }
+    const encodeChunk = vi.fn(async () => '')
+
+    await transferBlob({ element, requestId, src }, { encodeChunk })
+
+    expect(encodeChunk).toHaveBeenCalledTimes(4)
+    expect(commandState.calls.at(-1)).toEqual({
+      command: 'FailBlobTransfer',
+      id: 'model-1',
+      requestId,
+      message: 'native cancelled',
+    })
+    expect(
+      commandState.calls.some(call => call.command === 'CompleteBlobTransfer'),
+    ).toBe(false)
+  })
+
+  it('reports a fetch failure without starting the transfer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('revoked')))
+
+    await transferBlob({ element, requestId, src })
+
+    expect(commandState.calls).toEqual([
+      {
+        command: 'FailBlobTransfer',
+        id: 'model-1',
+        requestId,
+        message: 'revoked',
+      },
+    ])
+  })
+})

--- a/packages/core/src/blob/blobTransfer.ts
+++ b/packages/core/src/blob/blobTransfer.ts
@@ -1,0 +1,132 @@
+import {
+  CompleteBlobTransferCommand,
+  FailBlobTransferCommand,
+  StartBlobTransferCommand,
+  TransferBlobChunkCommand,
+} from '../JSBCommand'
+import { SpatialObject } from '../SpatialObject'
+
+/** Bytes per chunk shipped over the (string-only) bridge. */
+const CHUNK_SIZE = 2 * 1024 * 1024 // 2 MiB
+const MAX_IN_FLIGHT = 4
+
+export interface TransferBlobOptions {
+  /** The element whose transfer this is; supplies the id native routes chunks on. */
+  element: SpatialObject
+  /** Which native source attempt these bytes belong to. */
+  requestId: string
+  /** The `blob:` URL to ship. */
+  src: string
+}
+
+interface TransferBlobDependencies {
+  encodeChunk: (slice: Blob) => Promise<string>
+}
+
+/**
+ * Fetches a blob URL and streams it to native with bounded parallelism.
+ *
+ * At most four operations are in flight from slice encoding through native
+ * acknowledgement. The first failure stops new scheduling; already-started
+ * operations settle before a best-effort terminal error is sent.
+ *
+ * Component-agnostic: it only needs an element, request ID, and blob URL, so it
+ * can back blob transfers for components other than `<Model>` later.
+ */
+export async function transferBlob(
+  { element, requestId, src }: TransferBlobOptions,
+  { encodeChunk = encodeBase64 }: Partial<TransferBlobDependencies> = {},
+): Promise<void> {
+  try {
+    const response = await fetch(src)
+    const blob = await response.blob()
+    ensureSuccess(
+      await new StartBlobTransferCommand(element, {
+        requestId,
+        src,
+        mimeType: blob.type,
+        size: blob.size,
+      }).execute(),
+    )
+
+    let nextOffset = 0
+    let firstError: Error | undefined
+    const operationCount = Math.min(
+      MAX_IN_FLIGHT,
+      Math.ceil(blob.size / CHUNK_SIZE),
+    )
+
+    const pump = async () => {
+      while (firstError === undefined) {
+        const offset = nextOffset
+        if (offset >= blob.size) return
+        nextOffset += CHUNK_SIZE
+
+        try {
+          const data = await encodeChunk(
+            blob.slice(offset, offset + CHUNK_SIZE),
+          )
+          ensureSuccess(
+            await new TransferBlobChunkCommand(element, {
+              requestId,
+              offset,
+              data,
+            }).execute(),
+          )
+        } catch (error) {
+          firstError ??= toError(error)
+        }
+      }
+    }
+
+    await Promise.all(Array.from({ length: operationCount }, pump))
+    if (firstError) throw firstError
+
+    ensureSuccess(
+      await new CompleteBlobTransferCommand(element, {
+        requestId,
+      }).execute(),
+    )
+  } catch (error) {
+    await sendError(element, requestId, toError(error).message)
+  }
+}
+
+/** Base64-encodes a blob slice without materialising the bytes as a string. */
+function encodeBase64(slice: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      // `readAsDataURL` yields `data:<type>;base64,<payload>`; keep the payload.
+      const result = reader.result as string
+      resolve(result.slice(result.indexOf(',') + 1))
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(slice)
+  })
+}
+
+function ensureSuccess(result: { success: boolean; errorMessage?: string }) {
+  if (!result.success) {
+    throw new Error(result.errorMessage || 'Blob transfer command failed')
+  }
+}
+
+async function sendError(
+  element: SpatialObject,
+  requestId: string,
+  message: string,
+) {
+  try {
+    await new FailBlobTransferCommand(element, {
+      requestId,
+      message,
+    }).execute()
+  } catch {
+    // Best effort: native may already have invalidated this request.
+  }
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/packages/core/src/jsbcommand.coverage.test.ts
+++ b/packages/core/src/jsbcommand.coverage.test.ts
@@ -141,6 +141,10 @@ describe('JSBCommand', () => {
       AddSpatializedElementToSpatialScene,
       AddSpatializedElementToSpatialized2DElement,
       UpdateUnlitMaterialProperties,
+      StartBlobTransferCommand,
+      TransferBlobChunkCommand,
+      CompleteBlobTransferCommand,
+      FailBlobTransferCommand,
     } = mod
 
     const obj = { id: 'so-1' } as any
@@ -207,6 +211,59 @@ describe('JSBCommand', () => {
     expect(platformSpy.callJSB).toHaveBeenCalledWith(
       'UpdateUnlitMaterialProperties',
       JSON.stringify({ id: 'so-1', color: '#fff' }),
+    )
+
+    await new StartBlobTransferCommand(obj, {
+      requestId: 'request-1',
+      src: 'blob:https://example.com/model',
+      mimeType: 'model/gltf-binary',
+      size: 6,
+    }).execute()
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'StartBlobTransfer',
+      JSON.stringify({
+        id: 'so-1',
+        requestId: 'request-1',
+        src: 'blob:https://example.com/model',
+        mimeType: 'model/gltf-binary',
+        size: 6,
+      }),
+    )
+
+    await new TransferBlobChunkCommand(obj, {
+      requestId: 'request-1',
+      offset: 3,
+      data: 'ZGVm',
+    }).execute()
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'TransferBlobChunk',
+      JSON.stringify({
+        id: 'so-1',
+        requestId: 'request-1',
+        offset: 3,
+        data: 'ZGVm',
+      }),
+    )
+
+    await new CompleteBlobTransferCommand(obj, {
+      requestId: 'request-1',
+    }).execute()
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'CompleteBlobTransfer',
+      JSON.stringify({ id: 'so-1', requestId: 'request-1' }),
+    )
+
+    await new FailBlobTransferCommand(obj, {
+      requestId: 'request-1',
+      message: 'failed',
+    }).execute()
+    expect(platformSpy.callJSB).toHaveBeenCalledWith(
+      'FailBlobTransfer',
+      JSON.stringify({
+        id: 'so-1',
+        requestId: 'request-1',
+        message: 'failed',
+      }),
     )
   })
 })


### PR DESCRIPTION
Fetch the blob URL and transfer over JSB in small chunks. Chunks are sent in parallel.

```jsx
function BlobModel({ src, type }: BlobModelProps) {
  const [blobSrc, setBlobSrc] = useState<string>()
  useEffect(() => {
    fetch(src)
      .then(res => res.blob())
      .then(blob => setBlobSrc(URL.createObjectURL(blob)))
  }, [])
  return (
    <Model enable-xr style={{ height: '200px' }}>
      <source src={blobSrc} type={type}  />
    </Model>
  )
}
```


https://github.com/user-attachments/assets/23dab59b-1639-437c-9d80-f38e7cadd121

