### PR TITLE
chore: upgrade Node.js 22 to 24

### DIFF
--- a/.changeset/bitter-moose-rescue.md
+++ b/.changeset/bitter-moose-rescue.md
@@ -1,0 +1,6 @@
+---
+'@webspatial/platform-visionos': major
+'@webspatial/builder': major
+---
+
+Upgrade minimum Node.js version from 22 to 24

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -38,13 +38,9 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
-
-      - name: Update npm
-        # npm 12 doesn't work with pnpm 9
-        run: npm install -g npm@'^11.5.1'
 
       - name: Install dependencies and build
         run: pnpm run setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24, latest]
+        node-version: [24, latest]
     steps:
       - name: Checkout code repository
         uses: actions/checkout@v5

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
       
       - name: Install dependencies and build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to WebSpatial! This document provide
 
 ### Required Tools
 
-- [Node.js 22+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
+- [Node.js 24+](https://nodejs.org/en/download/package-manager) and pnpm 9+ to install dependencies and run the local test website
 - [Xcode 26.x](https://apps.apple.com/us/app/xcode/id497799835?mt=12) with the Apple Vision Pro simulator (current CI selects Xcode 26.3 for visionOS builds)
 - [VSCode](https://code.visualstudio.com/) Text editor (recommended)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WebSpatial is a set of [minimal extensions to HTML/CSS/DOM APIs](https://tpac202
 
 ## Requirements
 
-- Node.js 22 or newer
+- Node.js 24 or newer
 - pnpm 9 or newer
 
 ## Documentation

--- a/apps/spatial-next-eager-min/package.json
+++ b/apps/spatial-next-eager-min/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "typescript": "^5.7.3"

--- a/apps/spatial-next-min/package.json
+++ b/apps/spatial-next-min/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "typescript": "^5.7.3"

--- a/apps/spatial-remix-min/package.json
+++ b/apps/spatial-remix-min/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@react-router/dev": "7.15.0",
     "@tailwindcss/vite": "^4.2.2",
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "tailwindcss": "^4.2.2",

--- a/apps/spatial-rspack-min/package.json
+++ b/apps/spatial-rspack-min/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@rspack/cli": "^1.5.8",
     "@rspack/core": "^1.5.8",
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "typescript": "^5.7.3"

--- a/apps/spatial-vite-min/package.json
+++ b/apps/spatial-vite-min/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.3.1",

--- a/apps/test-server/src/pages/entity-animation/shared.tsx
+++ b/apps/test-server/src/pages/entity-animation/shared.tsx
@@ -140,7 +140,7 @@ export function EntityAnimationOverview() {
         <Link
           key={route.path}
           to={route.path}
-          data-name={`entity-motion-route-${route.path.split('/').at(-1)}`}
+          data-name={`entity-motion-route-${route.path.split('/').slice(-1)[0]}`}
           className="rounded-2xl border border-gray-800 bg-[#111] p-5 transition-colors hover:border-blue-700 hover:bg-[#141414]"
         >
           <div className="text-lg font-semibold text-gray-100">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "generateStaticSite": "./tools/scripts/generateWebsite.sh"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "pnpm": ">=9"
   },
   "simple-git-hooks": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Client CLI tool to Generate XRApp project for Apple Vision Pro",
   "type": "commonjs",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "bin": {
     "webspatial-builder": "bin/bundlepwa.js"
@@ -67,7 +67,7 @@
     "@types/inquirer": "^8.2.6",
     "@types/mime-types": "^2.1.0",
     "@types/minimist": "^1.2.0",
-    "@types/node": "^12.20.1",
+    "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.5.10",
     "@types/pngjs": "^6.0.5",
     "@types/semver": "^7.3.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -87,7 +87,7 @@
     "@babel/types": "^7.29.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/unist": "^3.0.2",

--- a/packages/visionOS/package.json
+++ b/packages/visionOS/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "package.json",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 2.29.2
       '@fission-ai/openspec':
         specifier: ^1.4.0
-        version: 1.4.0(@types/node@22.15.2)(rxjs@7.8.2)
+        version: 1.4.0(@types/node@24.13.3)(rxjs@7.8.2)
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -97,10 +97,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.15.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.1.8(@types/node@24.13.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
 
   apps/spatial-next-eager-min:
     dependencies:
@@ -121,8 +121,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -152,8 +152,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -196,13 +196,13 @@ importers:
     devDependencies:
       '@react-router/dev':
         specifier: 7.15.0
-        version: 7.15.0(@react-router/serve@7.15.0(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))(yaml@2.8.4)
+        version: 7.15.0(@react-router/serve@7.15.0(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))(yaml@2.8.4)
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.3.0(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.3.0(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -217,7 +217,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   apps/spatial-rspack-min:
     dependencies:
@@ -238,8 +238,8 @@ importers:
         specifier: ^1.5.8
         version: 1.7.11(@swc/helpers@0.5.15)
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -263,8 +263,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -273,13 +273,13 @@ importers:
         version: 18.3.7(@types/react@18.3.21)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   apps/test-server:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: 2.8.0(react-redux@9.2.0(@types/react@18.3.21)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@tailwindcss/typography':
         specifier: ^0.5.15
-        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3)))
+        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3)))
       '@tweenjs/tween.js':
         specifier: ^25.0.0
         version: 25.0.0
@@ -378,7 +378,7 @@ importers:
         version: 6.1.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3))
       three:
         specifier: ^0.164.1
         version: 0.164.1
@@ -409,7 +409,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -424,7 +424,7 @@ importers:
         version: 3.1.4(esbuild@0.25.3)
       esbuild-plugin-tailwindcss:
         specifier: ^1.2.0
-        version: 1.2.3(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3))
+        version: 1.2.3(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3))
       esbuild-sass-plugin:
         specifier: ^3.3.1
         version: 3.3.1(esbuild@0.25.3)(sass-embedded@1.87.0)
@@ -445,7 +445,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   packages/cli:
     dependencies:
@@ -514,8 +514,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.5
       '@types/node':
-        specifier: ^12.20.1
-        version: 12.20.55
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/node-fetch':
         specifier: ^2.5.10
         version: 2.6.12
@@ -587,8 +587,8 @@ importers:
         specifier: ^16.0.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.21
@@ -600,7 +600,7 @@ importers:
         version: 3.0.3
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -639,10 +639,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: 6.4.2
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.15.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@24.1.3)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.1.8(@types/node@24.13.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@24.1.3)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
 
   packages/visionOS: {}
 
@@ -650,7 +650,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.17
-        version: 4.2.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.2.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@webspatial/core-sdk':
         specifier: workspace:*
         version: link:../../packages/core
@@ -674,7 +674,7 @@ importers:
         version: 6.1.17(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.9.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3))
     devDependencies:
       '@types/chai':
         specifier: ^5.2.1
@@ -683,8 +683,8 @@ importers:
         specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: ^22.1.0
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -711,7 +711,7 @@ importers:
         version: 0.5.21
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.15.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@24.13.3)(typescript@5.9.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -720,7 +720,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   tests/ci-test:
     dependencies:
@@ -772,7 +772,7 @@ importers:
         version: 19.1.3(@types/react@19.1.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       eslint:
         specifier: ^9.22.0
         version: 9.26.0(jiti@2.6.1)
@@ -793,13 +793,13 @@ importers:
         version: 8.32.0(eslint@9.26.0(jiti@2.6.1))(typescript@5.7.3)
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   tests/marginal-delta-vite:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@webspatial/core-sdk':
         specifier: workspace:*
         version: link:../../packages/core
@@ -814,14 +814,14 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       vitest:
         specifier: ^3.1.2
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.15.2)(happy-dom@20.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@24.13.3)(happy-dom@20.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     devDependencies:
       '@types/node':
-        specifier: ^22.5.5
-        version: 22.15.2
+        specifier: ^24.0.0
+        version: 24.13.3
       '@types/react':
         specifier: ^18.3.21
         version: 18.3.21
@@ -836,7 +836,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@webspatial/core-sdk':
         specifier: workspace:*
         version: link:../../packages/core
@@ -854,7 +854,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: '>=6.4.2 <7.0.0'
-        version: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     devDependencies:
       '@types/react':
         specifier: ^18.3.21
@@ -867,7 +867,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@22.15.2)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+        version: 6.0.1(vite@8.0.10(@types/node@24.13.3)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@webspatial/core-sdk':
         specifier: workspace:*
         version: link:../../packages/core
@@ -885,7 +885,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.1
-        version: 8.0.10(@types/node@22.15.2)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+        version: 8.0.10(@types/node@24.13.3)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -2662,7 +2662,7 @@ packages:
     resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: 4.60.2
+      rollup: '>=3.30.0'
       tslib: '*'
       typescript: '>=3.7.0'
     peerDependenciesMeta:
@@ -3295,8 +3295,8 @@ packages:
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
-  '@types/node@22.15.2':
-    resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/pngjs@6.0.5':
     resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
@@ -7950,8 +7950,8 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -9104,10 +9104,10 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@fission-ai/openspec@1.4.0(@types/node@22.15.2)(rxjs@7.8.2)':
+  '@fission-ai/openspec@1.4.0(@types/node@24.13.3)(rxjs@7.8.2)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/prompts': 7.10.1(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/prompts': 7.10.1(@types/node@24.13.3)
       chalk: 5.6.2
       commander: 14.0.3
       cross-spawn: 7.0.6
@@ -9326,128 +9326,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@22.15.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@24.13.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/confirm@5.1.21(@types/node@22.15.2)':
+  '@inquirer/confirm@5.1.21(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/core@10.3.2(@types/node@22.15.2)':
+  '@inquirer/core@10.3.2(@types/node@24.13.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/editor@4.2.23(@types/node@22.15.2)':
+  '@inquirer/editor@4.2.23(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/expand@4.0.23(@types/node@22.15.2)':
+  '@inquirer/expand@4.0.23(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.15.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@22.15.2)':
+  '@inquirer/input@4.3.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/number@3.0.23(@types/node@22.15.2)':
+  '@inquirer/number@3.0.23(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/password@4.0.23(@types/node@22.15.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
-    optionalDependencies:
-      '@types/node': 22.15.2
-
-  '@inquirer/prompts@7.10.1(@types/node@22.15.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@22.15.2)
-      '@inquirer/confirm': 5.1.21(@types/node@22.15.2)
-      '@inquirer/editor': 4.2.23(@types/node@22.15.2)
-      '@inquirer/expand': 4.0.23(@types/node@22.15.2)
-      '@inquirer/input': 4.3.1(@types/node@22.15.2)
-      '@inquirer/number': 3.0.23(@types/node@22.15.2)
-      '@inquirer/password': 4.0.23(@types/node@22.15.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@22.15.2)
-      '@inquirer/search': 3.2.2(@types/node@22.15.2)
-      '@inquirer/select': 4.4.2(@types/node@22.15.2)
-    optionalDependencies:
-      '@types/node': 22.15.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@22.15.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.15.2
-
-  '@inquirer/search@3.2.2(@types/node@22.15.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.15.2
-
-  '@inquirer/select@4.4.2(@types/node@22.15.2)':
+  '@inquirer/password@4.0.23(@types/node@24.13.3)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.15.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.15.2)
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/prompts@7.10.1(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.13.3)
+      '@inquirer/confirm': 5.1.21(@types/node@24.13.3)
+      '@inquirer/editor': 4.2.23(@types/node@24.13.3)
+      '@inquirer/expand': 4.0.23(@types/node@24.13.3)
+      '@inquirer/input': 4.3.1(@types/node@24.13.3)
+      '@inquirer/number': 3.0.23(@types/node@24.13.3)
+      '@inquirer/password': 4.0.23(@types/node@24.13.3)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.13.3)
+      '@inquirer/search': 3.2.2(@types/node@24.13.3)
+      '@inquirer/select': 4.4.2(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
-  '@inquirer/type@3.0.10(@types/node@22.15.2)':
+  '@inquirer/search@3.2.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
+
+  '@inquirer/select@4.4.2(@types/node@24.13.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.13.3)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.13.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@inquirer/type@3.0.10(@types/node@24.13.3)':
+    optionalDependencies:
+      '@types/node': 24.13.3
 
   '@javascript-obfuscator/escodegen@2.3.0':
     dependencies:
@@ -10057,7 +10057,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@react-router/dev@7.15.0(@react-router/serve@7.15.0(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))(yaml@2.8.4)':
+  '@react-router/dev@7.15.0(@react-router/serve@7.15.0(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3))(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))(yaml@2.8.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
@@ -10087,8 +10087,8 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.17
       valibot: 1.4.1(typescript@5.9.3)
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     optionalDependencies:
       '@react-router/serve': 7.15.0(react-router@7.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       typescript: 5.9.3
@@ -10646,27 +10646,27 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3)))':
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3))
 
-  '@tailwindcss/vite@4.2.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@tailwindcss/vite@4.2.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
-  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10754,11 +10754,11 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/chai@5.2.2':
     dependencies:
@@ -10771,16 +10771,16 @@ snapshots:
 
   '@types/cli-progress@3.11.6':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.0.6
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/debug@4.1.12':
     dependencies:
@@ -10798,14 +10798,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -10835,7 +10835,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/inquirer@8.2.11':
     dependencies:
@@ -10862,24 +10862,24 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       form-data: 4.0.5
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/node@12.20.55': {}
 
   '@types/node@16.9.1': {}
 
-  '@types/node@22.15.2':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.18.2
 
   '@types/pngjs@6.0.5':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/prop-types@15.7.14': {}
 
@@ -10932,7 +10932,7 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -10941,12 +10941,12 @@ snapshots:
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@types/send': 0.17.4
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/stats.js@0.17.4': {}
 
@@ -10962,7 +10962,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -10982,11 +10982,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
     optional: true
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
@@ -11149,21 +11149,21 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.4.1(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@vitejs/plugin-react@4.4.1(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.1)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@22.15.2)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.13.3)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@22.15.2)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@24.13.3)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -11177,7 +11177,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.15.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+      vitest: 4.1.8(@types/node@24.13.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -11196,21 +11196,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.6(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.6(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
-  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.8(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -11600,7 +11600,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
 
   buffer@5.7.1:
     dependencies:
@@ -12158,12 +12158,12 @@ snapshots:
     dependencies:
       esbuild: 0.25.3
 
-  esbuild-plugin-tailwindcss@1.2.3(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3)):
+  esbuild-plugin-tailwindcss@1.2.3(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3)):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.12)
       postcss: 8.5.12
       postcss-modules: 6.0.1(postcss@8.5.12)
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3))
     transitivePeerDependencies:
       - ts-node
 
