### PR TITLE
Fix/ornament experimental types

### DIFF
--- a/.changeset/fix-ornament-experimental-types.md
+++ b/.changeset/fix-ornament-experimental-types.md
@@ -1,0 +1,9 @@
+---
+'@webspatial/react-sdk': patch
+---
+
+Keep the React Ornament component API scoped to the experimental entry.
+
+- Export `Ornament`, `OrnamentProps`, `OrnamentPoint3D`, and `OrnamentVisibility` from `@webspatial/react-sdk/experimental`.
+- Remove Ornament-specific helper type re-exports from the default `@webspatial/react-sdk` entry.
+- Make `OrnamentProps` explicitly describe the React component props instead of deriving from the Core SDK `OrnamentOptions` runtime type.

--- a/.changeset/fix-ornament-experimental-types.md
+++ b/.changeset/fix-ornament-experimental-types.md
@@ -3,7 +3,3 @@
 ---
 
 Keep the React Ornament component API scoped to the experimental entry.
-
-- Export `Ornament`, `OrnamentProps`, `OrnamentPoint3D`, and `OrnamentVisibility` from `@webspatial/react-sdk/experimental`.
-- Remove Ornament-specific helper type re-exports from the default `@webspatial/react-sdk` entry.
-- Make `OrnamentProps` explicitly describe the React component props instead of deriving from the Core SDK `OrnamentOptions` runtime type.

--- a/apps/test-server/src/pages/ornament-test/index.tsx
+++ b/apps/test-server/src/pages/ornament-test/index.tsx
@@ -4,10 +4,12 @@ import {
   Reality,
   type BackgroundMaterialType,
   type CornerRadius,
+} from '@webspatial/react-sdk'
+import {
+  Ornament,
   type OrnamentPoint3D,
   type OrnamentVisibility,
-} from '@webspatial/react-sdk'
-import { Ornament } from '@webspatial/react-sdk/experimental'
+} from '@webspatial/react-sdk/experimental'
 
 const POINTS: OrnamentPoint3D[] = [
   'topLeadingFront',

--- a/packages/react/src/__tests__/experimental-entry-shape.test.ts
+++ b/packages/react/src/__tests__/experimental-entry-shape.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it } from 'vitest'
 import * as ExperimentalEntry from '../experimental'
