### PR TITLE
chore: add logging when 3D model fails to load

### DIFF
--- a/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
+++ b/packages/visionOS/web-spatial/view/SpatializedStatic3DView.swift
@@ -202,6 +202,7 @@ struct SpatializedStatic3DView: View {
             do {
                 return try (url, await loadAsset(from: url))
             } catch {
+                logger.warning("Failed to load \(source) \(error)")
                 continue
             }
         }


### PR DESCRIPTION
For debugging it's helpful to log the specific reason 3D model was not loaded. If warning level is too noisy this can be reduced.

Ticket: 0