@@ -12829,7 +12829,7 @@ snapshots:
 
   happy-dom@20.10.2:
     dependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -14515,21 +14515,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.12
 
-  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3)):
+  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.4
     optionalDependencies:
       postcss: 8.5.12
-      ts-node: 10.9.2(@types/node@22.15.2)(typescript@5.7.3)
+      ts-node: 10.9.2(@types/node@24.13.3)(typescript@5.7.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.4
     optionalDependencies:
       postcss: 8.5.12
-      ts-node: 10.9.2(@types/node@22.15.2)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@24.13.3)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
@@ -15679,7 +15679,7 @@ snapshots:
 
   sync-message-port@1.2.0: {}
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15698,7 +15698,7 @@ snapshots:
       postcss: 8.5.12
       postcss-import: 15.1.0(postcss@8.5.12)
       postcss-js: 4.0.1(postcss@8.5.12)
-      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3))
+      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3))
       postcss-nested: 6.2.0(postcss@8.5.12)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -15706,7 +15706,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.9.3)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15725,7 +15725,7 @@ snapshots:
       postcss: 8.5.12
       postcss-import: 15.1.0(postcss@8.5.12)
       postcss-js: 4.0.1(postcss@8.5.12)
-      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@22.15.2)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.12)(ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.12)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -15918,14 +15918,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@22.15.2)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@24.13.3)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       acorn: 8.14.1
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -15937,14 +15937,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.15.2)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       acorn: 8.14.1
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -16063,7 +16063,7 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.18.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -16178,13 +16178,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16199,7 +16199,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
+  vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16208,7 +16208,7 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -16218,7 +16218,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.4
 
-  vite@8.0.10(@types/node@22.15.2)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
+  vite@8.0.10(@types/node@24.13.3)(esbuild@0.25.3)(jiti@2.6.1)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16226,7 +16226,7 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       esbuild: 0.25.3
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -16236,11 +16236,11 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.8.4
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.15.2)(happy-dom@20.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@24.13.3)(happy-dom@20.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.6(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -16258,12 +16258,12 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       happy-dom: 20.10.2
       jsdom: 26.1.0
     transitivePeerDependencies:
@@ -16280,10 +16280,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@types/node@22.15.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@24.1.3)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)):
+  vitest@4.1.8(@types/node@24.13.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@24.1.3)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -16300,20 +16300,20 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       happy-dom: 20.10.2
       jsdom: 24.1.3
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@22.15.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)):
+  vitest@4.1.8(@types/node@24.13.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(jsdom@26.1.0)(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.8(vite@6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -16330,10 +16330,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@22.15.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass-embedded@1.87.0)(sass@1.87.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.2
+      '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       happy-dom: 20.10.2
       jsdom: 26.1.0

--- a/tests/autoTest/package.json
+++ b/tests/autoTest/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/chai": "^5.2.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^22.1.0",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.20",

--- a/tests/marginal-delta-vite/package.json
+++ b/tests/marginal-delta-vite/package.json
@@ -17,7 +17,7 @@
     "vitest": "^3.1.2"
   },
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.0.0",
     "@types/react": "^18.3.21",
     "@types/react-dom": "^18.3.7",
     "typescript": "^5.7.3"

--- a/tools/scripts/check-release-workflows.js
+++ b/tools/scripts/check-release-workflows.js
@@ -69,9 +69,9 @@ assertExcludes(
   'publish-beta job must not install npm into pnpm global storage.',
 )
 assertExcludes(
-  publishBetaBlock,
+  changesetsWorkflow,
   'npm install -g npm',
-  'publish-beta job must not self-upgrade the runner-provided npm CLI.',
+  'Changesets workflow must use the npm CLI bundled with Node.js.',
 )
 assertIncludes(
   publishBetaBlock,


### PR DESCRIPTION
Drop support for Node.js 22. Use npm 11 bundled with Node.js 24