### PR TITLE
fix: changing Model source from empty value doesn't re-render (#1339)

### DIFF
--- a/.changeset/slow-bats-watch.md
+++ b/.changeset/slow-bats-watch.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': minor
+---
+
+fix changing Model source from empty value not re-rendering

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -49,13 +49,16 @@ struct SpatializedStatic3DView: View {
                             .if(enableGesture) { view in view.hoverEffect() }
                     }
                 case .failed:
-                    posterView {}
+                    posterView {
+                        // Transparent view is required so that lifecycle modifiers like .task still work
+                        Color.clear
+                    }
                 }
             }
             .scaleEffect(scale)
             .rotation3DEffect(rotation)
             .orbit(
-                enabled: spatializedStatic3DElement.stagemode == .orbit,
+                enabled: spatializedStatic3DElement.stagemode == .orbit && asset != nil,
                 entityTransform: $spatializedStatic3DElement.entityTransform,
                 onChange: onOrbit
             )


### PR DESCRIPTION
When sources is empty the `posterView {}` is rendered which resolves to `EmptyView` if no poster is provided. Consequently, the `Group` containing `.task(id:)` has no actual child in the view hierarchy. When sources later changes, there is no appearing view on which SwiftUI can restart the task

Cherry pick a5a5de830a08e3ad17bf5000ba964e4967753fce