### PR TITLE
refactor: simplify blobTransfer code

### DIFF
--- a/packages/core/src/SpatializedStatic3DElement.ts
+++ b/packages/core/src/SpatializedStatic3DElement.ts
@@ -312,13 +312,7 @@ export class SpatializedStatic3DElement extends SpatializedElement {
     } else if (data.type === SpatialWebMsgType.entitytransformchange) {
       this._entityTransform = new DOMMatrixReadOnly(data.detail.transform)
     } else if (data.type === SpatialWebMsgType.modelblobrequest) {
-      // Ship the blob bytes to native on demand. Fire-and-forget: the transfer
-      // reports progress and errors over its own JSB channel.
-      void transferBlob({
-        element: this,
-        requestId: data.detail.requestId,
-        src: data.detail.src,
-      })
+      transferBlob(this, data.detail.requestId, data.detail.src)
     } else {
       // Handle other spatial events using the base class implementation
       super.onReceiveEvent(data)

--- a/packages/core/src/blob/blobTransfer.test.ts
+++ b/packages/core/src/blob/blobTransfer.test.ts
@@ -8,7 +8,7 @@ interface CommandResult {
 
 const commandState = vi.hoisted(() => ({
   calls: [] as Array<Record<string, unknown>>,
-  chunkResult: { success: true } as CommandResult,
+  results: {} as Record<string, CommandResult>,
   deferChunkAcknowledgements: false,
   chunkResolvers: [] as Array<(result: CommandResult) => void>,
 }))
@@ -26,7 +26,9 @@ vi.mock('../JSBCommand', () => ({
         id: this.element.id,
         ...this.params,
       })
-      return Promise.resolve({ success: true })
+      return Promise.resolve(
+        commandState.results.StartBlobTransfer ?? { success: true },
+      )
     }
   },
   TransferBlobChunkCommand: class {
@@ -42,7 +44,9 @@ vi.mock('../JSBCommand', () => ({
         ...this.params,
       })
       if (!commandState.deferChunkAcknowledgements) {
-        return Promise.resolve(commandState.chunkResult)
+        return Promise.resolve(
+          commandState.results.TransferBlobChunk ?? { success: true },
+        )
       }
       return new Promise<CommandResult>(resolve => {
         commandState.chunkResolvers.push(resolve)
@@ -61,7 +65,9 @@ vi.mock('../JSBCommand', () => ({
         id: this.element.id,
         ...this.params,
       })
-      return Promise.resolve({ success: true })
+      return Promise.resolve(
+        commandState.results.CompleteBlobTransfer ?? { success: true },
+      )
     }
   },
   FailBlobTransferCommand: class {
@@ -76,11 +82,14 @@ vi.mock('../JSBCommand', () => ({
         id: this.element.id,
         ...this.params,
       })
-      return Promise.resolve({ success: true })
+      return Promise.resolve(
+        commandState.results.FailBlobTransfer ?? { success: true },
+      )
     }
   },
 }))
 
+const CHUNK_SIZE = 2 * 1024 * 1024
 const element = { id: 'model-1' } as any
 const requestId = 'request-1'
 const src = 'blob:https://example.com/model'
@@ -93,24 +102,82 @@ function fetchBlob(blob: Blob) {
   )
 }
 