+import type {
+  OrnamentPoint3D,
+  OrnamentProps,
+  OrnamentVisibility,
+} from '../experimental'
+
+type OrnamentTypeSurface = Pick<
+  OrnamentProps,
+  'attachmentAnchor' | 'contentAlignment' | 'visibility'
+>
+
+const ornamentTypeSurface: OrnamentTypeSurface = {
+  attachmentAnchor: 'bottom' satisfies OrnamentPoint3D,
+  contentAlignment: 'back' satisfies OrnamentPoint3D,
+  visibility: 'visible' satisfies OrnamentVisibility,
+}
 
 describe('experimental-entry public surface', () => {
   describe('Opt-in unstable runtime exports', () => {
     it('exports `Ornament` as a defined runtime value', () => {
       expect(ExperimentalEntry.Ornament).toBeDefined()
       expect(typeof ExperimentalEntry.Ornament).toBe('function')
+    })
+
+    it('keeps Ornament prop helper types available from the experimental entry', () => {
+      expect(ornamentTypeSurface).toEqual({
+        attachmentAnchor: 'bottom',
+        contentAlignment: 'back',
+        visibility: 'visible',
+      })
     })
   })
 

--- a/packages/react/src/default-entry-public-surface.test.ts
+++ b/packages/react/src/default-entry-public-surface.test.ts
@@ -232,6 +232,16 @@ describe('default-entry public surface (spec tasks.md §7.1 / §7.2 / §7.3 / §
       const matches = sourceNoComments.match(/export const version\s*=/g) ?? []
       expect(matches.length).toBe(1)
     })
+
+    it('does NOT re-export experimental Ornament type helpers', () => {
+      for (const typeName of [
+        'OrnamentOptions',
+        'OrnamentPoint3D',
+        'OrnamentVisibility',
+      ]) {
+        expect(sourceNoComments).not.toMatch(new RegExp(`\\b${typeName}\\b`))
+      }
+    })
   })
 
   describe('Facade vs real-impl identity', () => {

--- a/packages/react/src/experimental.ts
+++ b/packages/react/src/experimental.ts
@@ -9,8 +9,11 @@ import { registerReactSdkEntry } from './runtime/entryRegistry'
 registerReactSdkEntry('lazy')
 
 export { Ornament } from './facades/Ornament'
-export type { OrnamentProps } from './facades/Ornament'
-export type { OrnamentPoint3D, OrnamentVisibility } from '@webspatial/core-sdk'
+export type {
+  OrnamentPoint3D,
+  OrnamentProps,
+  OrnamentVisibility,
+} from './facades/Ornament'
 export { useAnimation } from './hooks-web/useAnimation'
 export { useEntityAnimation } from './hooks-web/useEntityAnimation'
 export type {

--- a/packages/react/src/experimental.ts
+++ b/packages/react/src/experimental.ts
@@ -10,6 +10,7 @@ registerReactSdkEntry('lazy')
 
 export { Ornament } from './facades/Ornament'
 export type { OrnamentProps } from './facades/Ornament'
+export type { OrnamentPoint3D, OrnamentVisibility } from '@webspatial/core-sdk'
 export { useAnimation } from './hooks-web/useAnimation'
 export { useEntityAnimation } from './hooks-web/useEntityAnimation'
 export type {

--- a/packages/react/src/facades/Ornament.tsx
+++ b/packages/react/src/facades/Ornament.tsx
@@ -7,7 +7,11 @@ import { WebSpatialRuntime } from '../webSpatialRuntime'
 import { warnBootForgotten } from './shared/warnBootForgotten'
 import type { OrnamentProps } from '../ornament'
 
-export type { OrnamentProps }
+export type {
+  OrnamentPoint3D,
+  OrnamentProps,
+  OrnamentVisibility,
+} from '../ornament'
 
 export function Ornament(props: OrnamentProps): React.ReactElement | null {
   const ready = useSpatialReady()

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -122,10 +122,6 @@ export type {
   // Attachment options.
   AttachmentEntityOptions,
   AttachmentEntityUpdateOptions,
-  // Ornament options.
-  OrnamentOptions,
-  OrnamentPoint3D,
-  OrnamentVisibility,
   // PWA manifest + scene config (used by builder tooling and consumer
   // manifest authoring).
   XRSceneSize,

--- a/packages/react/src/ornament/Ornament.tsx
+++ b/packages/react/src/ornament/Ornament.tsx
@@ -14,7 +14,6 @@ import {
   normalizeOrnamentOptions,
   type BackgroundMaterialType,
   type CornerRadius,
-  type OrnamentOptions,
   type OrnamentPoint3D,
   type OrnamentVisibility,
 } from '@webspatial/core-sdk'
@@ -35,9 +34,13 @@ type OrnamentStyle = CSSProperties & {
   [ORNAMENT_BACKGROUND_MATERIAL_STYLE_VAR]?: BackgroundMaterialType
 }
 
-type OrnamentPublicOptions = Omit<OrnamentOptions, 'backgroundMaterial'>
-
-export type OrnamentProps = OrnamentPublicOptions & {
+export type OrnamentProps = {
+  attachmentAnchor?: OrnamentPoint3D
+  contentAlignment?: OrnamentPoint3D
+  visibility?: OrnamentVisibility
+  width?: number
+  height?: number
+  cornerRadius?: Partial<CornerRadius>
   children: ReactNode
   style?: OrnamentStyle
 }
@@ -90,10 +93,8 @@ const UNITLESS_STYLE_PROPERTIES = new Set([
 
 function getOrnamentStyleBackgroundMaterial(
   style: OrnamentStyle | undefined,
-): OrnamentOptions['backgroundMaterial'] {
-  return style?.[ORNAMENT_BACKGROUND_MATERIAL_STYLE_VAR] as
-    | OrnamentOptions['backgroundMaterial']
-    | undefined
+): BackgroundMaterialType | undefined {
+  return style?.[ORNAMENT_BACKGROUND_MATERIAL_STYLE_VAR]
 }
 
 function hyphenateStyleName(name: string) {


### PR DESCRIPTION
## Summary

This PR tightens the React SDK Ornament API boundary so the React-facing Ornament component and helper types are only exposed from `@webspatial/react-sdk/experimental`.

Changes:
- Make `OrnamentProps` explicitly declare the React component props instead of deriving from `Omit<OrnamentOptions, 'backgroundMaterial'>`.
- Export `Ornament`, `OrnamentProps`, `OrnamentPoint3D`, and `OrnamentVisibility` from `@webspatial/react-sdk/experimental` through the Ornament facade.
- Remove Ornament-specific helper type re-exports from the default `@webspatial/react-sdk` entry.
- Update the Ornament test-server demo to import Ornament component/types from the experimental entry.
- Add export-surface tests to verify:
  - experimental entry exposes the Ornament helper types;
  - default entry does not re-export experimental Ornament helper types.

## Motivation

`OrnamentOptions` is a Core runtime options type, while `<Ornament />` has a React-specific public API. In particular, React-facing material configuration is expressed through `style['--xr-background-material']`, not a direct `backgroundMaterial` prop.

Explicitly declaring `OrnamentProps` avoids coupling the React component API to the Core runtime options bag and keeps the experimental Ornament surface isolated to the experimental entry.

## Validation

```bash
pnpm --filter @webspatial/react-sdk test cd apps/test-server && pnpm test
```

Results:
- React SDK: `51 files / 605 tests passed`
- test-server: `tsc` passed