### PR TITLE
fix: Model entityTransform shouldn't affect poster

### DIFF
--- a/.changeset/large-trains-train.md
+++ b/.changeset/large-trains-train.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/platform-visionos': patch
+---
+
+Fix Model poster should not be affected by entityTransform

--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -48,6 +48,10 @@ struct SpatializedStatic3DView: View {
                             .if(!depth.isZero) { view in view.scaledToFit3D() }
                             .if(enableGesture) { view in view.hoverEffect() }
                     }
+                    .scaleEffect(scale)
+                    .rotation3DEffect(rotation)
+                    .offset(x: x, y: y)
+                    .offset(z: z)
                 case .failed:
                     posterView {
                         // Transparent view is required so that lifecycle modifiers like .task still work
@@ -55,15 +59,11 @@ struct SpatializedStatic3DView: View {
                     }
                 }
             }
-            .scaleEffect(scale)
-            .rotation3DEffect(rotation)
             .orbit(
                 enabled: spatializedStatic3DElement.stagemode == .orbit && asset != nil,
                 entityTransform: $spatializedStatic3DElement.entityTransform,
                 onChange: onOrbit
             )
-            .offset(x: x, y: y)
-            .offset(z: z)
             .onChange(of: asset?.animationPlaybackController?.isComplete) { _, isComplete in
                 guard isComplete == true else { return }
                 if spatializedStatic3DElement.loop,


### PR DESCRIPTION
According to the specs and model explainer  entityTransform should not affect the poster image, only the 3D model. CSS transform of the <Model> element does transform the poster.

Fixes #1372

https://github.com/user-attachments/assets/f56e7d0e-ced3-46f9-be02-a83ed43fa67b