+function stubEncodingFileReader() {
+  class EncodingFileReader {
+    result: string | ArrayBuffer | null = null
+    error: DOMException | null = null
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+
+    readAsDataURL(blob: Blob) {
+      this.result = `data:${blob.type};base64,encoded-${blob.size}`
+      queueMicrotask(() => this.onload?.())
+    }
+  }
+
+  vi.stubGlobal('FileReader', EncodingFileReader)
+}
+
 describe('transferBlob', () => {
   beforeEach(() => {
     commandState.calls.length = 0
-    commandState.chunkResult = success()
+    commandState.results = {}
     commandState.deferChunkAcknowledgements = false
     commandState.chunkResolvers.length = 0
+    stubEncodingFileReader()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
-  it('keeps at most four chunks in flight through native acknowledgement', async () => {
-    fetchBlob(new Blob([new Uint8Array(10 * 1024 * 1024)]))
-    commandState.deferChunkAcknowledgements = true
-    const encodeChunk = vi.fn(async () => '')
+  it('sends metadata and offset chunks before completing', async () => {
+    fetchBlob(
+      new Blob([new Uint8Array(CHUNK_SIZE + 3)], {
+        type: 'model/vnd.usdz+zip',
+      }),
+    )
 
-    const transfer = transferBlob({ element, requestId, src }, { encodeChunk })
+    await transferBlob(element, requestId, src)
+
+    expect(commandState.calls[0]).toEqual({
+      command: 'StartBlobTransfer',
+      id: 'model-1',
+      requestId,
+      src,
+      mimeType: 'model/vnd.usdz+zip',
+      size: CHUNK_SIZE + 3,
+    })
+    expect(commandState.calls.slice(1, -1)).toEqual(
+      expect.arrayContaining([
+        {
+          command: 'TransferBlobChunk',
+          id: 'model-1',
+          requestId,
+          offset: 0,
+          data: `encoded-${CHUNK_SIZE}`,
+        },
+        {
+          command: 'TransferBlobChunk',
+          id: 'model-1',
+          requestId,
+          offset: CHUNK_SIZE,
+          data: 'encoded-3',
+        },
+      ]),
+    )
+    expect(commandState.calls.at(-1)).toEqual({
+      command: 'CompleteBlobTransfer',
+      id: 'model-1',
+      requestId,
+    })
+  })
+
+  it('keeps at most four chunks in flight through native acknowledgement', async () => {
+    fetchBlob(new Blob([new Uint8Array(5 * CHUNK_SIZE)]))
+    commandState.deferChunkAcknowledgements = true
+
+    const transfer = transferBlob(element, requestId, src)
 
     await vi.waitFor(() => {
       expect(commandState.chunkResolvers).toHaveLength(4)
@@ -119,7 +186,10 @@ describe('transferBlob', () => {
       commandState.calls
         .filter(call => call.command === 'TransferBlobChunk')
         .map(call => call.offset),
-    ).toEqual([0, 2 * 1024 * 1024, 4 * 1024 * 1024, 6 * 1024 * 1024])
+    ).toEqual([0, CHUNK_SIZE, 2 * CHUNK_SIZE, 3 * CHUNK_SIZE])
+    expect(
+      commandState.calls.some(call => call.command === 'CompleteBlobTransfer'),
+    ).toBe(false)
 
     commandState.chunkResolvers.shift()!(success())
     await vi.waitFor(() => {
@@ -143,9 +213,8 @@ describe('transferBlob', () => {
 
   it('starts and immediately completes a zero-byte blob', async () => {
     fetchBlob(new Blob([], { type: 'model/vnd.usdz+zip' }))
-    const encodeChunk = vi.fn(async () => '')
 
-    await transferBlob({ element, requestId, src }, { encodeChunk })
+    await transferBlob(element, requestId, src)
 
     expect(commandState.calls).toEqual([
       {
@@ -162,20 +231,20 @@ describe('transferBlob', () => {
         requestId,
       },
     ])
-    expect(encodeChunk).not.toHaveBeenCalled()
   })
 
-  it('stops scheduling when native rejects an in-flight chunk', async () => {
-    fetchBlob(new Blob([new Uint8Array(10 * 1024 * 1024)]))
-    commandState.chunkResult = {
+  it('stops scheduling and reports a rejected chunk', async () => {
+    fetchBlob(new Blob([new Uint8Array(5 * CHUNK_SIZE)]))
+    commandState.results.TransferBlobChunk = {
       success: false,
       errorMessage: 'native cancelled',
     }
-    const encodeChunk = vi.fn(async () => '')
 
-    await transferBlob({ element, requestId, src }, { encodeChunk })
+    await transferBlob(element, requestId, src)
 
-    expect(encodeChunk).toHaveBeenCalledTimes(4)
+    expect(
+      commandState.calls.filter(call => call.command === 'TransferBlobChunk'),
+    ).toHaveLength(4)
     expect(commandState.calls.at(-1)).toEqual({
       command: 'FailBlobTransfer',
       id: 'model-1',
@@ -187,10 +256,55 @@ describe('transferBlob', () => {
     ).toBe(false)
   })
 
-  it('reports a fetch failure without starting the transfer', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('revoked')))
+  it('uses the default command error when native omits a message', async () => {
+    fetchBlob(new Blob(['model']))
+    commandState.results.StartBlobTransfer = { success: false }
 
-    await transferBlob({ element, requestId, src })
+    await transferBlob(element, requestId, src)
+
+    expect(commandState.calls).toEqual([
+      expect.objectContaining({ command: 'StartBlobTransfer' }),
+      {
+        command: 'FailBlobTransfer',
+        id: 'model-1',
+        requestId,
+        message: 'Blob transfer command failed',
+      },
+    ])
+  })
+
+  it('reports a FileReader encoding error without completing', async () => {
+    class FailingFileReader {
+      result: string | ArrayBuffer | null = null
+      error = new Error('encoding failed')
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+
+      readAsDataURL() {
+        queueMicrotask(() => this.onerror?.())
+      }
+    }
+
+    fetchBlob(new Blob(['model']))
+    vi.stubGlobal('FileReader', FailingFileReader)
+
+    await transferBlob(element, requestId, src)
+
+    expect(commandState.calls.at(-1)).toEqual({
+      command: 'FailBlobTransfer',
+      id: 'model-1',
+      requestId,
+      message: 'encoding failed',
+    })
+    expect(
+      commandState.calls.some(call => call.command === 'CompleteBlobTransfer'),
+    ).toBe(false)
+  })
+
+  it('stringifies a non-Error fetch failure without starting', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue('revoked'))
+
+    await transferBlob(element, requestId, src)
 
     expect(commandState.calls).toEqual([
       {

--- a/packages/core/src/blob/blobTransfer.ts
+++ b/packages/core/src/blob/blobTransfer.ts
@@ -1,98 +1,52 @@
 import {
   CompleteBlobTransferCommand,
   FailBlobTransferCommand,
+  SpatializedElementCommand,
   StartBlobTransferCommand,
   TransferBlobChunkCommand,
 } from '../JSBCommand'
 import { SpatialObject } from '../SpatialObject'
 
-/** Bytes per chunk shipped over the (string-only) bridge. */
+// Bytes per chunk shipped over the (string-only) bridge.
 const CHUNK_SIZE = 2 * 1024 * 1024 // 2 MiB
 const MAX_IN_FLIGHT = 4
 
-export interface TransferBlobOptions {
-  /** The element whose transfer this is; supplies the id native routes chunks on. */
-  element: SpatialObject
-  /** Which native source attempt these bytes belong to. */
-  requestId: string
-  /** The `blob:` URL to ship. */
-  src: string
-}
-
-interface TransferBlobDependencies {
-  encodeChunk: (slice: Blob) => Promise<string>
-}
-
-/**
- * Fetches a blob URL and streams it to native with bounded parallelism.
- *
- * At most four operations are in flight from slice encoding through native
- * acknowledgement. The first failure stops new scheduling; already-started
- * operations settle before a best-effort terminal error is sent.
- *
- * Component-agnostic: it only needs an element, request ID, and blob URL, so it
- * can back blob transfers for components other than `<Model>` later.
- */
+// Fetches a blob URL and streams it to native with bounded parallelism.
 export async function transferBlob(
-  { element, requestId, src }: TransferBlobOptions,
-  { encodeChunk = encodeBase64 }: Partial<TransferBlobDependencies> = {},
-): Promise<void> {
+  element: SpatialObject,
+  requestId: string,
+  src: string,
+) {
   try {
     const response = await fetch(src)
     const blob = await response.blob()
-    ensureSuccess(
-      await new StartBlobTransferCommand(element, {
-        requestId,
-        src,
-        mimeType: blob.type,
-        size: blob.size,
-      }).execute(),
-    )
+    const params = { requestId, src, mimeType: blob.type, size: blob.size }
+    await execute(new StartBlobTransferCommand(element, params))
 
-    let nextOffset = 0
-    let firstError: Error | undefined
-    const operationCount = Math.min(
-      MAX_IN_FLIGHT,
-      Math.ceil(blob.size / CHUNK_SIZE),
-    )
-
-    const pump = async () => {
-      while (firstError === undefined) {
-        const offset = nextOffset
-        if (offset >= blob.size) return
-        nextOffset += CHUNK_SIZE
-
-        try {
-          const data = await encodeChunk(
-            blob.slice(offset, offset + CHUNK_SIZE),
-          )
-          ensureSuccess(
-            await new TransferBlobChunkCommand(element, {
-              requestId,
-              offset,
-              data,
-            }).execute(),
-          )
-        } catch (error) {
-          firstError ??= toError(error)
-        }
+    const chunks = chunkBlob(blob)
+    const transferChunks = async () => {
+      for await (const { offset, slice } of chunks) {
+        const params = { requestId, offset, data: await encodeBase64(slice) }
+        await execute(new TransferBlobChunkCommand(element, params))
       }
     }
 
-    await Promise.all(Array.from({ length: operationCount }, pump))
-    if (firstError) throw firstError
-
-    ensureSuccess(
-      await new CompleteBlobTransferCommand(element, {
-        requestId,
-      }).execute(),
-    )
-  } catch (error) {
-    await sendError(element, requestId, toError(error).message)
+    await Promise.all(Array.from({ length: MAX_IN_FLIGHT }, transferChunks))
+    await execute(new CompleteBlobTransferCommand(element, { requestId }))
+  } catch (ex) {
+    const message = ex instanceof Error ? ex.message : String(ex)
+    await new FailBlobTransferCommand(element, { requestId, message }).execute()
   }
 }
 
-/** Base64-encodes a blob slice without materialising the bytes as a string. */
+async function* chunkBlob(blob: Blob) {
+  for (let offset = 0; offset < blob.size; offset += CHUNK_SIZE) {
+    const slice = blob.slice(offset, offset + CHUNK_SIZE)
+    yield { offset, slice }
+  }
+}
+
+// Base64-encodes a blob slice without materialising the bytes as a string
 function encodeBase64(slice: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -106,27 +60,11 @@ function encodeBase64(slice: Blob): Promise<string> {
   })
 }
 
-function ensureSuccess(result: { success: boolean; errorMessage?: string }) {
+// Execute command and convert failure to exception
+async function execute(command: SpatializedElementCommand) {
+  const result = await command.execute()
   if (!result.success) {
     throw new Error(result.errorMessage || 'Blob transfer command failed')
   }
-}
-
-async function sendError(
-  element: SpatialObject,
-  requestId: string,
-  message: string,
-) {
-  try {
-    await new FailBlobTransferCommand(element, {
-      requestId,
-      message,
-    }).execute()
-  } catch {
-    // Best effort: native may already have invalidated this request.
-  }
-}
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error))
+  return result
 }


### PR DESCRIPTION
Simplify blobTransfer code using async generator. Immediately send failure command instead of waiting for queue to finish. There should be no functional changes.