### PR TITLE
fix: Remove usage of Array.at(-1)

### DIFF
--- a/apps/test-server/src/pages/entity-animation/shared.tsx
+++ b/apps/test-server/src/pages/entity-animation/shared.tsx
@@ -140,7 +140,7 @@ export function EntityAnimationOverview() {
         <Link
           key={route.path}
           to={route.path}
-          data-name={`entity-motion-route-${route.path.split('/').at(-1)}`}
+          data-name={`entity-motion-route-${route.path.split('/').slice(-1)[0]}`}
           className="rounded-2xl border border-gray-800 bg-[#111] p-5 transition-colors hover:border-blue-700 hover:bg-[#141414]"
         >
           <div className="text-lg font-semibold text-gray-100">


### PR DESCRIPTION
The test-server targets ES2020 and doesn't support Array.at() which is a ES2022 API. This feature was incorrectly polyfilled by old version of Typescript.