### PR TITLE
fix(ci): npm 12 breaks new version publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -43,7 +43,8 @@ jobs:
           cache: "pnpm"
 
       - name: Update npm
-        run: npm install -g npm@'>=11.5.1'
+        # npm 12 doesn't work with pnpm 9
+        run: npm install -g npm@'^11.5.1'
 
       - name: Install dependencies and build
         run: pnpm run setup


### PR DESCRIPTION
npm >=11.5.1 now installs npm 12 which introduced a breaking change of rejecting unknown flags. `pnpm publish --no-git-checks` and pnpm 9 forwards the flag `--no-git-checks` to npm which it doesn't understand. Fix npm to version 11 to resolve the publishing error.