### PR TITLE
chore git ignore buildServer.json used by xcode-build-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules
 # IDEs and editors
 .vscode
 **/.idea
+buildServer.json
 
 # Build and test output
 coverage


### PR DESCRIPTION
`buildServer.json` is used by [xcode-build-server](xcode-build-server) to integrate Xcode project with [sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp)